### PR TITLE
release: prepare qEmby 0.0.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.19)
 
-project(qEmby VERSION 0.0.5 LANGUAGES CXX)
+project(qEmby VERSION 0.0.6 LANGUAGES CXX)
 
 if(APPLE)
     set(CMAKE_OSX_DEPLOYMENT_TARGET 13.0)
@@ -44,7 +44,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 # ==========================================
-# 【关键修复】: 为第三方子模块 (qwindowkit/qmsetup) 注入所需的 Qt 版本环境变量
+# 为第三方子模块 (qwindowkit/qmsetup) 注入所需的 Qt 版本环境变量
 # ==========================================
 set(QT_VERSION_MAJOR ${Qt6_VERSION_MAJOR})
 set(QT_VERSION_MINOR ${Qt6_VERSION_MINOR})

--- a/src/qEmbyApp/components/danmakuserverdialog.cpp
+++ b/src/qEmbyApp/components/danmakuserverdialog.cpp
@@ -2,6 +2,8 @@
 
 #include "danmakuserverlistitemwidget.h"
 #include "modernmessagebox.h"
+#include "moderncombobox.h"
+#include "../utils/layoututils.h"
 #include "services/danmaku/danmakusettings.h"
 
 #include <QAbstractItemView>
@@ -27,6 +29,19 @@ QString fallbackServerName(const DanmakuServerDefinition &server)
 {
     return server.name.trimmed().isEmpty() ? server.baseUrl.trimmed()
                                            : server.name.trimmed();
+}
+
+bool isDanmuApiProvider(const DanmakuServerDefinition &server)
+{
+    return server.provider.trimmed().compare(
+               QStringLiteral("danmu_api"), Qt::CaseInsensitive) == 0;
+}
+
+bool isSupportedProvider(const QString &provider)
+{
+    const QString normalized = provider.trimmed().toLower();
+    return normalized == QLatin1String("dandanplay") ||
+           normalized == QLatin1String("danmu_api");
 }
 
 } 
@@ -62,7 +77,7 @@ DanmakuServerDialog::DanmakuServerDialog(QWidget *parent)
     listLayout->addWidget(listTitle);
 
     auto *listDesc = new QLabel(
-        tr("Each item shows the danmaku server name, address, app "
+        tr("Each item shows the danmaku server name, type, address, "
            "credentials, and description. The built-in official "
            "DandanPlay server supports anime only."),
         listPanel);
@@ -106,9 +121,9 @@ DanmakuServerDialog::DanmakuServerDialog(QWidget *parent)
     editorLayout->addWidget(editorTitle);
 
     auto *editorDesc = new QLabel(
-        tr("Update the server name, address, description, and app credentials for the "
-           "selected danmaku server. Official DandanPlay endpoints require "
-           "App ID and App Secret and support anime only."),
+        tr("Choose the server type and configure its address and credentials. "
+           "Official DandanPlay uses signed App credentials; LogVar / danmu_api "
+           "uses an optional access token and supports general video content."),
         editorPanel);
     editorDesc->setObjectName("DanmakuServerEditorDesc");
     editorDesc->setWordWrap(true);
@@ -127,6 +142,15 @@ DanmakuServerDialog::DanmakuServerDialog(QWidget *parent)
     m_nameEdit->setClearButtonEnabled(true);
     m_nameEdit->setPlaceholderText(tr("e.g., Official DandanPlay"));
     formLayout->addRow(nameLabel, m_nameEdit);
+
+    m_providerTypeLabel = new QLabel(tr("Server Type"), editorPanel);
+    m_providerTypeLabel->setObjectName("LibraryMetadataFieldLabel");
+    m_providerTypeCombo = LayoutUtils::createStyledCombo(editorPanel);
+    m_providerTypeCombo->addItem(tr("DandanPlay Official API"),
+                                 QStringLiteral("dandanplay"));
+    m_providerTypeCombo->addItem(tr("LogVar / danmu_api"),
+                                 QStringLiteral("danmu_api"));
+    formLayout->addRow(m_providerTypeLabel, m_providerTypeCombo);
 
     auto *urlLabel = new QLabel(tr("Server URL"), editorPanel);
     urlLabel->setObjectName("LibraryMetadataFieldLabel");
@@ -162,6 +186,16 @@ DanmakuServerDialog::DanmakuServerDialog(QWidget *parent)
     m_appSecretEdit->setPlaceholderText(
         tr("Required for official DandanPlay"));
     formLayout->addRow(m_appSecretLabel, m_appSecretEdit);
+
+    m_accessTokenLabel = new QLabel(tr("Access Token"), editorPanel);
+    m_accessTokenLabel->setObjectName("LibraryMetadataFieldLabel");
+    m_accessTokenEdit = new QLineEdit(editorPanel);
+    m_accessTokenEdit->setObjectName("ManageLibInput");
+    m_accessTokenEdit->setClearButtonEnabled(true);
+    m_accessTokenEdit->setEchoMode(QLineEdit::Password);
+    m_accessTokenEdit->setPlaceholderText(
+        tr("Optional TOKEN configured by danmu_api"));
+    formLayout->addRow(m_accessTokenLabel, m_accessTokenEdit);
 
     editorLayout->addLayout(formLayout);
     editorLayout->addStretch();
@@ -212,11 +246,18 @@ DanmakuServerDialog::DanmakuServerDialog(QWidget *parent)
             [this](const QString &text) {
               updateCurrentServerDescription(text);
             });
+    connect(m_providerTypeCombo,
+            qOverload<int>(&QComboBox::currentIndexChanged), this,
+            [this](int index) { updateCurrentServerProvider(index); });
     connect(m_appIdEdit, &QLineEdit::textChanged, this,
             [this](const QString &text) { updateCurrentServerAppId(text); });
     connect(m_appSecretEdit, &QLineEdit::textChanged, this,
             [this](const QString &text) {
               updateCurrentServerAppSecret(text);
+            });
+    connect(m_accessTokenEdit, &QLineEdit::textChanged, this,
+            [this](const QString &text) {
+              updateCurrentServerAccessToken(text);
             });
 
     connect(m_addButton, &QPushButton::clicked, this, [this]() {
@@ -224,11 +265,14 @@ DanmakuServerDialog::DanmakuServerDialog(QWidget *parent)
           DanmakuSettings::builtInOfficialDandanplayServer();
       server.id = createServerId();
       server.builtIn = false;
-      server.contentScope.clear();
-      server.description.clear();
+      server.provider = QStringLiteral("danmu_api");
+      server.baseUrl = QStringLiteral("http://127.0.0.1:9321");
+      server.contentScope = QStringLiteral("general");
+      server.description = tr("General video danmaku service");
       server.appId.clear();
       server.appSecret.clear();
-      server.name = tr("Danmaku Server %1").arg(m_servers.size() + 1);
+      server.accessToken.clear();
+      server.name = tr("LogVar / danmu_api");
       server.enabled = true;
       m_servers.append(server);
       refreshServerList();
@@ -251,11 +295,12 @@ void DanmakuServerDialog::setServers(QList<DanmakuServerDefinition> servers,
     for (DanmakuServerDefinition &server : servers) {
         server.id = server.id.trimmed();
         server.name = server.name.trimmed();
-        server.provider = server.provider.trimmed();
+        server.provider = server.provider.trimmed().toLower();
         server.baseUrl = normalizeBaseUrl(server.baseUrl);
         server.description = server.description.trimmed();
         server.appId = server.appId.trimmed();
         server.appSecret = server.appSecret.trimmed();
+        server.accessToken = server.accessToken.trimmed();
         server.contentScope = server.contentScope.trimmed().toLower();
 
         if (server.id.isEmpty()) {
@@ -269,6 +314,7 @@ void DanmakuServerDialog::setServers(QList<DanmakuServerDefinition> servers,
             server.baseUrl = builtIn.baseUrl;
             server.appId = builtIn.appId;
             server.appSecret = builtIn.appSecret;
+            server.accessToken.clear();
             server.description.clear();
             server.contentScope = builtIn.contentScope;
             if (server.name.isEmpty()) {
@@ -326,6 +372,20 @@ void DanmakuServerDialog::accept()
     }
 
     for (const DanmakuServerDefinition &server : std::as_const(m_servers)) {
+        if (!isSupportedProvider(server.provider)) {
+            m_editingServerId = server.id;
+            if (server.enabled) {
+                m_selectedServerId = server.id;
+            }
+            refreshServerList();
+            selectServer(editingServerIndex());
+            m_providerTypeCombo->setFocus();
+            ModernMessageBox::warning(
+                this, tr("Danmaku Servers"),
+                tr("Every danmaku server must use a supported server type."),
+                tr("OK"));
+            return;
+        }
         if (server.name.trimmed().isEmpty()) {
             m_editingServerId = server.id;
             if (server.enabled) {
@@ -692,10 +752,14 @@ void DanmakuServerDialog::loadCurrentServer()
     m_loading = true;
     const DanmakuServerDefinition &server = m_servers.at(index);
     m_nameEdit->setText(server.name);
+    const int providerIndex = m_providerTypeCombo->findData(
+        server.provider.trimmed().toLower());
+    m_providerTypeCombo->setCurrentIndex(providerIndex >= 0 ? providerIndex : 0);
     m_baseUrlEdit->setText(server.baseUrl);
     m_descriptionEdit->setText(server.description);
     m_appIdEdit->setText(server.appId);
     m_appSecretEdit->setText(server.appSecret);
+    m_accessTokenEdit->setText(server.accessToken);
     m_loading = false;
 }
 
@@ -718,17 +782,23 @@ void DanmakuServerDialog::updateEditorState()
     const int index = editingServerIndex();
     const bool hasCurrentServer = index >= 0 && index < m_servers.size();
     const bool isBuiltIn = hasCurrentServer && m_servers.at(index).builtIn;
+    const bool isDanmuApi =
+        hasCurrentServer && isDanmuApiProvider(m_servers.at(index));
     m_nameEdit->setEnabled(hasCurrentServer && !isBuiltIn);
+    m_providerTypeCombo->setEnabled(hasCurrentServer && !isBuiltIn);
     m_baseUrlEdit->setEnabled(hasCurrentServer && !isBuiltIn);
     m_descriptionLabel->setVisible(hasCurrentServer && !isBuiltIn);
     m_descriptionEdit->setVisible(hasCurrentServer && !isBuiltIn);
     m_descriptionEdit->setEnabled(hasCurrentServer && !isBuiltIn);
-    m_appIdLabel->setVisible(hasCurrentServer && !isBuiltIn);
-    m_appIdEdit->setVisible(hasCurrentServer && !isBuiltIn);
-    m_appIdEdit->setEnabled(hasCurrentServer && !isBuiltIn);
-    m_appSecretLabel->setVisible(hasCurrentServer && !isBuiltIn);
-    m_appSecretEdit->setVisible(hasCurrentServer && !isBuiltIn);
-    m_appSecretEdit->setEnabled(hasCurrentServer && !isBuiltIn);
+    m_appIdLabel->setVisible(hasCurrentServer && !isBuiltIn && !isDanmuApi);
+    m_appIdEdit->setVisible(hasCurrentServer && !isBuiltIn && !isDanmuApi);
+    m_appIdEdit->setEnabled(hasCurrentServer && !isBuiltIn && !isDanmuApi);
+    m_appSecretLabel->setVisible(hasCurrentServer && !isBuiltIn && !isDanmuApi);
+    m_appSecretEdit->setVisible(hasCurrentServer && !isBuiltIn && !isDanmuApi);
+    m_appSecretEdit->setEnabled(hasCurrentServer && !isBuiltIn && !isDanmuApi);
+    m_accessTokenLabel->setVisible(hasCurrentServer && !isBuiltIn && isDanmuApi);
+    m_accessTokenEdit->setVisible(hasCurrentServer && !isBuiltIn && isDanmuApi);
+    m_accessTokenEdit->setEnabled(hasCurrentServer && !isBuiltIn && isDanmuApi);
 }
 
 void DanmakuServerDialog::updateServerEnabled(int index, bool enabled)
@@ -820,6 +890,41 @@ void DanmakuServerDialog::updateCurrentServerDescription(
     refreshServerListItem(index);
 }
 
+void DanmakuServerDialog::updateCurrentServerProvider(int comboIndex)
+{
+    if (m_loading) {
+        return;
+    }
+    const int index = editingServerIndex();
+    if (index < 0 || index >= m_servers.size() ||
+        m_servers.at(index).builtIn || comboIndex < 0) {
+        return;
+    }
+
+    DanmakuServerDefinition &server = m_servers[index];
+    const QString provider =
+        m_providerTypeCombo->itemData(comboIndex).toString().trimmed();
+    if (provider.isEmpty() || server.provider == provider) {
+        return;
+    }
+    server.provider = provider;
+    if (provider == QLatin1String("danmu_api")) {
+        server.appId.clear();
+        server.appSecret.clear();
+        server.contentScope = QStringLiteral("general");
+        if (server.baseUrl.contains(QStringLiteral("api.dandanplay.net"),
+                                    Qt::CaseInsensitive)) {
+            server.baseUrl = QStringLiteral("http://127.0.0.1:9321");
+        }
+    } else {
+        server.accessToken.clear();
+        server.contentScope.clear();
+    }
+    loadCurrentServer();
+    updateEditorState();
+    refreshServerListItem(index);
+}
+
 void DanmakuServerDialog::updateCurrentServerAppId(const QString &appId)
 {
     if (m_loading) {
@@ -854,6 +959,21 @@ void DanmakuServerDialog::updateCurrentServerAppSecret(
     }
 
     m_servers[index].appSecret = appSecret.trimmed();
+    refreshServerListItem(index);
+}
+
+void DanmakuServerDialog::updateCurrentServerAccessToken(
+    const QString &accessToken)
+{
+    if (m_loading) {
+        return;
+    }
+    const int index = editingServerIndex();
+    if (index < 0 || index >= m_servers.size() ||
+        m_servers.at(index).builtIn) {
+        return;
+    }
+    m_servers[index].accessToken = accessToken.trimmed();
     refreshServerListItem(index);
 }
 

--- a/src/qEmbyApp/components/danmakuserverdialog.h
+++ b/src/qEmbyApp/components/danmakuserverdialog.h
@@ -14,6 +14,7 @@ class QLabel;
 class QPushButton;
 class QEvent;
 class QShowEvent;
+class ModernComboBox;
 
 class DanmakuServerDialog : public ModernDialogBase
 {
@@ -49,8 +50,10 @@ private:
     void updateCurrentServerName(const QString &name);
     void updateCurrentServerUrl(const QString &baseUrl);
     void updateCurrentServerDescription(const QString &description);
+    void updateCurrentServerProvider(int comboIndex);
     void updateCurrentServerAppId(const QString &appId);
     void updateCurrentServerAppSecret(const QString &appSecret);
+    void updateCurrentServerAccessToken(const QString &accessToken);
     void updateActionState();
 
     static QString createServerId();
@@ -63,6 +66,8 @@ private:
 
     QListWidget *m_serverList = nullptr;
     QLineEdit *m_nameEdit = nullptr;
+    QLabel *m_providerTypeLabel = nullptr;
+    ModernComboBox *m_providerTypeCombo = nullptr;
     QLineEdit *m_baseUrlEdit = nullptr;
     QLabel *m_descriptionLabel = nullptr;
     QLineEdit *m_descriptionEdit = nullptr;
@@ -70,6 +75,8 @@ private:
     QLineEdit *m_appIdEdit = nullptr;
     QLabel *m_appSecretLabel = nullptr;
     QLineEdit *m_appSecretEdit = nullptr;
+    QLabel *m_accessTokenLabel = nullptr;
+    QLineEdit *m_accessTokenEdit = nullptr;
     QPushButton *m_addButton = nullptr;
 };
 

--- a/src/qEmbyApp/components/danmakuserverlistitemwidget.cpp
+++ b/src/qEmbyApp/components/danmakuserverlistitemwidget.cpp
@@ -193,6 +193,11 @@ QString DanmakuServerListItemWidget::maskedSecret(const QString &secret)
 void DanmakuServerListItemWidget::refreshCredentialsLabel()
 {
     QStringList parts;
+    const bool isDanmuApi =
+        m_server.provider.trimmed().compare(
+            QStringLiteral("danmu_api"), Qt::CaseInsensitive) == 0;
+    parts.append(isDanmuApi ? tr("LogVar / danmu_api")
+                            : tr("DandanPlay"));
     if (m_server.builtIn &&
         m_server.contentScope.trimmed().compare(QStringLiteral("anime"),
                                                 Qt::CaseInsensitive) == 0) {
@@ -207,6 +212,10 @@ void DanmakuServerListItemWidget::refreshCredentialsLabel()
     if (!m_server.builtIn && !m_server.appSecret.trimmed().isEmpty()) {
         parts.append(tr("App Secret: %1")
                          .arg(maskedSecret(m_server.appSecret)));
+    }
+    if (isDanmuApi && !m_server.accessToken.trimmed().isEmpty()) {
+        parts.append(tr("Token: %1")
+                         .arg(maskedSecret(m_server.accessToken)));
     }
 
     const QString text = parts.join(QStringLiteral("    "));

--- a/src/qEmbyApp/components/detailactionwidget.cpp
+++ b/src/qEmbyApp/components/detailactionwidget.cpp
@@ -110,7 +110,19 @@ DetailActionWidget::DetailActionWidget(QWidget *parent) : QWidget(parent) {
   connect(m_playedBtn, &QPushButton::clicked, this,
           &DetailActionWidget::playedToggleRequested);
   connect(m_versionComboBox, &ModernMenuButton::currentIndexChanged, this,
-          &DetailActionWidget::sourceVersionChanged);
+          [this](int visualIndex) {
+            if (visualIndex >= 0 && visualIndex < m_sourceIndexes.size())
+              Q_EMIT sourceVersionChanged(m_sourceIndexes[visualIndex]);
+          });
+  connect(m_audioComboBox, &ModernMenuButton::currentIndexChanged, this,
+          [this](int) {
+            Q_EMIT audioStreamChanged(m_audioComboBox->currentData().toInt());
+          });
+  connect(m_subtitleComboBox, &ModernMenuButton::currentIndexChanged, this,
+          [this](int) {
+            Q_EMIT subtitleStreamChanged(
+                m_subtitleComboBox->currentData().toInt());
+          });
 
   clear();
 }
@@ -122,6 +134,7 @@ void DetailActionWidget::clear() {
 
   m_versionComboBox->blockSignals(true);
   m_versionComboBox->clear();
+  m_sourceIndexes.clear();
   m_versionComboBox->hide();
   m_versionComboBox->blockSignals(false);
 
@@ -221,12 +234,21 @@ void DetailActionWidget::setSources(const QList<MediaSourceInfo> &sources,
                                     int currentIndex) {
   m_versionComboBox->blockSignals(true);
   m_versionComboBox->clear();
+  m_sourceIndexes.clear();
 
   if (!sources.isEmpty()) {
-    for (int i = 0; i < sources.size(); ++i) {
+    const QString preferredRules =
+        ConfigStore::instance()
+            ->get<QString>(ConfigKeys::PlayerPreferredVersion)
+            .trimmed();
+    m_sourceIndexes = MediaSourcePreferenceUtils::preferredMediaSourceOrder(
+        sources, preferredRules);
+    for (int visualIndex = 0; visualIndex < m_sourceIndexes.size();
+         ++visualIndex) {
+      const int i = m_sourceIndexes[visualIndex];
       const auto &src = sources[i];
       QString versionName =
-          src.name.isEmpty() ? tr("Version %1").arg(i + 1) : src.name;
+          src.name.isEmpty() ? tr("Version %1").arg(visualIndex + 1) : src.name;
       QString videoInfo = tr("Unknown Video");
       for (const auto &stream : src.mediaStreams) {
         if (stream.type == "Video") {
@@ -249,16 +271,13 @@ void DetailActionWidget::setSources(const QList<MediaSourceInfo> &sources,
                                  src.id);
     }
 
-    int bestIndex = currentIndex;
-    if (sources.size() > 1) {
-      bestIndex = MediaSourcePreferenceUtils::resolvePreferredMediaSourceIndex(
-          sources,
-          ConfigStore::instance()
-              ->get<QString>(ConfigKeys::PlayerPreferredVersion)
-              .trimmed());
-    }
-
-    m_versionComboBox->setCurrentIndex(bestIndex);
+    const int selectedSourceIndex =
+        currentIndex >= 0 && currentIndex < sources.size()
+            ? currentIndex
+            : MediaSourcePreferenceUtils::resolvePreferredMediaSourceIndex(
+                  sources, preferredRules);
+    const int selectedVisualIndex = m_sourceIndexes.indexOf(selectedSourceIndex);
+    m_versionComboBox->setCurrentIndex(qMax(0, selectedVisualIndex));
     m_versionComboBox->show();
   } else {
     m_versionComboBox->hide();
@@ -266,7 +285,9 @@ void DetailActionWidget::setSources(const QList<MediaSourceInfo> &sources,
   m_versionComboBox->blockSignals(false);
 }
 
-void DetailActionWidget::setStreams(const MediaSourceInfo &source) {
+void DetailActionWidget::setStreams(
+    const MediaSourceInfo &source, std::optional<int> rememberedAudioIndex,
+    std::optional<int> rememberedSubtitleIndex) {
   m_audioComboBox->blockSignals(true);
   m_subtitleComboBox->blockSignals(true);
   m_audioComboBox->clear();
@@ -293,8 +314,18 @@ void DetailActionWidget::setStreams(const MediaSourceInfo &source) {
   int defaultSubIdx = 0; 
   bool subMatchedByPref = false;
   bool subMatchedByDefault = false; 
+  int rememberedAudioComboIndex = -1;
+  int rememberedSubtitleComboIndex = -1;
 
-  for (const auto &stream : source.mediaStreams) {
+  QList<int> orderedStreamPositions =
+      PlayerPreferenceUtils::preferredStreamOrder(source.mediaStreams,
+                                                   "Audio", prefAudioLang);
+  orderedStreamPositions.append(
+      PlayerPreferenceUtils::preferredStreamOrder(source.mediaStreams,
+                                                   "Subtitle", prefSubLang));
+
+  for (const int streamPosition : orderedStreamPositions) {
+    const auto &stream = source.mediaStreams[streamPosition];
     if (stream.type == "Audio") {
       QString title =
           stream.displayTitle.isEmpty() ? stream.language : stream.displayTitle;
@@ -320,6 +351,10 @@ void DetailActionWidget::setStreams(const MediaSourceInfo &source) {
                                secondLineParts.join("  ·  "), stream.index);
 
       int curIdx = m_audioComboBox->count() - 1;
+      if (rememberedAudioIndex.has_value() &&
+          stream.index == *rememberedAudioIndex) {
+        rememberedAudioComboIndex = curIdx;
+      }
       if (preferredAudioStreamIndex >= 0 &&
           stream.index == preferredAudioStreamIndex) {
         defaultAudioIdx = curIdx;
@@ -351,6 +386,10 @@ void DetailActionWidget::setStreams(const MediaSourceInfo &source) {
                                   secondLineParts.join("  ·  "), stream.index);
 
       int curIdx = m_subtitleComboBox->count() - 1;
+      if (rememberedSubtitleIndex.has_value() &&
+          stream.index == *rememberedSubtitleIndex) {
+        rememberedSubtitleComboIndex = curIdx;
+      }
       if (preferredSubtitleStreamIndex >= 0 &&
           stream.index == preferredSubtitleStreamIndex) {
         defaultSubIdx = curIdx;
@@ -363,8 +402,17 @@ void DetailActionWidget::setStreams(const MediaSourceInfo &source) {
     }
   }
 
+  if (rememberedAudioComboIndex >= 0) {
+    defaultAudioIdx = rememberedAudioComboIndex;
+  }
+
   
-  if (subtitleDisabled) {
+  if (rememberedSubtitleIndex.has_value() &&
+      *rememberedSubtitleIndex == -1) {
+    defaultSubIdx = 0;
+  } else if (rememberedSubtitleComboIndex >= 0) {
+    defaultSubIdx = rememberedSubtitleComboIndex;
+  } else if (subtitleDisabled) {
     defaultSubIdx = 0; 
   } else if (!subMatchedByPref && !subMatchedByDefault &&
              m_subtitleComboBox->count() > 1) {
@@ -392,7 +440,10 @@ void DetailActionWidget::setStreams(const MediaSourceInfo &source) {
 }
 
 int DetailActionWidget::currentSourceIndex() const {
-  return qMax(0, m_versionComboBox->currentIndex());
+  const int visualIndex = m_versionComboBox->currentIndex();
+  return visualIndex >= 0 && visualIndex < m_sourceIndexes.size()
+             ? m_sourceIndexes[visualIndex]
+             : 0;
 }
 int DetailActionWidget::currentAudioIndex() const {
   return m_audioComboBox->isVisible() ? m_audioComboBox->currentData().toInt()

--- a/src/qEmbyApp/components/detailactionwidget.h
+++ b/src/qEmbyApp/components/detailactionwidget.h
@@ -3,6 +3,7 @@
 
 #include <QWidget>
 #include "models/media/mediaitem.h"
+#include <optional>
 
 class QPushButton;
 class QProgressBar;
@@ -21,8 +22,10 @@ public:
 
     void setFavoriteState(bool isFavorite);
     void setPlayedState(bool played);
-    void setSources(const QList<MediaSourceInfo>& sources, int currentIndex = 0);
-    void setStreams(const MediaSourceInfo& source);
+    void setSources(const QList<MediaSourceInfo>& sources, int currentIndex = -1);
+    void setStreams(const MediaSourceInfo& source,
+                    std::optional<int> rememberedAudioIndex = std::nullopt,
+                    std::optional<int> rememberedSubtitleIndex = std::nullopt);
     void clear();
 
     int currentSourceIndex() const;
@@ -38,6 +41,8 @@ signals:
     void favoriteRequested();
     void playedToggleRequested();
     void sourceVersionChanged(int index);
+    void audioStreamChanged(int streamIndex);
+    void subtitleStreamChanged(int streamIndex);
     void externalPlayRequested(const QString &playerPath);
 
 private:
@@ -55,6 +60,7 @@ private:
     ModernMenuButton* m_versionComboBox;
     ModernMenuButton* m_audioComboBox;
     ModernMenuButton* m_subtitleComboBox;
+    QList<int> m_sourceIndexes;
 
     
     SplitPlayerButton* m_extPlayerBtn;

--- a/src/qEmbyApp/components/horizontallistviewgallery.cpp
+++ b/src/qEmbyApp/components/horizontallistviewgallery.cpp
@@ -8,6 +8,8 @@
 #include <QScrollBar>
 #include <QPropertyAnimation>
 #include <QEvent>
+#include <QHideEvent>
+#include <QShowEvent>
 #include <QWheelEvent>
 #include <QCursor>
 #include <QScroller>           
@@ -17,6 +19,31 @@
 #include <QDebug>
 #include <QSet>
 #include <algorithm>
+
+namespace {
+
+bool intersectsVisibleAncestorChain(const QWidget* widget)
+{
+    if (!widget || !widget->isVisible()) {
+        return false;
+    }
+
+    QRect visibleRect = widget->rect();
+    const QWidget* child = widget;
+    const QWidget* parent = child->parentWidget();
+    while (parent) {
+        visibleRect.moveTopLeft(child->mapTo(parent, visibleRect.topLeft()));
+        visibleRect = visibleRect.intersected(parent->rect());
+        if (visibleRect.isEmpty()) {
+            return false;
+        }
+        child = parent;
+        parent = child->parentWidget();
+    }
+    return true;
+}
+
+} 
 
 HorizontalListViewGallery::HorizontalListViewGallery(QEmbyCore* core, QWidget* parent)
     : QWidget(parent), m_core(core), m_hScrollAnim(nullptr), m_hScrollTarget(0), m_cardStyle(MediaCardDelegate::Poster)
@@ -165,7 +192,9 @@ void HorizontalListViewGallery::setItems(const QList<MediaItem>& items)
                            [this]() { updateVisibleImagePriority(); });
     }
     
-    if (m_shimmer && m_shimmer->isVisible() && !items.isEmpty()) {
+    
+    
+    if (m_shimmer && !items.isEmpty()) {
         m_shimmer->stopAnimation();
         m_shimmer->hide();
     }
@@ -220,6 +249,11 @@ int HorizontalListViewGallery::itemCount() const
     return m_listModel ? m_listModel->rowCount() : 0;
 }
 
+QList<MediaItem> HorizontalListViewGallery::items() const
+{
+    return m_listModel ? m_listModel->items() : QList<MediaItem> {};
+}
+
 void HorizontalListViewGallery::clearImageCache()
 {
     if (m_listModel) {
@@ -227,9 +261,22 @@ void HorizontalListViewGallery::clearImageCache()
     }
 }
 
+void HorizontalListViewGallery::setForceNetworkImages(bool forceNetwork)
+{
+    if (m_listModel) {
+        m_listModel->setForceNetworkImages(forceNetwork);
+    }
+}
+
+void HorizontalListViewGallery::clearFailedImageItems()
+{
+    if (m_listModel) {
+        m_listModel->clearFailedImageItems();
+    }
+}
+
 void HorizontalListViewGallery::setCardStyle(MediaCardDelegate::CardStyle style)
 {
-    bool styleChanged = (m_cardStyle != style);
     m_cardStyle = style; 
     if (m_listDelegate) {
         m_listDelegate->setStyle(style);
@@ -254,10 +301,7 @@ void HorizontalListViewGallery::setCardStyle(MediaCardDelegate::CardStyle style)
     
     if (m_listModel) {
         m_listModel->setPreferThumb(style == MediaCardDelegate::LibraryTile || style == MediaCardDelegate::EpisodeList);
-        
-        if (styleChanged) {
-            m_listModel->clearImageCache();
-        }
+        updateImageRequestSize();
     }
     
     updateButtonPositions();
@@ -270,6 +314,7 @@ void HorizontalListViewGallery::setTileSize(const QSize &size)
         m_listView->doItemsLayout();
         m_listView->viewport()->update();
     }
+    updateImageRequestSize();
     updateButtonPositions();
 }
 
@@ -289,6 +334,7 @@ void HorizontalListViewGallery::setContentPadding(int padding)
         m_listView->doItemsLayout();
         m_listView->viewport()->update();
     }
+    updateImageRequestSize();
     updateButtonPositions();
 }
 
@@ -379,6 +425,30 @@ void HorizontalListViewGallery::resizeEvent(QResizeEvent* event)
     if (m_shimmer && m_shimmer->isVisible()) {
         m_shimmer->setGeometry(m_listView->geometry());
     }
+}
+
+void HorizontalListViewGallery::hideEvent(QHideEvent* event)
+{
+    if (m_listModel && !m_imageRequestsSuspendedForVisibility) {
+        m_listModel->suspendImageRequests();
+        m_imageRequestsSuspendedForVisibility = true;
+    }
+    QWidget::hideEvent(event);
+}
+
+void HorizontalListViewGallery::showEvent(QShowEvent* event)
+{
+    QWidget::showEvent(event);
+    if (m_listModel && m_imageRequestsSuspendedForVisibility) {
+        m_listModel->resumeImageRequests();
+        m_imageRequestsSuspendedForVisibility = false;
+    }
+    QTimer::singleShot(0, this, [this]() {
+        updateVisibleImagePriority();
+        if (m_listView && m_listView->viewport()) {
+            m_listView->viewport()->update();
+        }
+    });
 }
 
 void HorizontalListViewGallery::updateButtonPositions()
@@ -488,6 +558,15 @@ void HorizontalListViewGallery::updateVisibleImagePriority()
         return;
     }
 
+    
+    
+    
+    
+    if (!intersectsVisibleAncestorChain(this)) {
+        m_listModel->setPriorityRows({});
+        return;
+    }
+
     QWidget* viewport = m_listView->viewport();
     if (!viewport) {
         return;
@@ -512,4 +591,19 @@ void HorizontalListViewGallery::updateVisibleImagePriority()
     QList<int> rows = rowSet.values();
     std::sort(rows.begin(), rows.end());
     m_listModel->setPriorityRows(rows);
+}
+
+void HorizontalListViewGallery::updateImageRequestSize()
+{
+    if (!m_listModel || !m_listDelegate) {
+        return;
+    }
+
+    QStyleOptionViewItem option;
+    const QSize cardSize = m_listDelegate->sizeHint(option, QModelIndex());
+    const int displayWidth =
+        qMax(1, cardSize.width() - m_listDelegate->contentPadding() * 2);
+    const int requestWidth = qBound(
+        160, qRound(displayWidth * devicePixelRatioF()), 768);
+    m_listModel->setImageMaxWidth(requestWidth);
 }

--- a/src/qEmbyApp/components/horizontallistviewgallery.h
+++ b/src/qEmbyApp/components/horizontallistviewgallery.h
@@ -35,7 +35,12 @@ public:
     
     void removeItem(const QString& itemId);
     int itemCount() const;
+    QList<MediaItem> items() const;
     void clearImageCache();
+    void setForceNetworkImages(bool forceNetwork);
+    
+    
+    void clearFailedImageItems();
 
     
     void setCardStyle(MediaCardDelegate::CardStyle style);
@@ -67,12 +72,15 @@ Q_SIGNALS:
 
 protected:
     void resizeEvent(QResizeEvent* event) override;
+    void hideEvent(QHideEvent* event) override;
+    void showEvent(QShowEvent* event) override;
     bool eventFilter(QObject* obj, QEvent* event) override;
 
 private:
     void updateButtonsVisibility();
     void updateButtonPositions();
     void updateVisibleImagePriority();
+    void updateImageRequestSize();
 
     QEmbyCore* m_core;
     QListView* m_listView;
@@ -92,6 +100,7 @@ private:
 
     
     ShimmerWidget* m_shimmer = nullptr;
+    bool m_imageRequestsSuspendedForVisibility = false;
 };
 
 #endif 

--- a/src/qEmbyApp/components/mediaactionmenu.cpp
+++ b/src/qEmbyApp/components/mediaactionmenu.cpp
@@ -1,24 +1,23 @@
 #include "mediaactionmenu.h"
-#include "../managers/thememanager.h" 
 #include "../managers/externalplayerdetector.h" 
+#include "../managers/thememanager.h"           
 #include "../utils/mediaidentifyutils.h"
 #include "../utils/mediaitemutils.h"
 #include "../utils/playlistutils.h"
-#include <qembycore.h>
-#include <services/manager/servermanager.h> 
-#include <models/profile/serverprofile.h>
 #include <QAction>
-#include <QIcon>
 #include <QFile>
 #include <QFileInfo>
+#include <QIcon>
 #include <QSet>
 #include <QVariant>
 #include <config/config_keys.h>
 #include <config/configstore.h>
+#include <models/profile/serverprofile.h>
+#include <qembycore.h>
+#include <services/manager/servermanager.h> 
 
 
-MediaActionMenu::MediaActionMenu(const MediaItem& item, QEmbyCore* core,
-                                 QWidget *parent,
+MediaActionMenu::MediaActionMenu(const MediaItem &item, QEmbyCore *core, QWidget *parent,
                                  const QList<CardContextMenuAction> &allowedActions)
     : QMenu(parent), m_item(item), m_core(core), m_allowedActions(allowedActions)
 {
@@ -36,17 +35,15 @@ MediaActionMenu::MediaActionMenu(const MediaItem& item, QEmbyCore* core,
     setupMenu();
 }
 
-CardContextMenuRequest MediaActionMenu::execRequest(const QPoint& globalPos)
+CardContextMenuRequest MediaActionMenu::execRequest(const QPoint &globalPos)
 {
     return requestFromAction(exec(globalPos));
 }
 
-QAction* MediaActionMenu::addMenuAction(CardContextMenuAction action,
-                                        const QIcon& icon,
-                                        const QString& text,
-                                        const QString& stringValue)
+QAction *MediaActionMenu::addMenuAction(CardContextMenuAction action, const QIcon &icon, const QString &text,
+                                        const QString &stringValue)
 {
-    auto* menuAction = new QAction(icon, text, this);
+    auto *menuAction = new QAction(icon, text, this);
 
     CardContextMenuRequest request;
     request.action = action;
@@ -57,14 +54,16 @@ QAction* MediaActionMenu::addMenuAction(CardContextMenuAction action,
     return menuAction;
 }
 
-CardContextMenuRequest MediaActionMenu::requestFromAction(const QAction* action)
+CardContextMenuRequest MediaActionMenu::requestFromAction(const QAction *action)
 {
-    if (!action) {
+    if (!action)
+    {
         return {};
     }
 
     const QVariant requestData = action->data();
-    if (!requestData.canConvert<CardContextMenuRequest>()) {
+    if (!requestData.canConvert<CardContextMenuRequest>())
+    {
         return {};
     }
 
@@ -78,7 +77,8 @@ void MediaActionMenu::setupMenu()
     
     QString themeDir = ThemeManager::instance()->isDarkMode() ? "dark" : "light";
     
-    auto adaptiveIcon = [&themeDir](const QString& baseName) -> QIcon {
+    auto adaptiveIcon = [&themeDir](const QString &baseName) -> QIcon
+    {
         
         QString themePath = QString(":/svg/%1/%2").arg(themeDir, baseName);
         if (QFile::exists(themePath))
@@ -88,60 +88,48 @@ void MediaActionMenu::setupMenu()
     };
 
     
-    auto maybeAdd = [this](CardContextMenuAction action, const QIcon &icon,
-                           const QString &text,
-                           const QString &stringValue = QString()) -> QAction * {
+    auto maybeAdd = [this](CardContextMenuAction action, const QIcon &icon, const QString &text,
+                           const QString &stringValue = QString()) -> QAction *
+    {
         if (!m_allowedActions.isEmpty() && !m_allowedActions.contains(action))
             return nullptr;
         return addMenuAction(action, icon, text, stringValue);
     };
 
     const auto activeProfile =
-        m_core && m_core->serverManager()
-            ? m_core->serverManager()->activeProfile()
-            : ServerProfile{};
+        m_core && m_core->serverManager() ? m_core->serverManager()->activeProfile() : ServerProfile{};
     const bool canIdentifyMedia =
-        activeProfile.isValid() && activeProfile.isAdmin &&
-        MediaIdentifyUtils::canIdentify(m_item);
-    const bool canEditMetadata =
-        activeProfile.isValid() && activeProfile.isAdmin &&
-        !m_item.id.trimmed().isEmpty() && m_item.type != "Playlist" &&
-        m_item.type != "Person";
-    const bool canEditImages =
-        activeProfile.isValid() && activeProfile.isAdmin &&
-        !m_item.id.trimmed().isEmpty() && m_item.type != "Playlist" &&
-        m_item.type != "Person";
-    const bool canRefreshMetadata =
-        activeProfile.isValid() && activeProfile.isAdmin &&
-        !m_item.id.trimmed().isEmpty() && m_item.type != "Playlist" &&
-        m_item.type != "Person";
-    const bool canRemoveMedia =
-        activeProfile.isValid() && activeProfile.isAdmin &&
-        !m_item.id.trimmed().isEmpty() && m_item.type != "Playlist" &&
-        m_item.type != "Person";
-    const bool canDownloadMedia =
-        activeProfile.isValid() && activeProfile.canDownloadMedia &&
-        !m_item.id.trimmed().isEmpty() && m_item.canDownload;
+        activeProfile.isValid() && activeProfile.isAdmin && MediaIdentifyUtils::canIdentify(m_item);
+    const bool canEditMetadata = activeProfile.isValid() && activeProfile.isAdmin && !m_item.id.trimmed().isEmpty() &&
+                                 m_item.type != "Playlist" && m_item.type != "Person";
+    const bool canEditImages = activeProfile.isValid() && activeProfile.isAdmin && !m_item.id.trimmed().isEmpty() &&
+                               m_item.type != "Playlist" && m_item.type != "Person";
+    const bool canRefreshMetadata = activeProfile.isValid() && activeProfile.isAdmin &&
+                                    !m_item.id.trimmed().isEmpty() && m_item.type != "Playlist" &&
+                                    m_item.type != "Person";
+    const bool canRemoveMedia = activeProfile.isValid() && activeProfile.isAdmin && !m_item.id.trimmed().isEmpty() &&
+                                m_item.type != "Playlist" && m_item.type != "Person";
+    const bool canDownloadMedia = activeProfile.isValid() && activeProfile.canDownloadMedia &&
+                                  !m_item.id.trimmed().isEmpty() && m_item.canDownload;
 
-    if (m_item.type == "Playlist") {
-        maybeAdd(CardContextMenuAction::DeletePlaylist,
-                      adaptiveIcon("remove.svg"), tr("Delete Playlist"));
+    if (m_item.type == "Playlist")
+    {
+        maybeAdd(CardContextMenuAction::DeletePlaylist, adaptiveIcon("remove.svg"), tr("Delete Playlist"));
         return;
     }
 
     
-    bool isPlayable = (m_item.mediaType == "Video" || 
-                       m_item.type == "Movie" || 
-                       m_item.type == "Episode" || 
+    bool isPlayable = (m_item.mediaType == "Video" || m_item.type == "Movie" || m_item.type == "Episode" ||
                        m_item.type == "MusicVideo");
-    
-    if (isPlayable) {
-        maybeAdd(CardContextMenuAction::Play, adaptiveIcon("play.svg"),
-                      tr("Play"));
+
+    if (isPlayable)
+    {
+        maybeAdd(CardContextMenuAction::Play, adaptiveIcon("play.svg"), tr("Play"));
 
         
         bool extEnabled = ConfigStore::instance()->get<bool>(ConfigKeys::ExtPlayerEnable, false);
-        if (extEnabled) {
+        if (extEnabled)
+        {
             QString currentPath = ConfigStore::instance()->get<QString>(ConfigKeys::ExtPlayerPath);
             QList<DetectedPlayer> allPlayers = ExternalPlayerDetector::loadFromConfig();
 
@@ -149,22 +137,27 @@ void MediaActionMenu::setupMenu()
             QSet<QString> knownPaths;
             for (const auto &p : allPlayers)
                 knownPaths.insert(p.path);
-            if (!currentPath.isEmpty() && currentPath != "custom" &&
-                !knownPaths.contains(currentPath) && QFileInfo::exists(currentPath)) {
+            if (!currentPath.isEmpty() && currentPath != "custom" && !knownPaths.contains(currentPath) &&
+                QFileInfo::exists(currentPath))
+            {
                 allPlayers.prepend({QFileInfo(currentPath).baseName(), currentPath});
             }
 
-            if (!allPlayers.isEmpty()) {
+            if (!allPlayers.isEmpty())
+            {
                 
                 QString activePlayerPath = currentPath;
-                if (activePlayerPath.isEmpty() || activePlayerPath == "custom") {
+                if (activePlayerPath.isEmpty() || activePlayerPath == "custom")
+                {
                     activePlayerPath = allPlayers.first().path;
                 }
 
                 
                 QString playerName;
-                for (const auto &p : allPlayers) {
-                    if (p.path == activePlayerPath) {
+                for (const auto &p : allPlayers)
+                {
+                    if (p.path == activePlayerPath)
+                    {
                         playerName = p.name;
                         break;
                     }
@@ -172,34 +165,28 @@ void MediaActionMenu::setupMenu()
                 if (playerName.isEmpty())
                     playerName = QFileInfo(activePlayerPath).baseName();
 
-                maybeAdd(CardContextMenuAction::ExternalPlay,
-                              adaptiveIcon("external-player.svg"),
-                              tr("Play with %1").arg(playerName),
-                              activePlayerPath);
+                maybeAdd(CardContextMenuAction::ExternalPlay, adaptiveIcon("external-player.svg"),
+                         tr("Play with %1").arg(playerName), activePlayerPath);
             }
         }
     }
 
     
-    maybeAdd(CardContextMenuAction::ViewDetails, adaptiveIcon("info.svg"),
-                  tr("View Details"));
+    maybeAdd(CardContextMenuAction::ViewDetails, adaptiveIcon("info.svg"), tr("View Details"));
 
-    if (canDownloadMedia) {
-        maybeAdd(CardContextMenuAction::Download,
-                      adaptiveIcon("download-menu.svg"), tr("Download"));
+    if (canDownloadMedia)
+    {
+        maybeAdd(CardContextMenuAction::Download, adaptiveIcon("download-menu.svg"), tr("Download"));
     }
 
-    if (PlaylistUtils::canAddItemToPlaylist(m_item)) {
-        maybeAdd(CardContextMenuAction::AddToPlaylist,
-                      adaptiveIcon("playlist-add.svg"),
-                      tr("Add to Playlist"));
+    if (PlaylistUtils::canAddItemToPlaylist(m_item))
+    {
+        maybeAdd(CardContextMenuAction::AddToPlaylist, adaptiveIcon("playlist-add.svg"), tr("Add to Playlist"));
     }
 
-    if (!m_item.playlistId.trimmed().isEmpty() &&
-        !m_item.playlistItemId.trimmed().isEmpty()) {
-        maybeAdd(CardContextMenuAction::RemoveFromPlaylist,
-                      adaptiveIcon("remove.svg"),
-                      tr("Remove from Playlist"));
+    if (!m_item.playlistId.trimmed().isEmpty() && !m_item.playlistItemId.trimmed().isEmpty())
+    {
+        maybeAdd(CardContextMenuAction::RemoveFromPlaylist, adaptiveIcon("remove.svg"), tr("Remove from Playlist"));
     }
 
     addSeparator();
@@ -208,8 +195,7 @@ void MediaActionMenu::setupMenu()
     QString favText = m_item.isFavorite() ? tr("Remove from Favorites") : tr("Add to Favorites");
     QString favIconName = m_item.isFavorite() ? "heart-fill.svg" : "heart-outline.svg";
 
-    maybeAdd(CardContextMenuAction::ToggleFavorite,
-                  adaptiveIcon(favIconName), favText);
+    maybeAdd(CardContextMenuAction::ToggleFavorite, adaptiveIcon(favIconName), favText);
 
     
     
@@ -219,54 +205,50 @@ void MediaActionMenu::setupMenu()
     QString playedText = m_item.userData.played ? tr("Mark as Unplayed") : tr("Mark as Played");
     QString playedIconName = m_item.userData.played ? "played.svg" : "unplayed.svg";
 
-    maybeAdd(m_item.userData.played ? CardContextMenuAction::MarkUnplayed
-                                         : CardContextMenuAction::MarkPlayed,
-                  adaptiveIcon(playedIconName), playedText);
+    maybeAdd(m_item.userData.played ? CardContextMenuAction::MarkUnplayed : CardContextMenuAction::MarkPlayed,
+             adaptiveIcon(playedIconName), playedText);
 
     
     
-    const bool canRemoveFromResume =
-        MediaItemUtils::canRemoveFromResume(m_item);
-    
+    const bool canRemoveFromResume = MediaItemUtils::canRemoveFromResume(m_item);
+
     
     bool isJellyfin = false;
-    if (m_core && m_core->serverManager() && m_core->serverManager()->activeProfile().isValid()) {
+    if (m_core && m_core->serverManager() && m_core->serverManager()->activeProfile().isValid())
+    {
         isJellyfin = (m_core->serverManager()->activeProfile().type == ServerProfile::Jellyfin);
     }
+
     
-    
-    if (canRemoveFromResume && !isJellyfin) {
-        maybeAdd(CardContextMenuAction::RemoveFromResume,
-                      adaptiveIcon("remove.svg"),
-                      tr("Remove from Continue Watching"));
+    if (canRemoveFromResume && !isJellyfin)
+    {
+        maybeAdd(CardContextMenuAction::RemoveFromResume, adaptiveIcon("remove.svg"),
+                 tr("Remove from Continue Watching"));
     }
 
-    if (canEditMetadata || canEditImages || canRefreshMetadata || canIdentifyMedia ||
-        canRemoveMedia) {
+    if (canEditMetadata || canEditImages || canRefreshMetadata || canIdentifyMedia || canRemoveMedia)
+    {
         addSeparator();
-        if (canEditMetadata) {
-            maybeAdd(CardContextMenuAction::EditMetadata,
-                          adaptiveIcon("edit.svg"),
-                          tr("Edit Metadata"));
+        if (canEditMetadata)
+        {
+            maybeAdd(CardContextMenuAction::EditMetadata, adaptiveIcon("edit.svg"), tr("Edit Metadata"));
         }
-        if (canEditImages) {
-            maybeAdd(CardContextMenuAction::EditImages,
-                          adaptiveIcon("edit-images.svg"),
-                          tr("Edit Images"));
+        if (canEditImages)
+        {
+            maybeAdd(CardContextMenuAction::EditImages, adaptiveIcon("edit-images.svg"), tr("Edit Images"));
         }
-        if (canRefreshMetadata) {
-            maybeAdd(CardContextMenuAction::RefreshMetadata,
-                          adaptiveIcon("refresh.svg"),
-                          tr("Refresh Metadata"));
+        if (canRefreshMetadata)
+        {
+            maybeAdd(CardContextMenuAction::RefreshMetadata, adaptiveIcon("refresh.svg"), tr("Refresh Metadata"));
         }
-        if (canIdentifyMedia) {
-            maybeAdd(CardContextMenuAction::Identify,
-                          adaptiveIcon("search.svg"), tr("Identify"));
+        if (canIdentifyMedia)
+        {
+            maybeAdd(CardContextMenuAction::Identify, adaptiveIcon("search.svg"), tr("Identify"));
         }
     }
 
-    if (canRemoveMedia) {
-        maybeAdd(CardContextMenuAction::RemoveMedia,
-                      adaptiveIcon("remove.svg"), tr("Remove Media"));
+    if (canRemoveMedia)
+    {
+        maybeAdd(CardContextMenuAction::RemoveMedia, adaptiveIcon("remove.svg"), tr("Remove Media"));
     }
 }

--- a/src/qEmbyApp/components/mediagridwidget.cpp
+++ b/src/qEmbyApp/components/mediagridwidget.cpp
@@ -154,7 +154,7 @@ void MediaGridWidget::setItems(const QList<MediaItem>& items) {
     adjustGrid();
     
     
-    if (m_shimmer && m_shimmer->isVisible() && !items.isEmpty()) {
+    if (m_shimmer && !items.isEmpty()) {
         m_shimmer->stopAnimation();
         m_shimmer->hide();
     }
@@ -274,6 +274,11 @@ void MediaGridWidget::updateVisibleImagePriority()
         return;
     }
 
+    if (!isVisible() || visibleRegion().isEmpty()) {
+        m_listModel->setPriorityRows({});
+        return;
+    }
+
     QWidget* viewport = m_listView->viewport();
     if (!viewport) {
         return;
@@ -323,6 +328,9 @@ void MediaGridWidget::adjustGrid() {
         if (cellWidth < 100) cellWidth = 100;
         
         m_listDelegate->setTileSize(QSize(cellWidth, 160));
+        const int requestWidth = qBound(
+            160, qRound(250 * devicePixelRatioF()), 768);
+        m_listModel->setImageMaxWidth(requestWidth);
     } else {
         availableWidth -= (m_basePadding * 2);
         int defaultCellWidth = 150;
@@ -353,6 +361,9 @@ void MediaGridWidget::adjustGrid() {
 
         int cellHeight = imgHeight + 60;
         m_listDelegate->setTileSize(QSize(cellWidth, cellHeight));
+        const int requestWidth = qBound(
+            160, qRound(imgWidth * devicePixelRatioF()), 768);
+        m_listModel->setImageMaxWidth(requestWidth);
     }
     
     m_listView->doItemsLayout();

--- a/src/qEmbyApp/components/moderndialogbase.cpp
+++ b/src/qEmbyApp/components/moderndialogbase.cpp
@@ -2,6 +2,7 @@
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QSizePolicy>
 
 
 #include <QWKWidgets/widgetwindowagent.h>
@@ -59,6 +60,10 @@ ModernDialogBase::ModernDialogBase(QWidget *parent,
     
     m_titleBarWidget = new QWidget(this);
     m_titleBarWidget->setObjectName("dialog-titlebar");
+    
+    
+    m_titleBarWidget->setSizePolicy(QSizePolicy::Expanding,
+                                    QSizePolicy::Fixed);
 
     auto *titleBarLayout = new QHBoxLayout(m_titleBarWidget);
 #if defined(Q_OS_MACOS) || defined(Q_OS_MAC)

--- a/src/qEmbyApp/components/mpvwidget.cpp
+++ b/src/qEmbyApp/components/mpvwidget.cpp
@@ -41,6 +41,14 @@ MpvWidget::~MpvWidget() {
     
     
     
+    if (QOpenGLContext *ctx = context()) {
+        disconnect(ctx, &QOpenGLContext::aboutToBeDestroyed,
+                   this, &MpvWidget::cleanupGL);
+    }
+
+    
+    
+    
     shutdown();
     if (m_controller) {
         m_controller->deleteLater();
@@ -74,17 +82,21 @@ void MpvWidget::shutdown() {
 
 void MpvWidget::cleanupGL() {
     if (m_mpv_gl) {
+        mpv_render_context_set_update_callback(m_mpv_gl, nullptr, nullptr);
+
+        
         
         
         if (isValid()) {
             makeCurrent();
-            mpv_render_context_set_update_callback(m_mpv_gl, nullptr, nullptr);
             mpv_render_context_free(m_mpv_gl);
             doneCurrent();
         } else {
-            qWarning() << "[MpvWidget] OpenGL context is not valid. Bypassing render context free.";
+            qWarning() << "[MpvWidget] OpenGL surface is invalid; freeing MPV render context without makeCurrent";
+            mpv_render_context_free(m_mpv_gl);
         }
         m_mpv_gl = nullptr;
+        qInfo() << "[MpvWidget] MPV render context released with OpenGL context";
     }
 }
 
@@ -116,6 +128,14 @@ void MpvWidget::initializeGL() {
 
     
     
+    
+    if (ctx) {
+        connect(ctx, &QOpenGLContext::aboutToBeDestroyed,
+                this, &MpvWidget::cleanupGL, Qt::DirectConnection);
+    }
+
+    
+    
     if (m_mpv_gl) {
         mpv_render_context_set_update_callback(m_mpv_gl, nullptr, nullptr);
         mpv_render_context_free(m_mpv_gl);
@@ -133,18 +153,31 @@ void MpvWidget::initializeGL() {
         {MPV_RENDER_PARAM_INVALID, nullptr}
     };
 
-    if (mpv_render_context_create(&m_mpv_gl, m_controller->mpv(), params) < 0) {
+    const int createError = mpv_render_context_create(&m_mpv_gl, m_controller->mpv(), params);
+    if (createError < 0) {
+        qCritical() << "[MpvWidget] MPV render context creation failed"
+                    << "| error:" << mpv_error_string(createError);
         emit errorOccurred(tr("OpenGL rendering initialization failed."));
         return;
     }
 
     mpv_render_context_set_update_callback(m_mpv_gl, onMpvRenderUpdate, this);
 
+    qInfo() << "[MpvWidget] MPV render context initialized"
+            << "| resumePending:" << m_resumeWhenRenderReady;
+
     if (!m_pendingUrl.isEmpty()) {
         loadMediaNow(m_pendingUrl, m_pendingServerId, true);
         m_pendingUrl.clear();
         m_pendingServerId.clear();
     }
+
+    if (m_resumeWhenRenderReady) {
+        m_resumeWhenRenderReady = false;
+        m_controller->setProperty("pause", false);
+    }
+
+    update();
 }
 
 void MpvWidget::paintGL() {
@@ -281,6 +314,19 @@ void MpvWidget::loadMedia(const QString &url, const QString &serverId) {
 
 void MpvWidget::play() {
     m_controller->setProperty("pause", false);
+}
+
+void MpvWidget::resumeAfterContextRestore() {
+    if (!m_mpv_gl || !context() || !context()->isValid()) {
+        m_resumeWhenRenderReady = true;
+        qInfo() << "[MpvWidget] Resume deferred until OpenGL context is ready";
+        update();
+        return;
+    }
+
+    m_resumeWhenRenderReady = false;
+    m_controller->setProperty("pause", false);
+    update();
 }
 
 void MpvWidget::pause() {

--- a/src/qEmbyApp/components/mpvwidget.h
+++ b/src/qEmbyApp/components/mpvwidget.h
@@ -20,6 +20,7 @@ public:
 
     void loadMedia(const QString &url, const QString &serverId = QString());
     void play();
+    void resumeAfterContextRestore();
     void pause();
     void stop();
     void seek(double positionInSeconds);
@@ -52,6 +53,7 @@ private:
     MpvController *m_controller;
     MpvHttpStreamRelay *m_streamRelay = nullptr;
     bool m_usingStreamRelay = false;
+    bool m_resumeWhenRenderReady = false;
     mpv_render_context *m_mpv_gl;
 
     

--- a/src/qEmbyApp/components/playerdanmakucontroller.cpp
+++ b/src/qEmbyApp/components/playerdanmakucontroller.cpp
@@ -9,11 +9,14 @@
 #include <qembycore.h>
 #include <services/danmaku/danmakuservice.h>
 #include <services/manager/servermanager.h>
+#include <services/media/mediaservice.h>
 
 #include <QCoreApplication>
 #include <QDir>
 #include <QDebug>
+#include <QFileInfo>
 #include <QTimer>
+#include <QUrl>
 #include <exception>
 
 namespace {
@@ -206,6 +209,34 @@ void PlayerDanmakuController::clearPlaybackContext()
         m_nativeDanmakuOverlay->clearDanmaku();
     }
     qDebug() << "[Danmaku][Player] Cleared playback context";
+    emit stateChanged();
+}
+
+void PlayerDanmakuController::prepareForMediaReload()
+{
+    if (!hasPlaybackContext()) {
+        return;
+    }
+
+    const bool hadTrack = m_danmakuTrackId > 0;
+    const bool hasPreparedContent = hasPreparedDanmaku();
+
+    
+    
+    
+    removeDanmakuTrack();
+    m_fileLoaded = false;
+    m_selectedSubtitleTrackId = -1;
+    if (m_nativeDanmakuOverlay) {
+        m_nativeDanmakuOverlay->setDanmakuVisible(false);
+    }
+
+    qDebug().noquote()
+        << "[Danmaku][Player] Prepared for media reload"
+        << "| mediaId:" << m_mediaContext.mediaId
+        << "| hadTrack:" << hadTrack
+        << "| hasPreparedContent:" << hasPreparedContent
+        << "| nativeRenderer:" << shouldUseNativeRenderer();
     emit stateChanged();
 }
 
@@ -493,6 +524,27 @@ DanmakuMediaContext PlayerDanmakuController::buildMediaContext(
     mediaContext.durationMs =
         (source.runTimeTicks > 0 ? source.runTimeTicks : item.runTimeTicks) / 10000;
     mediaContext.path = !source.path.isEmpty() ? source.path : item.path;
+    QString normalizedMediaPath = mediaContext.path;
+    const QUrl mediaPathUrl = QUrl::fromUserInput(normalizedMediaPath);
+    if (mediaPathUrl.scheme().compare(QStringLiteral("http"),
+                                      Qt::CaseInsensitive) == 0 ||
+        mediaPathUrl.scheme().compare(QStringLiteral("https"),
+                                      Qt::CaseInsensitive) == 0) {
+        normalizedMediaPath = mediaPathUrl.path();
+    }
+    normalizedMediaPath.replace(QLatin1Char('\\'), QLatin1Char('/'));
+    mediaContext.fileName =
+        QFileInfo(normalizedMediaPath).completeBaseName().trimmed();
+    if (mediaContext.fileName.isEmpty() && !item.name.trimmed().isEmpty()) {
+        mediaContext.fileName = item.name.trimmed();
+    }
+    mediaContext.fileSize = source.size > 0 ? source.size : item.size;
+    mediaContext.mediaModifiedAt = source.dateModified;
+    mediaContext.genres = item.genres;
+    if (m_core->mediaService() && !item.id.isEmpty() && !source.id.isEmpty()) {
+        mediaContext.mediaUrl =
+            m_core->mediaService()->getStreamUrl(item.id, source);
+    }
     mediaContext.providerIds = item.providerIds;
     return mediaContext;
 }

--- a/src/qEmbyApp/components/playerdanmakucontroller.h
+++ b/src/qEmbyApp/components/playerdanmakucontroller.h
@@ -24,6 +24,7 @@ public:
 
     void setPlaybackContext(const PlayerLaunchContext &context);
     void clearPlaybackContext();
+    void prepareForMediaReload();
 
     bool isDanmakuEnabled() const;
     bool isDanmakuVisible() const;

--- a/src/qEmbyApp/components/playerdanmakuidentifydialog.cpp
+++ b/src/qEmbyApp/components/playerdanmakuidentifydialog.cpp
@@ -40,6 +40,10 @@ QString providerDisplayName(const QString &provider)
         return QCoreApplication::translate("PlayerDanmakuIdentifyDialog",
                                            "DandanPlay");
     }
+    if (provider == QLatin1String("danmu_api")) {
+        return QCoreApplication::translate("PlayerDanmakuIdentifyDialog",
+                                           "LogVar / danmu_api");
+    }
     return provider.trimmed().isEmpty() ? QCoreApplication::translate(
                                               "PlayerDanmakuIdentifyDialog",
                                               "Unknown Source")

--- a/src/qEmbyApp/components/updatedialog.cpp
+++ b/src/qEmbyApp/components/updatedialog.cpp
@@ -1,0 +1,151 @@
+#include "updatedialog.h"
+
+#include <QCoreApplication>
+#include <QFrame>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QSizePolicy>
+#include <QTextBrowser>
+#include <QTextDocument>
+#include <QVBoxLayout>
+
+namespace {
+
+QLabel *createSummaryLabel(const QString &text, QWidget *parent)
+{
+    auto *label = new QLabel(text, parent);
+    label->setObjectName(QStringLiteral("UpdateDialogSummaryLabel"));
+    label->setAlignment(Qt::AlignLeft | Qt::AlignTop);
+    return label;
+}
+
+QLabel *createSummaryValue(const QString &text, QWidget *parent)
+{
+    auto *label = new QLabel(text, parent);
+    label->setObjectName(QStringLiteral("UpdateDialogSummaryValue"));
+    label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    label->setWordWrap(true);
+    label->setAlignment(Qt::AlignLeft | Qt::AlignTop);
+    return label;
+}
+
+} 
+
+UpdateDialog::UpdateDialog(const UpdateInfo &info,
+                           Mode mode,
+                           QWidget *parent)
+    : ModernDialogBase(parent)
+{
+    setTitle(tr("qEmby Update"));
+    setMinimumSize(540, 430);
+    resize(640, 600);
+
+    auto *layout = contentLayout();
+    layout->setSpacing(0);
+
+    auto *headline = new QLabel(tr("A new version of qEmby is available."), this);
+    headline->setObjectName(QStringLiteral("UpdateDialogHeadline"));
+    headline->setWordWrap(true);
+    layout->addWidget(headline);
+    layout->addSpacing(10);
+
+    auto *summary = new QFrame(this);
+    summary->setObjectName(QStringLiteral("UpdateDialogSummary"));
+    auto *summaryLayout = new QGridLayout(summary);
+    summaryLayout->setContentsMargins(14, 12, 14, 12);
+    summaryLayout->setHorizontalSpacing(12);
+    summaryLayout->setVerticalSpacing(6);
+    summaryLayout->setColumnStretch(1, 1);
+
+    const QString releaseName = info.name.isEmpty() ? info.version : info.name;
+    const QString published = info.publishedAt.isValid()
+                                  ? info.publishedAt.toLocalTime().date().toString(
+                                        Qt::ISODate)
+                                  : tr("Unknown");
+    const QString currentVersion = QCoreApplication::applicationVersion();
+
+    summaryLayout->addWidget(createSummaryLabel(tr("Current version"), summary),
+                             0, 0);
+    summaryLayout->addWidget(createSummaryValue(currentVersion, summary), 0, 1);
+    summaryLayout->addWidget(createSummaryLabel(tr("New version"), summary), 1,
+                             0);
+    summaryLayout->addWidget(createSummaryValue(info.version, summary), 1, 1);
+    summaryLayout->addWidget(createSummaryLabel(tr("Release"), summary), 2, 0);
+    summaryLayout->addWidget(createSummaryValue(releaseName, summary), 2, 1);
+    summaryLayout->addWidget(createSummaryLabel(tr("Published"), summary), 3, 0);
+    summaryLayout->addWidget(createSummaryValue(published, summary), 3, 1);
+    layout->addWidget(summary);
+    layout->addSpacing(14);
+
+    auto *notesTitle = new QLabel(tr("Release notes"), this);
+    notesTitle->setObjectName(QStringLiteral("UpdateDialogSectionTitle"));
+    layout->addWidget(notesTitle);
+    layout->addSpacing(8);
+
+    auto *notesBrowser = new QTextBrowser(this);
+    notesBrowser->setObjectName(QStringLiteral("UpdateDialogReleaseNotes"));
+    notesBrowser->setOpenExternalLinks(true);
+    notesBrowser->setReadOnly(true);
+    notesBrowser->document()->setDocumentMargin(14);
+    notesBrowser->setMarkdown(info.releaseNotes.trimmed().isEmpty()
+                                  ? tr("No release notes were provided.")
+                                  : info.releaseNotes);
+    notesBrowser->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    notesBrowser->setMinimumHeight(180);
+    layout->addWidget(notesBrowser, 1);
+    layout->addSpacing(12);
+
+    auto *buttonLayout = new QHBoxLayout();
+    buttonLayout->setContentsMargins(0, 0, 0, 0);
+    buttonLayout->setSpacing(12);
+    buttonLayout->addStretch();
+
+    if (mode == Mode::Automatic) {
+        auto *laterButton = new QPushButton(tr("Remind Me Later"), this);
+        laterButton->setObjectName(QStringLiteral("dialog-btn-cancel"));
+        laterButton->setCursor(Qt::PointingHandCursor);
+        laterButton->setToolTip(
+            tr("Hide this reminder until the next application startup"));
+        connect(laterButton, &QPushButton::clicked, this, [this]() {
+            m_decision = Decision::RemindLater;
+            reject();
+        });
+        buttonLayout->addWidget(laterButton);
+
+        auto *ignoreVersionButton =
+            new QPushButton(tr("Ignore This Version"), this);
+        ignoreVersionButton->setObjectName(QStringLiteral("dialog-btn-cancel"));
+        ignoreVersionButton->setCursor(Qt::PointingHandCursor);
+        ignoreVersionButton->setToolTip(
+            tr("Do not remind me again for this version"));
+        connect(ignoreVersionButton, &QPushButton::clicked, this, [this]() {
+            m_decision = Decision::IgnoreVersion;
+            reject();
+        });
+        buttonLayout->addWidget(ignoreVersionButton);
+    } else {
+        auto *cancelButton = new QPushButton(tr("Cancel"), this);
+        cancelButton->setObjectName(QStringLiteral("dialog-btn-cancel"));
+        cancelButton->setCursor(Qt::PointingHandCursor);
+        connect(cancelButton, &QPushButton::clicked, this, &QDialog::reject);
+        buttonLayout->addWidget(cancelButton);
+    }
+
+    auto *updateButton = new QPushButton(tr("Update Now"), this);
+    updateButton->setObjectName(QStringLiteral("dialog-btn-primary"));
+    updateButton->setCursor(Qt::PointingHandCursor);
+    updateButton->setDefault(true);
+    connect(updateButton, &QPushButton::clicked, this, [this]() {
+        m_decision = Decision::Update;
+        accept();
+    });
+    buttonLayout->addWidget(updateButton);
+    layout->addLayout(buttonLayout);
+}
+
+UpdateDialog::Decision UpdateDialog::decision() const
+{
+    return m_decision;
+}

--- a/src/qEmbyApp/components/updatedialog.h
+++ b/src/qEmbyApp/components/updatedialog.h
@@ -1,0 +1,25 @@
+#ifndef UPDATEDIALOG_H
+#define UPDATEDIALOG_H
+
+#include "../managers/updatemanager.h"
+#include "moderndialogbase.h"
+
+class UpdateDialog : public ModernDialogBase
+{
+    Q_OBJECT
+
+public:
+    enum class Mode { Manual, Automatic };
+    enum class Decision { Dismissed, RemindLater, IgnoreVersion, Update };
+
+    explicit UpdateDialog(const UpdateInfo &info,
+                          Mode mode,
+                          QWidget *parent = nullptr);
+
+    Decision decision() const;
+
+private:
+    Decision m_decision = Decision::Dismissed;
+};
+
+#endif 

--- a/src/qEmbyApp/components/updateindicatorbutton.cpp
+++ b/src/qEmbyApp/components/updateindicatorbutton.cpp
@@ -1,0 +1,101 @@
+#include "updateindicatorbutton.h"
+
+#include <QHideEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPaintEvent>
+#include <QPropertyAnimation>
+#include <QShowEvent>
+#include <QStyle>
+#include <QStyleOptionButton>
+
+UpdateIndicatorButton::UpdateIndicatorButton(QWidget *parent)
+    : QPushButton(parent),
+      m_arrowAnimation(new QPropertyAnimation(this, "arrowProgress", this))
+{
+    setFixedSize(26, 26);
+    setCursor(Qt::PointingHandCursor);
+
+    m_arrowAnimation->setStartValue(0.0);
+    m_arrowAnimation->setEndValue(1.0);
+    m_arrowAnimation->setDuration(980);
+    m_arrowAnimation->setEasingCurve(QEasingCurve::Linear);
+    m_arrowAnimation->setLoopCount(-1);
+}
+
+qreal UpdateIndicatorButton::arrowProgress() const
+{
+    return m_arrowProgress;
+}
+
+void UpdateIndicatorButton::setArrowProgress(qreal progress)
+{
+    if (qFuzzyCompare(m_arrowProgress, progress)) {
+        return;
+    }
+    m_arrowProgress = progress;
+    update();
+}
+
+void UpdateIndicatorButton::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event);
+
+    QStyleOptionButton option;
+    initStyleOption(&option);
+    option.text.clear();
+    option.icon = QIcon();
+
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    style()->drawControl(QStyle::CE_PushButton, &option, &painter, this);
+
+    const QPointF center(width() / 2.0, height() / 2.0);
+    const QColor circleColor = underMouse() ? QColor(QStringLiteral("#16A34A"))
+                                            : QColor(QStringLiteral("#22C55E"));
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(circleColor);
+    painter.drawEllipse(center, 7.5, 7.5);
+
+    painter.setBrush(Qt::NoBrush);
+    painter.setPen(QPen(QColor(QStringLiteral("#FFFFFF")), 1.5,
+                        Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+
+    QPainterPath iconClip;
+    iconClip.addEllipse(center, 7.1, 7.1);
+    painter.setClipPath(iconClip);
+
+    auto drawArrowAt = [&painter, center](qreal y) {
+        const qreal x = center.x();
+        painter.drawLine(QPointF(x, y + 2.3), QPointF(x, y - 2.3));
+        painter.drawLine(QPointF(x - 2.0, y - 0.3), QPointF(x, y - 2.3));
+        painter.drawLine(QPointF(x + 2.0, y - 0.3), QPointF(x, y - 2.3));
+    };
+
+    
+    
+    
+    
+    constexpr qreal arrowSpacing = 14.5;
+    const qreal primaryY = center.y() + arrowSpacing / 2.0 -
+                           m_arrowProgress * arrowSpacing;
+    drawArrowAt(primaryY - arrowSpacing);
+    drawArrowAt(primaryY);
+    drawArrowAt(primaryY + arrowSpacing);
+    painter.setClipping(false);
+}
+
+void UpdateIndicatorButton::showEvent(QShowEvent *event)
+{
+    QPushButton::showEvent(event);
+    if (m_arrowAnimation->state() != QAbstractAnimation::Running) {
+        m_arrowAnimation->start();
+    }
+}
+
+void UpdateIndicatorButton::hideEvent(QHideEvent *event)
+{
+    m_arrowAnimation->stop();
+    m_arrowProgress = 0.0;
+    QPushButton::hideEvent(event);
+}

--- a/src/qEmbyApp/components/updateindicatorbutton.h
+++ b/src/qEmbyApp/components/updateindicatorbutton.h
@@ -1,0 +1,31 @@
+#ifndef UPDATEINDICATORBUTTON_H
+#define UPDATEINDICATORBUTTON_H
+
+#include <QPushButton>
+
+class QPropertyAnimation;
+class QHideEvent;
+class QShowEvent;
+
+class UpdateIndicatorButton : public QPushButton
+{
+    Q_OBJECT
+    Q_PROPERTY(qreal arrowProgress READ arrowProgress WRITE setArrowProgress)
+
+public:
+    explicit UpdateIndicatorButton(QWidget *parent = nullptr);
+
+    qreal arrowProgress() const;
+    void setArrowProgress(qreal progress);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+    void showEvent(QShowEvent *event) override;
+    void hideEvent(QHideEvent *event) override;
+
+private:
+    qreal m_arrowProgress = 0.0;
+    QPropertyAnimation *m_arrowAnimation = nullptr;
+};
+
+#endif 

--- a/src/qEmbyApp/components/updateprogressdialog.cpp
+++ b/src/qEmbyApp/components/updateprogressdialog.cpp
@@ -1,0 +1,201 @@
+#include "updateprogressdialog.h"
+
+#include "modernmessagebox.h"
+#include "modernswitch.h"
+#include "../managers/windowsupdatemanager.h"
+#include <QApplication>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLocale>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QTimer>
+#include <QVBoxLayout>
+
+namespace {
+
+QString formatBytes(qint64 bytes)
+{
+    constexpr qreal kiloByte = 1024.0;
+    constexpr qreal megaByte = kiloByte * 1024.0;
+    if (bytes >= static_cast<qint64>(megaByte)) {
+        return UpdateProgressDialog::tr("%1 MB")
+            .arg(QLocale().toString(bytes / megaByte, 'f', 1));
+    }
+    return UpdateProgressDialog::tr("%1 KB")
+        .arg(QLocale().toString(bytes / kiloByte, 'f', 1));
+}
+
+} 
+
+UpdateProgressDialog::UpdateProgressDialog(const UpdateInfo &info,
+                                           QWidget *parent)
+    : ModernDialogBase(parent), m_info(info)
+{
+    setTitle(tr("Update qEmby"));
+    setMinimumWidth(500);
+    resize(560, 320);
+
+    auto *layout = contentLayout();
+    layout->setSpacing(12);
+
+    auto *headline = new QLabel(tr("Updating to %1").arg(info.version), this);
+    headline->setObjectName(QStringLiteral("UpdateProgressHeadline"));
+    layout->addWidget(headline);
+
+    m_statusLabel = new QLabel(tr("Preparing download…"), this);
+    m_statusLabel->setObjectName(QStringLiteral("UpdateProgressStatus"));
+    m_statusLabel->setWordWrap(true);
+    layout->addWidget(m_statusLabel);
+
+    m_progressBar = new QProgressBar(this);
+    m_progressBar->setObjectName(QStringLiteral("UpdateDownloadProgressBar"));
+    m_progressBar->setRange(0, 100);
+    m_progressBar->setValue(0);
+    m_progressBar->setTextVisible(false);
+    layout->addWidget(m_progressBar);
+
+    m_detailLabel = new QLabel(tr("Waiting for download…"), this);
+    m_detailLabel->setObjectName(QStringLiteral("UpdateProgressDetail"));
+    m_detailLabel->setWordWrap(true);
+    m_detailLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    layout->addWidget(m_detailLabel);
+
+    auto *restartCard = new QWidget(this);
+    restartCard->setObjectName(QStringLiteral("UpdateRestartCard"));
+    restartCard->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    auto *restartLayout = new QHBoxLayout(restartCard);
+    restartLayout->setContentsMargins(15, 11, 15, 11);
+    restartLayout->setSpacing(16);
+
+    auto *restartTextLayout = new QVBoxLayout();
+    restartTextLayout->setContentsMargins(0, 0, 0, 0);
+    restartTextLayout->setSpacing(3);
+    auto *restartTitle =
+        new QLabel(tr("Start qEmby after updating"), restartCard);
+    restartTitle->setObjectName(QStringLiteral("UpdateRestartTitle"));
+    auto *restartDescription = new QLabel(
+        tr("Automatically reopen the application after installation completes"),
+        restartCard);
+    restartDescription->setObjectName(
+        QStringLiteral("UpdateRestartDescription"));
+    restartDescription->setWordWrap(true);
+    restartTextLayout->addWidget(restartTitle);
+    restartTextLayout->addWidget(restartDescription);
+    restartLayout->addLayout(restartTextLayout, 1);
+
+    m_restartSwitch = new ModernSwitch(restartCard);
+    m_restartSwitch->setChecked(true);
+    m_restartSwitch->setToolTip(tr("Start qEmby after updating"));
+    restartLayout->addWidget(m_restartSwitch);
+    layout->addWidget(restartCard);
+
+    auto *buttonLayout = new QHBoxLayout();
+    buttonLayout->setSpacing(12);
+    buttonLayout->addStretch();
+
+    m_cancelButton = new QPushButton(tr("Cancel"), this);
+    m_cancelButton->setObjectName(QStringLiteral("dialog-btn-cancel"));
+    m_cancelButton->setCursor(Qt::PointingHandCursor);
+    connect(m_cancelButton, &QPushButton::clicked, this, &QDialog::reject);
+    buttonLayout->addWidget(m_cancelButton);
+
+    m_installButton = new QPushButton(tr("Install Update"), this);
+    m_installButton->setObjectName(QStringLiteral("dialog-btn-primary"));
+    m_installButton->setCursor(Qt::PointingHandCursor);
+    m_installButton->setEnabled(false);
+    connect(m_installButton, &QPushButton::clicked, this,
+            &UpdateProgressDialog::installUpdate);
+    buttonLayout->addWidget(m_installButton);
+    layout->addLayout(buttonLayout);
+
+    auto *manager = WindowsUpdateManager::instance();
+    connect(manager, &WindowsUpdateManager::stageChanged, this,
+            [this](WindowsUpdateManager::Stage stage, const QString &text) {
+                m_statusLabel->setText(text);
+                if (stage != WindowsUpdateManager::Stage::Downloading) {
+                    m_progressBar->setRange(0, 0);
+                }
+            });
+    connect(manager, &WindowsUpdateManager::downloadProgress, this,
+            &UpdateProgressDialog::updateDownloadProgress);
+    connect(manager, &WindowsUpdateManager::readyToInstall, this,
+            [this](const QString &) {
+                m_progressBar->setRange(0, 100);
+                m_progressBar->setValue(100);
+                m_detailLabel->setText(tr("SHA-256 digest verified."));
+                m_installButton->setEnabled(true);
+                m_installButton->setFocus();
+            });
+    connect(manager, &WindowsUpdateManager::failed, this,
+            &UpdateProgressDialog::setFailure);
+    connect(this, &QDialog::finished, this, [this, manager]() {
+        if (!m_installLaunched) {
+            manager->cancel();
+        }
+    });
+
+    QTimer::singleShot(0, manager,
+                       [manager, info]() { manager->startDownload(info); });
+}
+
+void UpdateProgressDialog::startUpdate(const UpdateInfo &info, QWidget *parent)
+{
+#ifdef Q_OS_WIN
+    UpdateProgressDialog dialog(info, parent);
+    dialog.exec();
+#else
+    if (!UpdateManager::instance()->openUpdate(info)) {
+        ModernMessageBox::warning(
+            parent, tr("Update Failed"),
+            tr("The update page could not be opened. Please try again later."));
+    }
+#endif
+}
+
+void UpdateProgressDialog::updateDownloadProgress(qint64 received, qint64 total)
+{
+    if (total > 0) {
+        m_progressBar->setRange(0, 100);
+        m_progressBar->setValue(
+            static_cast<int>((received * 100) / qMax<qint64>(1, total)));
+        m_detailLabel->setText(
+            tr("%1 of %2 (%3%)")
+                .arg(formatBytes(received), formatBytes(total),
+                     QString::number(m_progressBar->value())));
+    } else {
+        m_progressBar->setRange(0, 0);
+        m_detailLabel->setText(tr("Downloaded %1").arg(formatBytes(received)));
+    }
+}
+
+void UpdateProgressDialog::setFailure(const QString &error)
+{
+    m_statusLabel->setText(tr("Update failed"));
+    m_detailLabel->setText(error);
+    m_progressBar->setRange(0, 100);
+    m_progressBar->setValue(0);
+    m_cancelButton->setText(tr("Close"));
+    m_installButton->setEnabled(false);
+    m_restartSwitch->setEnabled(false);
+}
+
+void UpdateProgressDialog::installUpdate()
+{
+    QString error;
+    if (!WindowsUpdateManager::instance()->launchInstaller(
+            m_restartSwitch->isChecked(), &error)) {
+        setFailure(error);
+        return;
+    }
+
+    m_installLaunched = true;
+    m_statusLabel->setText(tr("Starting the Windows installer…"));
+    m_detailLabel->setText(
+        tr("qEmby will close now. Installation progress will be shown by the "
+           "Windows installer."));
+    m_cancelButton->setEnabled(false);
+    m_installButton->setEnabled(false);
+    m_restartSwitch->setEnabled(false);
+    QTimer::singleShot(350, qApp, &QCoreApplication::quit);
+}

--- a/src/qEmbyApp/components/updateprogressdialog.h
+++ b/src/qEmbyApp/components/updateprogressdialog.h
@@ -1,0 +1,37 @@
+#ifndef UPDATEPROGRESSDIALOG_H
+#define UPDATEPROGRESSDIALOG_H
+
+#include "../managers/updatemanager.h"
+#include "moderndialogbase.h"
+
+class QLabel;
+class QProgressBar;
+class QPushButton;
+class ModernSwitch;
+
+class UpdateProgressDialog : public ModernDialogBase
+{
+    Q_OBJECT
+
+public:
+    explicit UpdateProgressDialog(const UpdateInfo &info,
+                                  QWidget *parent = nullptr);
+
+    static void startUpdate(const UpdateInfo &info, QWidget *parent = nullptr);
+
+private:
+    void updateDownloadProgress(qint64 received, qint64 total);
+    void setFailure(const QString &error);
+    void installUpdate();
+
+    UpdateInfo m_info;
+    QLabel *m_statusLabel = nullptr;
+    QLabel *m_detailLabel = nullptr;
+    QProgressBar *m_progressBar = nullptr;
+    ModernSwitch *m_restartSwitch = nullptr;
+    QPushButton *m_cancelButton = nullptr;
+    QPushButton *m_installButton = nullptr;
+    bool m_installLaunched = false;
+};
+
+#endif 

--- a/src/qEmbyApp/main.cpp
+++ b/src/qEmbyApp/main.cpp
@@ -10,6 +10,9 @@
 #include "components/mpvcontroller.h"
 #include "managers/languagemanager.h"
 #include "managers/logmanager.h"
+#include "managers/singleapplicationmanager.h"
+#include "config/config_keys.h"
+#include "config/configstore.h"
 
 #ifdef Q_OS_WIN
 #include <windows.h>
@@ -40,13 +43,22 @@ int main(int argc, char *argv[]) {
   a.setApplicationVersion(APP_VERSION);
   a.setOrganizationName("AlanHJ");
   a.setOrganizationDomain("github.com/AlanHJ/qEmby");
+
+  LogManager::instance()->init();
+
+  SingleApplicationManager singleApplication;
+  const auto singleApplicationResult = singleApplication.start(
+      ConfigStore::instance()->get<bool>(ConfigKeys::SingleApplication, false));
+  if (singleApplicationResult ==
+      SingleApplicationManager::StartResult::SecondaryInstance) {
+    return 0;
+  }
 #if !defined(Q_OS_MACOS) && !defined(Q_OS_MAC)
   QGuiApplication::setDesktopFileName(QStringLiteral("qemby"));
   const QIcon appIcon(QStringLiteral(":/svg/qemby_logo.svg"));
   a.setWindowIcon(appIcon);
 #endif
 
-  LogManager::instance()->init();
   LanguageManager::instance()->init();
 
   
@@ -54,6 +66,15 @@ int main(int argc, char *argv[]) {
   ProxyManager::installApplicationFactory();
 
   MainWindow w;
+  QObject::connect(&singleApplication,
+                   &SingleApplicationManager::activationRequested, &w, [&w]() {
+                     if (w.isMinimized()) {
+                       w.setWindowState(w.windowState() & ~Qt::WindowMinimized);
+                     }
+                     w.show();
+                     w.raise();
+                     w.activateWindow();
+                   });
 #if !defined(Q_OS_MACOS) && !defined(Q_OS_MAC)
   w.setWindowIcon(appIcon);
 #endif

--- a/src/qEmbyApp/mainwindow.cpp
+++ b/src/qEmbyApp/mainwindow.cpp
@@ -8,6 +8,7 @@
 #include "managers/thememanager.h" 
 #include "managers/searchhistorymanager.h"
 #include "managers/traymanager.h"  
+#include "managers/updatemanager.h"
 #include "config/configstore.h"    
 #include "config/config_keys.h"    
 #include "utils/contextmenuutils.h"
@@ -35,6 +36,10 @@
 #include <services/auth/authservice.h>
 #include "components/themetransitionwidget.h"
 #include "components/moderntoast.h" 
+#include "components/modernmessagebox.h"
+#include "components/updatedialog.h"
+#include "components/updateindicatorbutton.h"
+#include "components/updateprogressdialog.h"
 #include <QPropertyAnimation>
 #include <QEasingCurve>
 #include <QFocusEvent>
@@ -89,16 +94,21 @@ MainWindow::MainWindow(QWidget *parent)
     
     m_trayManager = new TrayManager(this);
     connect(m_trayManager, &TrayManager::showMainRequested, this, [this]() {
-        showNormal();
+        
+        
+        
+        show();
+        raise();
         activateWindow();
 
         
-        
-        if (m_wasPausedByTray) {
+        if (m_hadPlayerWhenHiddenToTray) {
+            const bool shouldResumePlaying = m_wasPausedByTray;
+            m_hadPlayerWhenHiddenToTray = false;
             m_wasPausedByTray = false;
-            QTimer::singleShot(500, this, [this]() {
+            QTimer::singleShot(0, this, [this, shouldResumePlaying]() {
                 if (auto *player = m_homeView->activePlayerView()) {
-                    player->resumePlayback();
+                    player->restoreAfterWindowShow(shouldResumePlaying);
                 }
             });
         }
@@ -337,11 +347,26 @@ MainWindow::MainWindow(QWidget *parent)
 
     windowBar->setCenterWidget(centerContainer);
 
+    
+    m_updateButton = new UpdateIndicatorButton(centerContainer);
+    m_updateButton->setObjectName(QStringLiteral("titlebar-update-button"));
+    m_updateButton->setCursor(Qt::PointingHandCursor);
+    m_updateButton->setToolTip(tr("A new qEmby version is available"));
+    m_updateButton->hide();
+    connect(m_updateButton, &UpdateIndicatorButton::clicked, this,
+            &MainWindow::showUpdateConfirmation);
+#if defined(Q_OS_MACOS) || defined(Q_OS_MAC)
+    centerLayout->insertWidget(1, m_updateButton, 0, Qt::AlignVCenter);
+#else
+    centerLayout->insertWidget(0, m_updateButton, 0, Qt::AlignVCenter);
+#endif
+
 
     agent->setTitleBar(windowBar);
 
     agent->setHitTestVisible(themeButton, true);
     agent->setHitTestVisible(m_globalSearchBox, true); 
+    agent->setHitTestVisible(m_updateButton, true);
     agent->setSystemButton(QWK::WindowAgentBase::WindowIcon, iconButton);
 #if !defined(Q_OS_MACOS) && !defined(Q_OS_MAC)
     agent->setSystemButton(QWK::WindowAgentBase::Minimize, minButton);
@@ -358,6 +383,37 @@ MainWindow::MainWindow(QWidget *parent)
 #endif
 
     setMenuWidget(windowBar);
+
+    auto *updateManager = UpdateManager::instance();
+    connect(updateManager, &UpdateManager::updateAvailable, this,
+            [this](const UpdateInfo &info, UpdateManager::CheckMode mode) {
+                if (mode != UpdateManager::CheckMode::Automatic) {
+                    return;
+                }
+                m_availableUpdate = info;
+                m_hasAvailableUpdate = true;
+                m_updateButton->setToolTip(
+                    tr("qEmby %1 is available").arg(info.version));
+                m_updateButton->show();
+            });
+    connect(updateManager, &UpdateManager::updateOpened, this,
+            [this](const QString &) {
+                m_hasAvailableUpdate = false;
+                m_updateButton->hide();
+            });
+    connect(ConfigStore::instance(), &ConfigStore::valueChanged, this,
+            [this](const QString &key, const QVariant &value) {
+                if (key == ConfigKeys::CheckForUpdates && !value.toBool()) {
+                    m_hasAvailableUpdate = false;
+                    m_updateButton->hide();
+                }
+            });
+
+    if (ConfigStore::instance()->get<bool>(ConfigKeys::CheckForUpdates, true)) {
+        QTimer::singleShot(1500, updateManager, [updateManager]() {
+            updateManager->checkForUpdates(UpdateManager::CheckMode::Automatic);
+        });
+    }
 
     
     m_viewStack = new QStackedWidget(this);
@@ -711,6 +767,39 @@ MainWindow::MainWindow(QWidget *parent)
                     hideGlobalSearchTransientUi();
                 }
             });
+}
+
+void MainWindow::showUpdateConfirmation()
+{
+    if (!m_hasAvailableUpdate) {
+        return;
+    }
+
+    UpdateDialog dialog(m_availableUpdate, UpdateDialog::Mode::Automatic, this);
+    dialog.exec();
+    if (dialog.decision() == UpdateDialog::Decision::Update) {
+        UpdateProgressDialog::startUpdate(m_availableUpdate, this);
+        return;
+    }
+
+    if (dialog.decision() == UpdateDialog::Decision::RemindLater) {
+        qInfo() << "MainWindow: update reminder dismissed for this session"
+                << "| version=" << m_availableUpdate.version;
+        m_hasAvailableUpdate = false;
+        m_updateButton->hide();
+        return;
+    }
+
+    if (dialog.decision() != UpdateDialog::Decision::IgnoreVersion) {
+        return;
+    }
+
+    ConfigStore::instance()->set(ConfigKeys::IgnoredUpdateVersion,
+                                 m_availableUpdate.version);
+    qInfo() << "MainWindow: update ignored"
+            << "| version=" << m_availableUpdate.version;
+    m_hasAvailableUpdate = false;
+    m_updateButton->hide();
 }
 
 MainWindow::~MainWindow() {}
@@ -1254,7 +1343,10 @@ void MainWindow::closeEvent(QCloseEvent *event)
     
     if (!m_realQuit && useTray && QSystemTrayIcon::isSystemTrayAvailable()) {
         
+        m_hadPlayerWhenHiddenToTray = false;
+        m_wasPausedByTray = false;
         if (auto *player = m_homeView->activePlayerView()) {
+            m_hadPlayerWhenHiddenToTray = true;
             if (player->isMediaPlaying()) {
                 player->pausePlayback();
                 m_wasPausedByTray = true;

--- a/src/qEmbyApp/mainwindow.h
+++ b/src/qEmbyApp/mainwindow.h
@@ -1,9 +1,10 @@
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 
-#include <QMainWindow>
-#include <QElapsedTimer> 
 #include <QCloseEvent>   
+#include <QElapsedTimer> 
+#include <QMainWindow>
+#include "managers/updatemanager.h"
 
 class QEmbyCore;
 class LoginView;
@@ -12,51 +13,57 @@ class QStackedWidget;
 class QLineEdit;
 class QCompleter;
 class QStringListModel;
-class TrayManager;       
+class TrayManager; 
 class SearchHistoryPopup;
+class UpdateIndicatorButton;
 
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
 
-public:
-    MainWindow(QWidget *parent = nullptr);
-    ~MainWindow();
+    public:
+        MainWindow(QWidget *parent = nullptr);
+        ~MainWindow();
 
-public Q_SLOTS:
-    void navigateToHome();
-    void navigateToLogin();
+    public Q_SLOTS:
+        void navigateToHome();
+        void navigateToLogin();
 
-protected:
-    bool eventFilter(QObject *watched, QEvent *event) override;
-    void closeEvent(QCloseEvent *event) override; 
+    protected:
+        bool eventFilter(QObject * watched, QEvent * event) override;
+        void closeEvent(QCloseEvent * event) override; 
 
-private:
-    void setupGlobalSearchHistory();
-    void hideGlobalSearchTransientUi();
-    void updateGlobalSearchCompleter(const QString &text = QString());
-    void showGlobalSearchHistoryPopup(const QString &filterText = QString());
-    void submitGlobalSearch(const QString &query);
-    QString currentSearchServerId() const;
+    private:
+        void setupGlobalSearchHistory();
+        void hideGlobalSearchTransientUi();
+        void updateGlobalSearchCompleter(const QString &text = QString());
+        void showGlobalSearchHistoryPopup(const QString &filterText = QString());
+        void submitGlobalSearch(const QString &query);
+        QString currentSearchServerId() const;
+        void showUpdateConfirmation();
 
-    QEmbyCore *m_core;
-    QStackedWidget *m_viewStack;
-    LoginView *m_loginView;
-    HomeView *m_homeView;
-    QLineEdit *m_globalSearchBox;
-    QCompleter *m_globalSearchCompleter = nullptr;
-    QStringListModel *m_globalSearchModel = nullptr;
-    SearchHistoryPopup *m_globalSearchHistoryPopup = nullptr;
-    TrayManager *m_trayManager = nullptr; 
+        QEmbyCore *m_core;
+        QStackedWidget *m_viewStack;
+        LoginView *m_loginView;
+        HomeView *m_homeView;
+        QLineEdit *m_globalSearchBox;
+        QCompleter *m_globalSearchCompleter = nullptr;
+        QStringListModel *m_globalSearchModel = nullptr;
+        SearchHistoryPopup *m_globalSearchHistoryPopup = nullptr;
+        UpdateIndicatorButton *m_updateButton = nullptr;
+        UpdateInfo m_availableUpdate;
+        bool m_hasAvailableUpdate = false;
+        TrayManager *m_trayManager = nullptr; 
 
-    
-    QElapsedTimer m_backClickTimer;
+        
+        QElapsedTimer m_backClickTimer;
 
-    quint32 m_defaultWidth{450};
-    quint32 m_defaultHeight{320};
-    bool m_realQuit{false}; 
-    bool m_themeAnimating{false}; 
-    bool m_wasPausedByTray{false}; 
+        quint32 m_defaultWidth{450};
+        quint32 m_defaultHeight{320};
+        bool m_realQuit{false};        
+        bool m_themeAnimating{false};  
+        bool m_wasPausedByTray{false}; 
+        bool m_hadPlayerWhenHiddenToTray{false};
 };
 
 #endif 

--- a/src/qEmbyApp/managers/downloadmanager.cpp
+++ b/src/qEmbyApp/managers/downloadmanager.cpp
@@ -145,13 +145,16 @@ QString buildSuggestedFileName(const MediaItem& item,
     return ensureFileExtension(baseName, extension);
 }
 
-int resolvePreferredMediaSourceIndex(const QList<MediaSourceInfo>& mediaSources)
+int resolvePreferredMediaSourceIndex(const QList<MediaSourceInfo>& mediaSources,
+                                     const QString& serverId,
+                                     const QString& mediaId)
 {
     return MediaSourcePreferenceUtils::resolvePreferredMediaSourceIndex(
         mediaSources,
         ConfigStore::instance()
             ->get<QString>(ConfigKeys::PlayerPreferredVersion)
-            .trimmed());
+            .trimmed(),
+        MediaSourcePreferenceUtils::rememberedMediaSourceId(serverId, mediaId));
 }
 
 bool recordMatchesProfile(const DownloadManager::DownloadRecord& record,
@@ -1081,7 +1084,8 @@ QCoro::Task<void> DownloadManager::startDownload(
         }
     } else {
         const int sourceIndex =
-            resolvePreferredMediaSourceIndex(detail.mediaSources);
+            resolvePreferredMediaSourceIndex(detail.mediaSources, profile.id,
+                                             detail.id);
         selectedSource =
             (sourceIndex >= 0 && sourceIndex < detail.mediaSources.size())
                 ? &detail.mediaSources.at(sourceIndex)

--- a/src/qEmbyApp/managers/playbackmanager.cpp
+++ b/src/qEmbyApp/managers/playbackmanager.cpp
@@ -385,6 +385,20 @@ void PlaybackManager::launchExternalPlayer(const QString& mediaId, const QString
                                                   "auto"));
     }
 
+    if (hasSourceInfo && m_core->serverManager()) {
+        const PlayerPreferenceUtils::RememberedStreamSelection remembered =
+            PlayerPreferenceUtils::validatedRememberedStreamSelection(
+                m_core->serverManager()->activeProfile().id, mediaId,
+                sourceInfo);
+        if (remembered.audioIndex.has_value()) {
+            selectedAudioIdx = *remembered.audioIndex;
+        }
+        if (remembered.subtitleIndex.has_value()) {
+            selectedSubIdx = *remembered.subtitleIndex;
+            subtitleDisabled = *remembered.subtitleIndex < 0;
+        }
+    }
+
     
     QStringList args;
     

--- a/src/qEmbyApp/managers/singleapplicationmanager.cpp
+++ b/src/qEmbyApp/managers/singleapplicationmanager.cpp
@@ -1,0 +1,85 @@
+#include "singleapplicationmanager.h"
+
+#include "config/configstore.h"
+#include <QCoreApplication>
+#include <QCryptographicHash>
+#include <QDebug>
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QLockFile>
+
+namespace {
+constexpr int kConnectTimeoutMs = 300;
+}
+
+SingleApplicationManager::SingleApplicationManager(QObject *parent)
+    : QObject(parent) {}
+
+SingleApplicationManager::~SingleApplicationManager() = default;
+
+SingleApplicationManager::StartResult
+SingleApplicationManager::start(bool enabled) {
+  if (!enabled) {
+    qInfo() << "SingleApplication: disabled by configuration";
+    return StartResult::Disabled;
+  }
+
+  const QString name = serverName();
+  m_lockFile = std::make_unique<QLockFile>(ConfigStore::instance()->filePath() +
+                                           QStringLiteral(".instance.lock"));
+  m_lockFile->setStaleLockTime(0);
+  if (!m_lockFile->tryLock()) {
+    const bool notified = notifyRunningInstance();
+    qInfo() << "SingleApplication: another instance owns the lock"
+            << "| activation notified:" << notified;
+    return StartResult::SecondaryInstance;
+  }
+
+  
+  QLocalServer::removeServer(name);
+  m_server = new QLocalServer(this);
+  if (!m_server->listen(name)) {
+    qWarning() << "SingleApplication: failed to listen" << name
+               << "| error:" << m_server->errorString();
+    m_lockFile->unlock();
+    m_lockFile.reset();
+    return StartResult::Disabled;
+  }
+
+  connect(m_server, &QLocalServer::newConnection, this, [this]() {
+    while (QLocalSocket *socket = m_server->nextPendingConnection()) {
+      socket->readAll();
+      socket->disconnectFromServer();
+      socket->deleteLater();
+    }
+    qInfo() << "SingleApplication: activation requested by another launch";
+    emit activationRequested();
+  });
+
+  qInfo() << "SingleApplication: primary instance is listening";
+  return StartResult::PrimaryInstance;
+}
+
+bool SingleApplicationManager::notifyRunningInstance() const {
+  QLocalSocket socket;
+  socket.connectToServer(serverName(), QIODevice::WriteOnly);
+  if (!socket.waitForConnected(kConnectTimeoutMs)) {
+    return false;
+  }
+
+  socket.write("activate");
+  socket.flush();
+  socket.waitForBytesWritten(kConnectTimeoutMs);
+  socket.disconnectFromServer();
+  return true;
+}
+
+QString SingleApplicationManager::serverName() const {
+  const QByteArray identity =
+      QCoreApplication::organizationName().toUtf8() + '/' +
+      QCoreApplication::applicationName().toUtf8() + '/' +
+      ConfigStore::instance()->filePath().toUtf8();
+  const QByteArray suffix =
+      QCryptographicHash::hash(identity, QCryptographicHash::Sha256).toHex().left(16);
+  return QStringLiteral("qemby-%1").arg(QString::fromLatin1(suffix));
+}

--- a/src/qEmbyApp/managers/singleapplicationmanager.h
+++ b/src/qEmbyApp/managers/singleapplicationmanager.h
@@ -1,0 +1,31 @@
+#ifndef SINGLEAPPLICATIONMANAGER_H
+#define SINGLEAPPLICATIONMANAGER_H
+
+#include <QObject>
+#include <memory>
+
+class QLocalServer;
+class QLockFile;
+
+class SingleApplicationManager : public QObject {
+  Q_OBJECT
+
+public:
+  enum class StartResult { Disabled, PrimaryInstance, SecondaryInstance };
+
+  explicit SingleApplicationManager(QObject *parent = nullptr);
+  ~SingleApplicationManager() override;
+  StartResult start(bool enabled);
+
+signals:
+  void activationRequested();
+
+private:
+  bool notifyRunningInstance() const;
+  QString serverName() const;
+
+  QLocalServer *m_server = nullptr;
+  std::unique_ptr<QLockFile> m_lockFile;
+};
+
+#endif 

--- a/src/qEmbyApp/managers/updatemanager.cpp
+++ b/src/qEmbyApp/managers/updatemanager.cpp
@@ -1,0 +1,235 @@
+#include "updatemanager.h"
+
+#include "config/config_keys.h"
+#include "config/configstore.h"
+#include <QCoreApplication>
+#include <QDesktopServices>
+#include <QDebug>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QRegularExpression>
+#include <QStringList>
+#include <QVersionNumber>
+
+namespace {
+
+const QUrl kLatestReleaseApi(
+    QStringLiteral("https://api.github.com/repos/AlanHJ/qEmby/releases/latest"));
+
+QString normalizedVersion(QString version)
+{
+    version = version.trimmed();
+    if (version.startsWith(QLatin1Char('v'), Qt::CaseInsensitive)) {
+        version.remove(0, 1);
+    }
+    const qsizetype suffixPos = version.indexOf(QRegularExpression(QStringLiteral("[-+]")));
+    return suffixPos >= 0 ? version.left(suffixPos) : version;
+}
+
+struct SelectedReleaseAsset {
+    QUrl url;
+    QString name;
+    QString sha256Digest;
+    qint64 size = 0;
+};
+
+SelectedReleaseAsset platformReleaseAsset(const QJsonArray &assets)
+{
+#if defined(Q_OS_WIN)
+    const QStringList preferredExtensions = {QStringLiteral(".exe"),
+                                              QStringLiteral(".msi")};
+#elif defined(Q_OS_MACOS) || defined(Q_OS_MAC)
+    const QStringList preferredExtensions = {QStringLiteral(".dmg"),
+                                              QStringLiteral(".pkg")};
+#else
+    const QStringList preferredExtensions = {QStringLiteral(".appimage"),
+                                              QStringLiteral(".deb"),
+                                              QStringLiteral(".rpm")};
+#endif
+
+    for (const QString &extension : preferredExtensions) {
+        for (const QJsonValue &value : assets) {
+            const QJsonObject asset = value.toObject();
+            const QString name = asset.value(QStringLiteral("name")).toString();
+            if (!name.endsWith(extension, Qt::CaseInsensitive)) {
+                continue;
+            }
+            const QUrl url(asset.value(QStringLiteral("browser_download_url")).toString());
+            if (url.isValid() && url.scheme() == QStringLiteral("https")) {
+                QString digest =
+                    asset.value(QStringLiteral("digest")).toString().trimmed();
+                if (digest.startsWith(QStringLiteral("sha256:"),
+                                      Qt::CaseInsensitive)) {
+                    digest.remove(0, 7);
+                }
+                return {url, name, digest.toLower(),
+                        asset.value(QStringLiteral("size")).toInteger()};
+            }
+        }
+    }
+    return {};
+}
+
+} 
+
+UpdateManager *UpdateManager::instance()
+{
+    static auto *manager = new UpdateManager(QCoreApplication::instance());
+    return manager;
+}
+
+UpdateManager::UpdateManager(QObject *parent)
+    : QObject(parent), m_networkManager(new QNetworkAccessManager(this))
+{
+}
+
+bool UpdateManager::isChecking(CheckMode mode) const
+{
+    return mode == CheckMode::Automatic ? m_automaticCheckInProgress
+                                        : m_manualCheckInProgress;
+}
+
+void UpdateManager::checkForUpdates(CheckMode mode)
+{
+    bool &inProgress = mode == CheckMode::Automatic
+                           ? m_automaticCheckInProgress
+                           : m_manualCheckInProgress;
+    if (inProgress) {
+        qInfo() << "UpdateManager: check already in progress"
+                << "| mode="
+                << (mode == CheckMode::Automatic ? "automatic" : "manual");
+        return;
+    }
+
+    inProgress = true;
+    qInfo() << "UpdateManager: checking GitHub release"
+            << "| mode=" << (mode == CheckMode::Automatic ? "automatic" : "manual")
+            << "| currentVersion=" << QCoreApplication::applicationVersion();
+
+    QNetworkRequest request(kLatestReleaseApi);
+    request.setHeader(QNetworkRequest::UserAgentHeader,
+                      QStringLiteral("qEmby/%1")
+                          .arg(QCoreApplication::applicationVersion()));
+    request.setRawHeader("Accept", "application/vnd.github+json");
+    request.setRawHeader("X-GitHub-Api-Version", "2026-03-10");
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                         QNetworkRequest::NoLessSafeRedirectPolicy);
+
+    QNetworkReply *reply = m_networkManager->get(request);
+    connect(reply, &QNetworkReply::finished, this,
+            [this, reply, mode]() { handleReply(reply, mode); });
+}
+
+void UpdateManager::handleReply(QNetworkReply *reply, CheckMode mode)
+{
+    if (mode == CheckMode::Automatic) {
+        m_automaticCheckInProgress = false;
+    } else {
+        m_manualCheckInProgress = false;
+    }
+    const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    const QByteArray payload = reply->readAll();
+    const QNetworkReply::NetworkError networkError = reply->error();
+    const QString networkErrorText = reply->errorString();
+    reply->deleteLater();
+
+    
+    if (status == 404) {
+        qInfo() << "UpdateManager: repository has no published release";
+        Q_EMIT noUpdateAvailable(mode);
+        return;
+    }
+    if (networkError != QNetworkReply::NoError) {
+        qWarning() << "UpdateManager: release request failed"
+                   << "| status=" << status << "| error=" << networkErrorText;
+        Q_EMIT checkFailed(tr("Could not connect to GitHub: %1").arg(networkErrorText),
+                           mode);
+        return;
+    }
+
+    QJsonParseError parseError;
+    const QJsonDocument document = QJsonDocument::fromJson(payload, &parseError);
+    if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+        qWarning() << "UpdateManager: invalid GitHub response"
+                   << "| parseError=" << parseError.errorString();
+        Q_EMIT checkFailed(tr("GitHub returned invalid update information."), mode);
+        return;
+    }
+
+    const QJsonObject release = document.object();
+    const QString tag = release.value(QStringLiteral("tag_name")).toString();
+    const QString remoteVersionText = normalizedVersion(tag);
+    const QString localVersionText =
+        normalizedVersion(QCoreApplication::applicationVersion());
+    const QVersionNumber remoteVersion = QVersionNumber::fromString(remoteVersionText);
+    const QVersionNumber localVersion = QVersionNumber::fromString(localVersionText);
+    if (remoteVersion.isNull() || localVersion.isNull()) {
+        qWarning() << "UpdateManager: invalid version"
+                   << "| local=" << localVersionText << "| remote=" << tag;
+        Q_EMIT checkFailed(tr("The release contains an invalid version number: %1")
+                               .arg(tag),
+                           mode);
+        return;
+    }
+
+    qInfo() << "UpdateManager: release response parsed"
+            << "| local=" << localVersionText << "| remote=" << remoteVersionText
+            << "| assets=" << release.value(QStringLiteral("assets")).toArray().size();
+    if (QVersionNumber::compare(remoteVersion, localVersion) <= 0) {
+        Q_EMIT noUpdateAvailable(mode);
+        return;
+    }
+
+    UpdateInfo info;
+    info.version = tag.trimmed().isEmpty() ? remoteVersionText : tag.trimmed();
+    info.name = release.value(QStringLiteral("name")).toString().trimmed();
+    info.releaseNotes = release.value(QStringLiteral("body")).toString().trimmed();
+    info.publishedAt = QDateTime::fromString(
+        release.value(QStringLiteral("published_at")).toString(), Qt::ISODate);
+    info.releaseUrl = QUrl(release.value(QStringLiteral("html_url")).toString());
+    const SelectedReleaseAsset selectedAsset = platformReleaseAsset(
+        release.value(QStringLiteral("assets")).toArray());
+    info.downloadUrl = selectedAsset.url;
+    info.assetName = selectedAsset.name;
+    info.sha256Digest = selectedAsset.sha256Digest;
+    info.assetSize = selectedAsset.size;
+
+    const QString ignoredVersion = ConfigStore::instance()->get<QString>(
+        ConfigKeys::IgnoredUpdateVersion, QString());
+    if (mode == CheckMode::Automatic && ignoredVersion == info.version) {
+        qInfo() << "UpdateManager: release ignored by user"
+                << "| version=" << info.version;
+        return;
+    }
+    if (mode == CheckMode::Automatic && m_openedVersion == info.version) {
+        qInfo() << "UpdateManager: release already opened this session"
+                << "| version=" << info.version;
+        return;
+    }
+
+    Q_EMIT updateAvailable(info, mode);
+}
+
+bool UpdateManager::openUpdate(const UpdateInfo &info)
+{
+    const QUrl target = info.downloadUrl.isValid() ? info.downloadUrl
+                                                    : info.releaseUrl;
+    if (!target.isValid() || target.scheme() != QStringLiteral("https")) {
+        qWarning() << "UpdateManager: refusing invalid update URL" << target;
+        return false;
+    }
+
+    qInfo() << "UpdateManager: opening update"
+            << "| version=" << info.version
+            << "| directAsset=" << info.downloadUrl.isValid();
+    const bool opened = QDesktopServices::openUrl(target);
+    if (opened) {
+        m_openedVersion = info.version;
+        Q_EMIT updateOpened(info.version);
+    }
+    return opened;
+}

--- a/src/qEmbyApp/managers/updatemanager.h
+++ b/src/qEmbyApp/managers/updatemanager.h
@@ -1,0 +1,56 @@
+#ifndef UPDATEMANAGER_H
+#define UPDATEMANAGER_H
+
+#include <QDateTime>
+#include <QMetaType>
+#include <QObject>
+#include <QString>
+#include <QUrl>
+
+class QNetworkAccessManager;
+class QNetworkReply;
+
+struct UpdateInfo {
+    QString version;
+    QString name;
+    QString releaseNotes;
+    QDateTime publishedAt;
+    QUrl releaseUrl;
+    QUrl downloadUrl;
+    QString assetName;
+    QString sha256Digest;
+    qint64 assetSize = 0;
+};
+Q_DECLARE_METATYPE(UpdateInfo)
+
+class UpdateManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum class CheckMode { Automatic, Manual };
+    Q_ENUM(CheckMode)
+
+    static UpdateManager *instance();
+
+    void checkForUpdates(CheckMode mode);
+    bool openUpdate(const UpdateInfo &info);
+    bool isChecking(CheckMode mode) const;
+
+Q_SIGNALS:
+    void updateAvailable(const UpdateInfo &info, UpdateManager::CheckMode mode);
+    void noUpdateAvailable(UpdateManager::CheckMode mode);
+    void checkFailed(const QString &error, UpdateManager::CheckMode mode);
+    void updateOpened(const QString &version);
+
+private:
+    explicit UpdateManager(QObject *parent = nullptr);
+    void handleReply(QNetworkReply *reply, CheckMode mode);
+
+    QNetworkAccessManager *m_networkManager = nullptr;
+    bool m_automaticCheckInProgress = false;
+    bool m_manualCheckInProgress = false;
+    QString m_openedVersion;
+};
+
+#endif 

--- a/src/qEmbyApp/managers/windowsupdatemanager.cpp
+++ b/src/qEmbyApp/managers/windowsupdatemanager.cpp
@@ -1,0 +1,267 @@
+#include "windowsupdatemanager.h"
+
+#include <QCoreApplication>
+#include <QCryptographicHash>
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QProcess>
+#include <QSaveFile>
+#include <QStandardPaths>
+
+WindowsUpdateManager *WindowsUpdateManager::instance()
+{
+    static auto *manager =
+        new WindowsUpdateManager(QCoreApplication::instance());
+    return manager;
+}
+
+WindowsUpdateManager::WindowsUpdateManager(QObject *parent)
+    : QObject(parent), m_networkManager(new QNetworkAccessManager(this))
+{
+}
+
+bool WindowsUpdateManager::isBusy() const
+{
+    return m_reply != nullptr;
+}
+
+void WindowsUpdateManager::startDownload(const UpdateInfo &info)
+{
+    cancel();
+    m_cancelled = false;
+    m_verifiedInstallerPath.clear();
+
+    if (!info.downloadUrl.isValid() ||
+        info.downloadUrl.scheme() != QStringLiteral("https") ||
+        !info.assetName.endsWith(QStringLiteral(".exe"), Qt::CaseInsensitive)) {
+        fail(tr("No compatible Windows installer is available for this release."));
+        return;
+    }
+    if (info.sha256Digest.size() != 64) {
+        fail(tr("The release does not provide a valid SHA-256 digest."));
+        return;
+    }
+
+    const QString updateDirectory =
+        QStandardPaths::writableLocation(QStandardPaths::TempLocation) +
+        QStringLiteral("/qEmby-updates/") + info.version;
+    if (!QDir().mkpath(updateDirectory)) {
+        fail(tr("Could not create the temporary update directory."));
+        return;
+    }
+
+    const QString safeFileName = QFileInfo(info.assetName).fileName();
+    if (safeFileName.isEmpty()) {
+        fail(tr("The Windows installer has an invalid file name."));
+        return;
+    }
+    m_targetPath = QDir(updateDirectory).filePath(safeFileName);
+    m_expectedDigest = info.sha256Digest.toLower();
+    QFile::remove(m_targetPath);
+
+    m_outputFile = new QSaveFile(m_targetPath, this);
+    if (!m_outputFile->open(QIODevice::WriteOnly)) {
+        fail(tr("Could not open the temporary update file for writing."));
+        return;
+    }
+    m_hash = new QCryptographicHash(QCryptographicHash::Sha256);
+
+    qInfo() << "WindowsUpdateManager: starting download"
+            << "| version=" << info.version << "| asset=" << safeFileName
+            << "| expectedBytes=" << info.assetSize;
+
+    QNetworkRequest request(info.downloadUrl);
+    request.setHeader(QNetworkRequest::UserAgentHeader,
+                      QStringLiteral("qEmby/%1")
+                          .arg(QCoreApplication::applicationVersion()));
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                         QNetworkRequest::NoLessSafeRedirectPolicy);
+    m_reply = m_networkManager->get(request);
+
+    Q_EMIT stageChanged(Stage::Downloading, tr("Downloading update…"));
+    connect(m_reply, &QNetworkReply::downloadProgress, this,
+            &WindowsUpdateManager::downloadProgress);
+    connect(m_reply, &QIODevice::readyRead, this, [this]() {
+        if (!m_reply || !m_outputFile || !m_hash) {
+            return;
+        }
+        const QByteArray data = m_reply->readAll();
+        if (m_outputFile->write(data) != data.size()) {
+            fail(tr("Failed to write the downloaded update to disk."));
+            return;
+        }
+        m_hash->addData(data);
+    });
+    connect(m_reply, &QNetworkReply::finished, this,
+            &WindowsUpdateManager::finishDownload);
+}
+
+void WindowsUpdateManager::cancel()
+{
+    const bool hadWork = m_reply || m_outputFile || m_hash ||
+                         !m_verifiedInstallerPath.isEmpty();
+    m_cancelled = true;
+    if (m_reply) {
+        disconnect(m_reply, nullptr, this, nullptr);
+        m_reply->abort();
+        m_reply->deleteLater();
+        m_reply = nullptr;
+    }
+    if (m_outputFile) {
+        m_outputFile->cancelWriting();
+        delete m_outputFile;
+        m_outputFile = nullptr;
+    }
+    delete m_hash;
+    m_hash = nullptr;
+    if (!m_targetPath.isEmpty()) {
+        QFile::remove(m_targetPath);
+    }
+    m_verifiedInstallerPath.clear();
+    if (hadWork) {
+        Q_EMIT cancelled();
+    }
+}
+
+void WindowsUpdateManager::finishDownload()
+{
+    if (!m_reply) {
+        return;
+    }
+    QNetworkReply *reply = m_reply;
+    m_reply = nullptr;
+    const QNetworkReply::NetworkError networkError = reply->error();
+    const QString networkErrorText = reply->errorString();
+    const int status =
+        reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    reply->deleteLater();
+
+    if (m_cancelled) {
+        return;
+    }
+    if (networkError != QNetworkReply::NoError || status < 200 || status >= 300) {
+        fail(tr("Update download failed: %1").arg(networkErrorText));
+        return;
+    }
+    if (m_outputFile && m_hash) {
+        const QByteArray remainingData = reply->readAll();
+        if (!remainingData.isEmpty()) {
+            if (m_outputFile->write(remainingData) != remainingData.size()) {
+                fail(tr("Failed to write the downloaded update to disk."));
+                return;
+            }
+            m_hash->addData(remainingData);
+        }
+    }
+    if (!m_outputFile || !m_hash || !m_outputFile->commit()) {
+        fail(tr("Could not finalize the downloaded update file."));
+        return;
+    }
+    delete m_outputFile;
+    m_outputFile = nullptr;
+
+    Q_EMIT stageChanged(Stage::VerifyingDigest,
+                        tr("Verifying SHA-256 digest…"));
+    const QString actualDigest = QString::fromLatin1(m_hash->result().toHex());
+    delete m_hash;
+    m_hash = nullptr;
+    if (actualDigest.compare(m_expectedDigest, Qt::CaseInsensitive) != 0) {
+        qWarning() << "WindowsUpdateManager: SHA-256 verification failed"
+                   << "| asset=" << QFileInfo(m_targetPath).fileName();
+        QFile::remove(m_targetPath);
+        fail(tr("SHA-256 verification failed. The downloaded file may be corrupted."));
+        return;
+    }
+
+    m_verifiedInstallerPath = m_targetPath;
+    qInfo() << "WindowsUpdateManager: installer SHA-256 verified"
+            << "| asset=" << QFileInfo(m_targetPath).fileName();
+    Q_EMIT stageChanged(Stage::Ready, tr("Update verified and ready to install."));
+    Q_EMIT readyToInstall(m_verifiedInstallerPath);
+}
+
+void WindowsUpdateManager::fail(const QString &error)
+{
+    if (m_reply) {
+        disconnect(m_reply, nullptr, this, nullptr);
+        m_reply->abort();
+        m_reply->deleteLater();
+        m_reply = nullptr;
+    }
+    if (m_outputFile) {
+        m_outputFile->cancelWriting();
+        delete m_outputFile;
+        m_outputFile = nullptr;
+    }
+    delete m_hash;
+    m_hash = nullptr;
+    m_verifiedInstallerPath.clear();
+    Q_EMIT failed(error);
+}
+
+bool WindowsUpdateManager::launchInstaller(bool restartAfterUpdate,
+                                            QString *errorMessage)
+{
+#ifdef Q_OS_WIN
+    if (m_verifiedInstallerPath.isEmpty() ||
+        !QFileInfo::exists(m_verifiedInstallerPath)) {
+        if (errorMessage) {
+            *errorMessage = tr("The verified installer is no longer available.");
+        }
+        return false;
+    }
+
+    auto powerShellQuote = [](QString value) {
+        value.replace(QLatin1Char('\''), QStringLiteral("''"));
+        return QString(QLatin1Char('\'')) + value + QLatin1Char('\'');
+    };
+
+    
+    
+    QString script =
+        QStringLiteral("$ErrorActionPreference='Stop';"
+                       "Wait-Process -Id %1 -ErrorAction SilentlyContinue;"
+                       "$p=Start-Process -FilePath %2 "
+                       "-ArgumentList @('/SILENT','/SUPPRESSMSGBOXES','/NORESTART') "
+                       "-Wait -PassThru;")
+            .arg(QCoreApplication::applicationPid())
+            .arg(powerShellQuote(m_verifiedInstallerPath));
+    if (restartAfterUpdate) {
+        script += QStringLiteral("if($p.ExitCode -eq 0){Start-Process -FilePath %1;}")
+                      .arg(powerShellQuote(
+                          QCoreApplication::applicationFilePath()));
+    }
+    const QByteArray encodedCommand =
+        QByteArray(reinterpret_cast<const char *>(script.utf16()),
+                   script.size() * static_cast<int>(sizeof(char16_t)))
+            .toBase64();
+    const QStringList powerShellArguments = {
+        QStringLiteral("-NoProfile"), QStringLiteral("-NonInteractive"),
+        QStringLiteral("-WindowStyle"), QStringLiteral("Hidden"),
+        QStringLiteral("-EncodedCommand"),
+        QString::fromLatin1(encodedCommand)};
+    if (!QProcess::startDetached(QStringLiteral("powershell.exe"),
+                                 powerShellArguments,
+                                 QCoreApplication::applicationDirPath())) {
+        if (errorMessage) {
+            *errorMessage =
+                tr("Could not start the Windows update helper.");
+        }
+        return false;
+    }
+    qInfo() << "WindowsUpdateManager: update helper started"
+            << "| restartAfterUpdate=" << restartAfterUpdate;
+    return true;
+#else
+    Q_UNUSED(restartAfterUpdate);
+    if (errorMessage) {
+        *errorMessage = tr("In-app installation is only available on Windows.");
+    }
+    return false;
+#endif
+}

--- a/src/qEmbyApp/managers/windowsupdatemanager.h
+++ b/src/qEmbyApp/managers/windowsupdatemanager.h
@@ -1,0 +1,48 @@
+#ifndef WINDOWSUPDATEMANAGER_H
+#define WINDOWSUPDATEMANAGER_H
+
+#include "updatemanager.h"
+#include <QObject>
+
+class QCryptographicHash;
+class QNetworkAccessManager;
+class QNetworkReply;
+class QSaveFile;
+
+class WindowsUpdateManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum class Stage { Downloading, VerifyingDigest, Ready };
+    Q_ENUM(Stage)
+
+    static WindowsUpdateManager *instance();
+
+    void startDownload(const UpdateInfo &info);
+    void cancel();
+    bool launchInstaller(bool restartAfterUpdate, QString *errorMessage = nullptr);
+    bool isBusy() const;
+
+Q_SIGNALS:
+    void stageChanged(WindowsUpdateManager::Stage stage, const QString &text);
+    void downloadProgress(qint64 received, qint64 total);
+    void readyToInstall(const QString &installerPath);
+    void failed(const QString &error);
+    void cancelled();
+
+private:
+    explicit WindowsUpdateManager(QObject *parent = nullptr);
+    void finishDownload();
+    void fail(const QString &error);
+    QNetworkAccessManager *m_networkManager = nullptr;
+    QNetworkReply *m_reply = nullptr;
+    QSaveFile *m_outputFile = nullptr;
+    QCryptographicHash *m_hash = nullptr;
+    QString m_expectedDigest;
+    QString m_targetPath;
+    QString m_verifiedInstallerPath;
+    bool m_cancelled = false;
+};
+
+#endif 

--- a/src/qEmbyApp/resources/i18n/qEmby_fr_FR.ts
+++ b/src/qEmbyApp/resources/i18n/qEmby_fr_FR.ts
@@ -8410,4 +8410,16 @@ Adresse: %2</translation>
     </message>
 </context>
 
+<context>
+    <name>TrayManager</name>
+    <message>
+        <source>Show qEmby</source>
+        <translation>Afficher qEmby</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation>Quitter</translation>
+    </message>
+</context>
+
 </TS>

--- a/src/qEmbyApp/resources/i18n/qEmby_zh_CN.ts
+++ b/src/qEmbyApp/resources/i18n/qEmby_zh_CN.ts
@@ -24,6 +24,54 @@
         <source>Search</source>
         <translation>搜索</translation>
     </message>
+    <message>
+        <source>A new qEmby version is available</source>
+        <translation>发现新的 qEmby 版本</translation>
+    </message>
+    <message>
+        <source>qEmby %1 is available</source>
+        <translation>qEmby %1 已可用</translation>
+    </message>
+    <message>
+        <source>qEmby Update</source>
+        <translation>qEmby 更新</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation>立即升级</translation>
+    </message>
+    <message>
+        <source>No release notes were provided.</source>
+        <translation>此版本未提供更新说明。</translation>
+    </message>
+    <message>
+        <source>… Open the release page to read more.</source>
+        <translation>… 打开发布页面查看更多内容。</translation>
+    </message>
+    <message>
+        <source>A new version of qEmby is available.
+
+Current version: %1
+New version: %2
+
+Release notes:
+%3</source>
+        <translation>发现新的 qEmby 版本。
+
+当前版本：%1
+新版本：%2
+
+更新说明：
+%3</translation>
+    </message>
+    <message>
+        <source>Update Failed</source>
+        <translation>升级失败</translation>
+    </message>
+    <message>
+        <source>The update page could not be opened. Please try again later.</source>
+        <translation>无法打开升级页面，请稍后重试。</translation>
+    </message>
 </context>
 
 <context>
@@ -2019,6 +2067,22 @@ Choose a file, paste an image URL, or drag one onto the preview.</source>
         <translation>最小化到系统托盘而非退出应用</translation>
     </message>
     <message>
+        <source>Single Application Mode</source>
+        <translation>单例应用模式</translation>
+    </message>
+    <message>
+        <source>Check for Updates</source>
+        <translation>检查更新</translation>
+    </message>
+    <message>
+        <source>Automatically check GitHub for a new qEmby version on startup</source>
+        <translation>每次启动时自动从 GitHub 检查新的 qEmby 版本</translation>
+    </message>
+    <message>
+        <source>Allow only one qEmby instance and activate it when launched again (requires restart)</source>
+        <translation>仅允许一个 qEmby 实例运行，再次启动时激活现有窗口（需要重启生效）</translation>
+    </message>
+    <message>
         <source>Enable Logging</source>
         <translation>启用日志</translation>
     </message>
@@ -2586,6 +2650,193 @@ This will remove the current log and rotated backups. This action cannot be undo
         <source>French translation</source>
         <translation>法语翻译</translation>
     </message>
+    <message>
+        <source>Check for Updates</source>
+        <translation>检查更新</translation>
+    </message>
+    <message>
+        <source>Checking for updates…</source>
+        <translation>正在检查更新…</translation>
+    </message>
+    <message>
+        <source>You are using the latest version</source>
+        <translation>当前已是最新版本</translation>
+    </message>
+    <message>
+        <source>Update Check Failed</source>
+        <translation>检查更新失败</translation>
+    </message>
+    <message>
+        <source>qEmby Update</source>
+        <translation>qEmby 更新</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation>立即升级</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>No release notes were provided.</source>
+        <translation>此版本未提供更新说明。</translation>
+    </message>
+    <message>
+        <source>… Open the release page to read more.</source>
+        <translation>… 打开发布页面查看更多内容。</translation>
+    </message>
+    <message>
+        <source>A new version of qEmby is available.
+
+Current version: %1
+New version: %2
+
+Release notes:
+%3</source>
+        <translation>发现新的 qEmby 版本。
+
+当前版本：%1
+新版本：%2
+
+更新说明：
+%3</translation>
+    </message>
+    <message>
+        <source>Update Failed</source>
+        <translation>升级失败</translation>
+    </message>
+    <message>
+        <source>The update page could not be opened. Please try again later.</source>
+        <translation>无法打开升级页面，请稍后重试。</translation>
+    </message>
+</context>
+
+<context>
+    <name>UpdateManager</name>
+    <message>
+        <source>Could not connect to GitHub: %1</source>
+        <translation>无法连接 GitHub：%1</translation>
+    </message>
+    <message>
+        <source>GitHub returned invalid update information.</source>
+        <translation>GitHub 返回了无效的更新信息。</translation>
+    </message>
+    <message>
+        <source>The release contains an invalid version number: %1</source>
+        <translation>发布版本包含无效的版本号：%1</translation>
+    </message>
+</context>
+
+<context>
+    <name>UpdateDialog</name>
+    <message>
+        <source>qEmby Update</source>
+        <translation>qEmby 更新</translation>
+    </message>
+    <message>
+        <source>A new version of qEmby is available.</source>
+        <translation>发现新的 qEmby 版本。</translation>
+    </message>
+    <message>
+        <source>Current version</source>
+        <translation>当前版本</translation>
+    </message>
+    <message>
+        <source>New version</source>
+        <translation>新版本</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <translation>发布名称</translation>
+    </message>
+    <message>
+        <source>Published</source>
+        <translation>发布日期</translation>
+    </message>
+    <message>
+        <source>Release notes</source>
+        <translation>更新说明</translation>
+    </message>
+    <message>
+        <source>No release notes were provided.</source>
+        <translation>此版本未提供更新说明。</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>未知</translation>
+    </message>
+    <message>
+        <source>Ignore</source>
+        <translation>忽略此版本</translation>
+    </message>
+    <message>
+        <source>Remind Me Later</source>
+        <translation>忽略本次（下次提示）</translation>
+    </message>
+    <message>
+        <source>Hide this reminder until the next application startup</source>
+        <translation>本次不再显示，下次启动应用时继续提示</translation>
+    </message>
+    <message>
+        <source>Ignore This Version</source>
+        <translation>忽略此版本</translation>
+    </message>
+    <message>
+        <source>Do not remind me again for this version</source>
+        <translation>此版本不再提示，后续新版本仍会提示</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Update Now</source>
+        <translation>立即升级</translation>
+    </message>
+</context>
+
+<context>
+    <name>WindowsUpdateManager</name>
+    <message><source>No compatible Windows installer is available for this release.</source><translation>此版本没有可用的 Windows 安装程序。</translation></message>
+    <message><source>The release does not provide a valid SHA-256 digest.</source><translation>此版本未提供有效的 SHA-256 摘要。</translation></message>
+    <message><source>Could not create the temporary update directory.</source><translation>无法创建临时更新目录。</translation></message>
+    <message><source>The Windows installer has an invalid file name.</source><translation>Windows 安装程序的文件名无效。</translation></message>
+    <message><source>Could not open the temporary update file for writing.</source><translation>无法写入临时更新文件。</translation></message>
+    <message><source>Downloading update…</source><translation>正在下载更新…</translation></message>
+    <message><source>Failed to write the downloaded update to disk.</source><translation>无法将下载的更新写入磁盘。</translation></message>
+    <message><source>Update download failed: %1</source><translation>更新下载失败：%1</translation></message>
+    <message><source>Could not finalize the downloaded update file.</source><translation>无法完成下载文件的保存。</translation></message>
+    <message><source>Verifying SHA-256 digest…</source><translation>正在校验 SHA-256 摘要…</translation></message>
+    <message><source>SHA-256 verification failed. The downloaded file may be corrupted.</source><translation>SHA-256 校验失败，下载文件可能已损坏。</translation></message>
+    <message><source>Update verified and ready to install.</source><translation>更新已通过校验，可以安装。</translation></message>
+    <message><source>The verified installer is no longer available.</source><translation>已校验的安装程序已不存在。</translation></message>
+    <message><source>Could not start the Windows installer.</source><translation>无法启动 Windows 安装程序。</translation></message>
+    <message><source>Could not start the Windows update helper.</source><translation>无法启动 Windows 更新辅助程序。</translation></message>
+    <message><source>In-app installation is only available on Windows.</source><translation>应用内安装仅支持 Windows。</translation></message>
+</context>
+
+<context>
+    <name>UpdateProgressDialog</name>
+    <message><source>%1 MB</source><translation>%1 MB</translation></message>
+    <message><source>%1 KB</source><translation>%1 KB</translation></message>
+    <message><source>Update qEmby</source><translation>升级 qEmby</translation></message>
+    <message><source>Updating to %1</source><translation>正在升级到 %1</translation></message>
+    <message><source>Preparing download…</source><translation>正在准备下载…</translation></message>
+    <message><source>Waiting for download…</source><translation>等待开始下载…</translation></message>
+    <message><source>Start qEmby after updating</source><translation>升级后自动启动 qEmby</translation></message>
+    <message><source>Automatically reopen the application after installation completes</source><translation>安装完成后自动重新打开应用</translation></message>
+    <message><source>Cancel</source><translation>取消</translation></message>
+    <message><source>Install Update</source><translation>安装更新</translation></message>
+    <message><source>SHA-256 digest verified.</source><translation>SHA-256 摘要校验已通过。</translation></message>
+    <message><source>Update Failed</source><translation>升级失败</translation></message>
+    <message><source>The update page could not be opened. Please try again later.</source><translation>无法打开升级页面，请稍后重试。</translation></message>
+    <message><source>%1 of %2 (%3%)</source><translation>已下载 %1，共 %2（%3%）</translation></message>
+    <message><source>Downloaded %1</source><translation>已下载 %1</translation></message>
+    <message><source>Update failed</source><translation>升级失败</translation></message>
+    <message><source>Close</source><translation>关闭</translation></message>
+    <message><source>Starting the Windows installer…</source><translation>正在启动 Windows 安装程序…</translation></message>
+    <message><source>qEmby will close now. Installation progress will be shown by the Windows installer.</source><translation>qEmby 即将关闭，后续安装进度将由 Windows 安装程序显示。</translation></message>
 </context>
 
 <context>
@@ -2613,6 +2864,14 @@ This will remove the current log and rotated backups. This action cannot be undo
     <message>
         <source>Unknown Series</source>
         <translation>未知剧集</translation>
+    </message>
+    <message>
+        <source>Mark as Played</source>
+        <translation>标记为已播放</translation>
+    </message>
+    <message>
+        <source>Mark as Unplayed</source>
+        <translation>标记为未播放</translation>
     </message>
     <message>
         <source>Error Loading Episodes</source>
@@ -7737,6 +7996,10 @@ Comments: %4</source>
 <context>
     <name>PlayerDanmakuIdentifyDialog</name>
     <message>
+        <source>LogVar / danmu_api</source>
+        <translation>LogVar / danmu_api</translation>
+    </message>
+    <message>
         <source>Local File</source>
         <translation>本地文件</translation>
     </message>
@@ -8113,6 +8376,38 @@ Comments: %4</source>
 <context>
     <name>DanmakuServerDialog</name>
     <message>
+        <source>Each item shows the danmaku server name, type, address, credentials, and description. The built-in official DandanPlay server supports anime only.</source>
+        <translation>每个列表项会显示弹幕服务器的名称、类型、地址、凭据和说明。内置的官方弹弹Play服务器仅支持动画。</translation>
+    </message>
+    <message>
+        <source>Choose the server type and configure its address and credentials. Official DandanPlay uses signed App credentials; LogVar / danmu_api uses an optional access token and supports general video content.</source>
+        <translation>选择服务器类型并配置地址和凭据。官方弹弹Play使用 App 签名凭据；LogVar / danmu_api 使用可选访问令牌并支持常规影视内容。</translation>
+    </message>
+    <message>
+        <source>Server Type</source>
+        <translation>服务类型</translation>
+    </message>
+    <message>
+        <source>DandanPlay Official API</source>
+        <translation>弹弹Play 官方 API</translation>
+    </message>
+    <message>
+        <source>LogVar / danmu_api</source>
+        <translation>LogVar / danmu_api</translation>
+    </message>
+    <message>
+        <source>Access Token</source>
+        <translation>访问令牌</translation>
+    </message>
+    <message>
+        <source>Optional TOKEN configured by danmu_api</source>
+        <translation>danmu_api 中配置的可选 TOKEN</translation>
+    </message>
+    <message>
+        <source>General video danmaku service</source>
+        <translation>常规影视弹幕服务</translation>
+    </message>
+    <message>
         <source>Danmaku Servers</source>
         <translation>弹幕服务器</translation>
     </message>
@@ -8217,6 +8512,10 @@ Comments: %4</source>
         <translation>每个弹幕服务器都必须填写名称。</translation>
     </message>
     <message>
+        <source>Every danmaku server must use a supported server type.</source>
+        <translation>每个弹幕服务器都必须选择受支持的服务器类型。</translation>
+    </message>
+    <message>
         <source>Every danmaku server must have a server URL.</source>
         <translation>每个弹幕服务器都必须填写服务器地址。</translation>
     </message>
@@ -8228,6 +8527,18 @@ Comments: %4</source>
 
 <context>
     <name>DanmakuServerListItemWidget</name>
+    <message>
+        <source>DandanPlay</source>
+        <translation>弹弹Play</translation>
+    </message>
+    <message>
+        <source>LogVar / danmu_api</source>
+        <translation>LogVar / danmu_api</translation>
+    </message>
+    <message>
+        <source>Token: %1</source>
+        <translation>令牌：%1</translation>
+    </message>
     <message>
         <source>Remove Server</source>
         <translation>删除服务器</translation>
@@ -8252,6 +8563,30 @@ Comments: %4</source>
 
 <context>
     <name>PagePlayer</name>
+    <message>
+        <source>Preferred server: %1</source>
+        <translation>首选服务器：%1</translation>
+    </message>
+    <message>
+        <source>Server type: %1</source>
+        <translation>服务类型：%1</translation>
+    </message>
+    <message>
+        <source>Enabled servers: %1</source>
+        <translation>已启用服务器：%1</translation>
+    </message>
+    <message>
+        <source>Supported content: General video</source>
+        <translation>支持内容：常规影视</translation>
+    </message>
+    <message>
+        <source>DandanPlay</source>
+        <translation>弹弹Play</translation>
+    </message>
+    <message>
+        <source>LogVar / danmu_api</source>
+        <translation>LogVar / danmu_api</translation>
+    </message>
     <message>
         <source>Danmaku</source>
         <translation>弹幕</translation>
@@ -8656,6 +8991,10 @@ Address: %2</source>
 
 <context>
     <name>PlayerView</name>
+    <message>
+        <source>LogVar / danmu_api</source>
+        <translation>LogVar / danmu_api</translation>
+    </message>
     <message>
         <source>Seasons &amp; Episodes</source>
         <translation>季与剧集</translation>
@@ -9267,6 +9606,18 @@ This cannot be undone.</source>
     <message>
         <source>Sync passphrase</source>
         <translation>同步密码短语</translation>
+    </message>
+</context>
+
+<context>
+    <name>TrayManager</name>
+    <message>
+        <source>Show qEmby</source>
+        <translation>显示 qEmby</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation>退出</translation>
     </message>
 </context>
 

--- a/src/qEmbyApp/resources/qss/dark-style.qss
+++ b/src/qEmbyApp/resources/qss/dark-style.qss
@@ -76,6 +76,21 @@ QWK--WindowBar>QLabel#win-title-label {
     font-family: "Segoe UI", "Microsoft YaHei", sans-serif;
 }
 
+QWK--WindowBar QPushButton#titlebar-update-button {
+    border: none;
+    border-radius: 6px;
+    background-color: transparent;
+    padding: 6px;
+}
+
+QWK--WindowBar QPushButton#titlebar-update-button:hover {
+    background-color: #334155;
+}
+
+QWK--WindowBar QPushButton#titlebar-update-button:pressed {
+    background-color: #475569;
+}
+
 QLabel#mac-title-label {
     padding: 0;
     border: none;
@@ -1104,6 +1119,115 @@ QPushButton#dialog-btn-primary:hover {
 QPushButton#dialog-btn-primary:disabled {
     background-color: rgba(59, 130, 246, 0.4);
     color: rgba(255, 255, 255, 0.7);
+}
+
+QLabel#UpdateDialogHeadline {
+    color: #F8FAFC;
+    font-size: 16px;
+    font-weight: 700;
+    padding-bottom: 2px;
+}
+
+QFrame#UpdateDialogSummary {
+    background-color: #1E293B;
+    border: 1px solid #334155;
+    border-radius: 10px;
+}
+
+QLabel#UpdateDialogSummaryLabel {
+    color: #94A3B8;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+QLabel#UpdateDialogSummaryValue {
+    color: #E2E8F0;
+    font-size: 13px;
+}
+
+QLabel#UpdateDialogSectionTitle {
+    color: #F8FAFC;
+    font-size: 14px;
+    font-weight: 700;
+    padding-top: 4px;
+}
+
+QTextBrowser#UpdateDialogReleaseNotes {
+    color: #CBD5E1;
+    background-color: #0F172A;
+    border: 1px solid #334155;
+    border-radius: 10px;
+    padding: 0;
+    selection-background-color: #2563EB;
+}
+
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar:vertical {
+    width: 10px;
+    margin: 0;
+    background: transparent;
+}
+
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar::handle:vertical {
+    min-height: 30px;
+    margin: 2px 1px;
+    border-radius: 4px;
+    background-color: #64748B;
+}
+
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar::handle:vertical:hover {
+    background-color: #94A3B8;
+}
+
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar::add-line:vertical,
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar::sub-line:vertical,
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar::add-page:vertical,
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar::sub-page:vertical {
+    height: 0;
+    background: transparent;
+    border: none;
+}
+
+QLabel#UpdateProgressHeadline {
+    color: #F8FAFC;
+    font-size: 17px;
+    font-weight: 700;
+}
+
+QLabel#UpdateProgressStatus {
+    color: #E2E8F0;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+QLabel#UpdateProgressDetail,
+QLabel#UpdateRestartDescription {
+    color: #94A3B8;
+    font-size: 13px;
+}
+
+QLabel#UpdateRestartTitle {
+    color: #E2E8F0;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+QWidget#UpdateRestartCard {
+    background-color: #1E293B;
+    border: 1px solid #334155;
+    border-radius: 10px;
+}
+
+QProgressBar#UpdateDownloadProgressBar {
+    min-height: 8px;
+    max-height: 8px;
+    background-color: #334155;
+    border: none;
+    border-radius: 4px;
+}
+
+QProgressBar#UpdateDownloadProgressBar::chunk {
+    background-color: #22C55E;
+    border-radius: 4px;
 }
 
 ModernDialogBase#playerDanmakuSettingsDialog,
@@ -3557,6 +3681,17 @@ QMenu#TagPresetMenu::indicator {
     background-color: transparent;
 }
 
+QScrollArea#ManagePageScrollArea {
+    background-color: transparent;
+    border: none;
+    margin: 0;
+    padding: 0;
+}
+
+QScrollArea#ManagePageScrollArea>QWidget>QWidget {
+    background-color: transparent;
+}
+
 /* 分栏子标题 (SettingsSubTitle) */
 QLabel#SettingsSubTitle {
     font-size: 11px;
@@ -3815,48 +3950,44 @@ QLabel#SettingsPageTitle {
 
 /* ==========================================
    Modern Tray Menu (Dark Mode)
-   设计理念：Apple 悬浮风 / 内部隔离胶囊
+   设计理念：与全局 QMenu 同色系 (Slate) / 胶囊式悬浮
    ========================================== */
 #modern-tray-menu {
-    /* 使用 rgba 允许底部有非常轻微的透色感 */
-    background-color: rgba(30, 30, 32, 245);
-    border: 1px solid #3F3F46;
-    /* Tailwind Zinc 700 细腻光泽边框 */
+    background-color: rgba(30, 41, 59, 245);
+    /* Slate 800，与全局 QMenu 同色系 */
+    border: 1px solid #334155;
+    /* Slate 700 边框 */
     border-radius: 8px;
-    /* 整体菜单外沿圆角 */
     padding: 6px 0px;
-    /* 头部和尾部的呼吸留白 */
+    /* margin 让圆角绘制区域内缩，脱离物理窗口直角边界 */
+    margin: 4px;
 }
 
 #modern-tray-menu::item {
-    color: #E4E4E7;
-    /* Tailwind Zinc 200 */
+    color: #CBD5E1;
+    /* Slate 300，与全局 QMenu::item 一致 */
     padding: 6px 32px 6px 14px;
-    /* 左右宽阔的热区，保证不拥挤 */
     margin: 2px 6px;
-    /* 【核心】：让 hover 高亮区不贴边，形成独立胶囊 */
+    /* hover 高亮区不贴边，形成独立胶囊 */
     border-radius: 5px;
-    /* 胶囊状内圆角 */
     font-size: 13px;
 }
 
 #modern-tray-menu::item:selected {
-    background-color: #3B82F6;
-    /* Tailwind Blue 500 (极具现代感的亮蓝) */
-    color: #FFFFFF;
+    background-color: #334155;
+    /* Slate 700 柔和高亮，与全局 QMenu 一致 */
+    color: #F8FAFC;
 }
 
 #modern-tray-menu::separator {
     height: 1px;
-    background-color: #3F3F46;
-    /* 边框同色分割线 */
+    background-color: #334155;
+    /* Slate 700 分割线 */
     margin: 4px 12px;
-    /* 分割线缩进，不贯穿两头 */
 }
 
 #modern-tray-menu::icon {
     padding-left: 10px;
-    /* 图标与左边缘的呼吸距 */
 }
 
 /* =========================================

--- a/src/qEmbyApp/resources/qss/light-style.qss
+++ b/src/qEmbyApp/resources/qss/light-style.qss
@@ -75,6 +75,21 @@ QWK--WindowBar>QLabel#win-title-label {
     font-family: "Segoe UI", "Microsoft YaHei", sans-serif;
 }
 
+QWK--WindowBar QPushButton#titlebar-update-button {
+    border: none;
+    border-radius: 6px;
+    background-color: transparent;
+    padding: 6px;
+}
+
+QWK--WindowBar QPushButton#titlebar-update-button:hover {
+    background-color: #E2E8F0;
+}
+
+QWK--WindowBar QPushButton#titlebar-update-button:pressed {
+    background-color: #CBD5E1;
+}
+
 QLabel#mac-title-label {
     padding: 0;
     border: none;
@@ -1126,6 +1141,115 @@ QPushButton#dialog-btn-primary:hover {
 QPushButton#dialog-btn-primary:disabled {
     background-color: rgba(59, 130, 246, 0.4);
     color: rgba(255, 255, 255, 0.7);
+}
+
+QLabel#UpdateDialogHeadline {
+    color: #0F172A;
+    font-size: 16px;
+    font-weight: 700;
+    padding-bottom: 2px;
+}
+
+QFrame#UpdateDialogSummary {
+    background-color: #F8FAFC;
+    border: 1px solid #E2E8F0;
+    border-radius: 10px;
+}
+
+QLabel#UpdateDialogSummaryLabel {
+    color: #64748B;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+QLabel#UpdateDialogSummaryValue {
+    color: #1E293B;
+    font-size: 13px;
+}
+
+QLabel#UpdateDialogSectionTitle {
+    color: #0F172A;
+    font-size: 14px;
+    font-weight: 700;
+    padding-top: 4px;
+}
+
+QTextBrowser#UpdateDialogReleaseNotes {
+    color: #334155;
+    background-color: #FFFFFF;
+    border: 1px solid #CBD5E1;
+    border-radius: 10px;
+    padding: 0;
+    selection-background-color: #3B82F6;
+}
+
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar:vertical {
+    width: 10px;
+    margin: 0;
+    background: transparent;
+}
+
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar::handle:vertical {
+    min-height: 30px;
+    margin: 2px 1px;
+    border-radius: 4px;
+    background-color: #94A3B8;
+}
+
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar::handle:vertical:hover {
+    background-color: #64748B;
+}
+
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar::add-line:vertical,
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar::sub-line:vertical,
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar::add-page:vertical,
+QTextBrowser#UpdateDialogReleaseNotes QScrollBar::sub-page:vertical {
+    height: 0;
+    background: transparent;
+    border: none;
+}
+
+QLabel#UpdateProgressHeadline {
+    color: #0F172A;
+    font-size: 17px;
+    font-weight: 700;
+}
+
+QLabel#UpdateProgressStatus {
+    color: #1E293B;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+QLabel#UpdateProgressDetail,
+QLabel#UpdateRestartDescription {
+    color: #64748B;
+    font-size: 13px;
+}
+
+QLabel#UpdateRestartTitle {
+    color: #1E293B;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+QWidget#UpdateRestartCard {
+    background-color: #F8FAFC;
+    border: 1px solid #E2E8F0;
+    border-radius: 10px;
+}
+
+QProgressBar#UpdateDownloadProgressBar {
+    min-height: 8px;
+    max-height: 8px;
+    background-color: #E2E8F0;
+    border: none;
+    border-radius: 4px;
+}
+
+QProgressBar#UpdateDownloadProgressBar::chunk {
+    background-color: #22C55E;
+    border-radius: 4px;
 }
 
 ModernDialogBase#playerDanmakuSettingsDialog,
@@ -3873,6 +3997,17 @@ QMenu#TagPresetMenu::indicator {
     background-color: transparent;
 }
 
+QScrollArea#ManagePageScrollArea {
+    background-color: transparent;
+    border: none;
+    margin: 0;
+    padding: 0;
+}
+
+QScrollArea#ManagePageScrollArea>QWidget>QWidget {
+    background-color: transparent;
+}
+
 /* 副标题 */
 QLabel#SettingsSubTitle {
     font-size: 11px;
@@ -3885,19 +4020,21 @@ QLabel#SettingsSubTitle {
 
 /* ==========================================
    Modern Tray Menu (Light Mode)
-   设计理念：Fluent 干净通透 / 柔和对比
+   设计理念：与全局 QMenu 同色系 (Gray) / 胶囊式悬浮
    ========================================== */
 #modern-tray-menu {
     background-color: rgba(255, 255, 255, 248);
     border: 1px solid #E5E7EB;
-    /* Tailwind Gray 200 */
+    /* Gray 200 边框，与全局 QMenu 一致 */
     border-radius: 8px;
     padding: 6px 0px;
+    /* margin 让圆角绘制区域内缩，脱离物理窗口直角边界 */
+    margin: 4px;
 }
 
 #modern-tray-menu::item {
-    color: #374151;
-    /* Tailwind Gray 700 */
+    color: #4B5563;
+    /* Gray 600，与全局 QMenu::item 一致 */
     padding: 6px 32px 6px 14px;
     margin: 2px 6px;
     border-radius: 5px;
@@ -3905,16 +4042,15 @@ QLabel#SettingsSubTitle {
 }
 
 #modern-tray-menu::item:selected {
-    background-color: #EFF6FF;
-    /* Tailwind Blue 50 (极柔和的浅蓝色底) */
-    color: #1D4ED8;
-    /* Tailwind Blue 700 (选中时文字变深蓝，层次分明) */
+    background-color: #E5E7EB;
+    /* Gray 200，胶囊式 item 在白底上需要更深一档才可见 */
+    color: #111827;
 }
 
 #modern-tray-menu::separator {
     height: 1px;
-    background-color: #F3F4F6;
-    /* Tailwind Gray 100 */
+    background-color: #E5E7EB;
+    /* Gray 200 分割线 */
     margin: 4px 12px;
 }
 

--- a/src/qEmbyApp/utils/mediasourcepreferenceutils.cpp
+++ b/src/qEmbyApp/utils/mediasourcepreferenceutils.cpp
@@ -1,5 +1,7 @@
 #include "mediasourcepreferenceutils.h"
 
+#include <config/config_keys.h>
+#include <config/configstore.h>
 #include <QDateTime>
 #include <QDebug>
 #include <QFileInfo>
@@ -266,16 +268,21 @@ int compareByCriterion(const MediaSourceInfo &left, const MediaSourceInfo &right
         criterion == SortCriterion::BitrateAsc) {
         bool leftValid = false;
         bool rightValid = false;
-        return compareNumbers(sourceVideoBitrate(left, &leftValid), leftValid,
-                              sourceVideoBitrate(right, &rightValid), rightValid);
+        
+        
+        
+        const qint64 leftBitrate = sourceVideoBitrate(left, &leftValid);
+        const qint64 rightBitrate = sourceVideoBitrate(right, &rightValid);
+        return compareNumbers(leftBitrate, leftValid, rightBitrate, rightValid);
     }
 
     if (criterion == SortCriterion::SizeDesc ||
         criterion == SortCriterion::SizeAsc) {
         bool leftValid = false;
         bool rightValid = false;
-        return compareNumbers(sourceFileSize(left, &leftValid), leftValid,
-                              sourceFileSize(right, &rightValid), rightValid);
+        const qint64 leftSize = sourceFileSize(left, &leftValid);
+        const qint64 rightSize = sourceFileSize(right, &rightValid);
+        return compareNumbers(leftSize, leftValid, rightSize, rightValid);
     }
 
     bool leftValid = false;
@@ -359,16 +366,6 @@ QList<int> sortedCandidates(const QList<MediaSourceInfo> &mediaSources,
     return candidates;
 }
 
-QList<SortCriterion> collectAllSortCriteria(const QList<ParsedRule> &rules) {
-    QList<SortCriterion> result;
-    for (const ParsedRule &rule : rules) {
-        if (rule.isSort) {
-            result.append(rule.sortCriterion);
-        }
-    }
-    return result;
-}
-
 QList<SortCriterion> collectFollowingSortCriteria(const QList<ParsedRule> &rules,
                                                   int startIndex) {
     QList<SortCriterion> result;
@@ -414,15 +411,20 @@ QStringList splitPreferredVersionRules(const QString &rawRules) {
     return result;
 }
 
-int resolvePreferredMediaSourceIndex(const QList<MediaSourceInfo> &mediaSources,
+QList<int> preferredMediaSourceOrder(const QList<MediaSourceInfo> &mediaSources,
                                      const QString &rawRules) {
-    if (mediaSources.size() <= 1) {
-        return 0;
+    QList<int> remaining;
+    remaining.reserve(mediaSources.size());
+    for (int i = 0; i < mediaSources.size(); ++i) {
+        remaining.append(i);
+    }
+    if (remaining.size() <= 1) {
+        return remaining;
     }
 
     const QStringList tokens = splitPreferredVersionRules(rawRules);
     if (tokens.isEmpty()) {
-        return 0;
+        return remaining;
     }
 
     QList<ParsedRule> rules;
@@ -430,14 +432,18 @@ int resolvePreferredMediaSourceIndex(const QList<MediaSourceInfo> &mediaSources,
         rules.append(parseRule(token));
     }
 
-    const QList<SortCriterion> globalSortCriteria = collectAllSortCriteria(rules);
+    QList<int> ordered;
+    ordered.reserve(mediaSources.size());
 
     for (int i = 0; i < rules.size(); ++i) {
+        if (remaining.isEmpty()) {
+            break;
+        }
+
         const ParsedRule &rule = rules[i];
         if (!rule.isSort) {
             QList<int> matches;
-            for (int sourceIndex = 0; sourceIndex < mediaSources.size();
-                 ++sourceIndex) {
+            for (const int sourceIndex : remaining) {
                 if (sourceMatchesKeyword(mediaSources[sourceIndex], rule.keyword)) {
                     matches.append(sourceIndex);
                 }
@@ -449,48 +455,41 @@ int resolvePreferredMediaSourceIndex(const QList<MediaSourceInfo> &mediaSources,
 
             QList<SortCriterion> sortCriteria =
                 collectFollowingSortCriteria(rules, i);
-            if (sortCriteria.isEmpty()) {
-                sortCriteria = globalSortCriteria;
-            }
 
             bool usedMeaningfulSort = false;
             const QList<int> orderedMatches = sortedCandidates(
                 mediaSources, matches, sortCriteria, &usedMeaningfulSort);
-            const int chosenIndex =
-                orderedMatches.isEmpty() ? matches.first() : orderedMatches.first();
+            for (const int sourceIndex : orderedMatches) {
+                ordered.append(sourceIndex);
+                remaining.removeOne(sourceIndex);
+            }
 
             QStringList sortNames;
             for (const SortCriterion criterion : sortCriteria) {
                 sortNames.append(criterionName(criterion));
             }
             qDebug().noquote()
-                << QStringLiteral("[MediaSourcePreferenceUtils] Preferred source matched by keyword")
+                << QStringLiteral("[MediaSourcePreferenceUtils] Ordered sources matched by keyword")
                        + QStringLiteral(" | rules=%1").arg(rawRules)
                        + QStringLiteral(" | keyword=%1").arg(rule.keyword)
                        + QStringLiteral(" | matchedCount=%1").arg(matches.size())
                        + QStringLiteral(" | sortCriteria=%1").arg(sortNames.join(','))
-                       + QStringLiteral(" | selectedIndex=%1").arg(chosenIndex)
-                       + QStringLiteral(" | selectedName=%1")
-                             .arg(mediaSources[chosenIndex].name);
-            return chosenIndex;
+                       + QStringLiteral(" | firstMatchedIndex=%1")
+                             .arg(orderedMatches.first());
+            continue;
         }
 
         QList<SortCriterion> sortCriteria = collectFollowingSortCriteria(rules, i);
         sortCriteria.prepend(rule.sortCriterion);
 
         bool usedMeaningfulSort = false;
-        QList<int> candidates;
-        for (int sourceIndex = 0; sourceIndex < mediaSources.size(); ++sourceIndex) {
-            candidates.append(sourceIndex);
-        }
-
         const QList<int> orderedCandidates = sortedCandidates(
-            mediaSources, candidates, sortCriteria, &usedMeaningfulSort);
+            mediaSources, remaining, sortCriteria, &usedMeaningfulSort);
         if (orderedCandidates.isEmpty()) {
             continue;
         }
 
-        if (!usedMeaningfulSort && mediaSources.size() > 1) {
+        if (!usedMeaningfulSort && remaining.size() > 1) {
             qDebug().noquote()
                 << QStringLiteral("[MediaSourcePreferenceUtils] Sort rule skipped because metadata is unavailable")
                        + QStringLiteral(" | rules=%1").arg(rawRules)
@@ -504,17 +503,65 @@ int resolvePreferredMediaSourceIndex(const QList<MediaSourceInfo> &mediaSources,
             sortNames.append(criterionName(criterion));
         }
         qDebug().noquote()
-            << QStringLiteral("[MediaSourcePreferenceUtils] Preferred source matched by sort")
+                << QStringLiteral("[MediaSourcePreferenceUtils] Ordered sources by sort")
                    + QStringLiteral(" | rules=%1").arg(rawRules)
                    + QStringLiteral(" | sortCriteria=%1").arg(sortNames.join(','))
-                   + QStringLiteral(" | selectedIndex=%1")
-                         .arg(orderedCandidates.first())
-                   + QStringLiteral(" | selectedName=%1")
-                         .arg(mediaSources[orderedCandidates.first()].name);
-        return orderedCandidates.first();
+                       + QStringLiteral(" | firstIndex=%1")
+                             .arg(orderedCandidates.first())
+                       + QStringLiteral(" | firstName=%1")
+                             .arg(mediaSources[orderedCandidates.first()].name);
+        ordered.append(orderedCandidates);
+        remaining.clear();
+        break;
     }
 
-    return 0;
+    ordered.append(remaining);
+    return ordered;
+}
+
+int resolvePreferredMediaSourceIndex(const QList<MediaSourceInfo> &mediaSources,
+                                     const QString &rawRules,
+                                     const QString &rememberedSourceId) {
+    if (mediaSources.isEmpty()) {
+        return 0;
+    }
+
+    if (!rememberedSourceId.trimmed().isEmpty()) {
+        for (int i = 0; i < mediaSources.size(); ++i) {
+            if (mediaSources[i].id.compare(rememberedSourceId,
+                                           Qt::CaseInsensitive) == 0) {
+                qDebug() << "[MediaSourcePreferenceUtils] Restored manually selected source"
+                         << "sourceId=" << rememberedSourceId << "sourceIndex=" << i;
+                return i;
+            }
+        }
+        qDebug() << "[MediaSourcePreferenceUtils] Remembered source is unavailable; using preference rules"
+                 << "sourceId=" << rememberedSourceId;
+    }
+
+    const QList<int> order = preferredMediaSourceOrder(mediaSources, rawRules);
+    return order.isEmpty() ? 0 : order.first();
+}
+
+QString rememberedMediaSourceId(const QString &serverId, const QString &mediaId) {
+    if (serverId.trimmed().isEmpty() || mediaId.trimmed().isEmpty()) {
+        return {};
+    }
+    return ConfigStore::instance()->get<QString>(ConfigKeys::forServerMedia(
+        serverId, mediaId, ConfigKeys::PlayerSelectedMediaSource));
+}
+
+void rememberMediaSourceId(const QString &serverId, const QString &mediaId,
+                           const QString &mediaSourceId) {
+    if (serverId.trimmed().isEmpty() || mediaId.trimmed().isEmpty() ||
+        mediaSourceId.trimmed().isEmpty()) {
+        return;
+    }
+    ConfigStore::instance()->set(ConfigKeys::forServerMedia(
+        serverId, mediaId, ConfigKeys::PlayerSelectedMediaSource),
+        mediaSourceId);
+    qDebug() << "[MediaSourcePreferenceUtils] Remembered manual source selection"
+             << "mediaId=" << mediaId << "sourceId=" << mediaSourceId;
 }
 
 } 

--- a/src/qEmbyApp/utils/mediasourcepreferenceutils.h
+++ b/src/qEmbyApp/utils/mediasourcepreferenceutils.h
@@ -10,8 +10,16 @@ namespace MediaSourcePreferenceUtils {
 
 QStringList splitPreferredVersionRules(const QString &rawRules);
 
-int resolvePreferredMediaSourceIndex(const QList<MediaSourceInfo> &mediaSources,
+QList<int> preferredMediaSourceOrder(const QList<MediaSourceInfo> &mediaSources,
                                      const QString &rawRules);
+
+int resolvePreferredMediaSourceIndex(const QList<MediaSourceInfo> &mediaSources,
+                                     const QString &rawRules,
+                                     const QString &rememberedSourceId = QString());
+
+QString rememberedMediaSourceId(const QString &serverId, const QString &mediaId);
+void rememberMediaSourceId(const QString &serverId, const QString &mediaId,
+                           const QString &mediaSourceId);
 
 } 
 

--- a/src/qEmbyApp/utils/playerpreferenceutils.cpp
+++ b/src/qEmbyApp/utils/playerpreferenceutils.cpp
@@ -1,8 +1,12 @@
 #include "playerpreferenceutils.h"
 
+#include <config/config_keys.h>
+#include <config/configstore.h>
 #include <QDebug>
 #include <QHash>
 #include <QRegularExpression>
+#include <algorithm>
+#include <limits>
 
 namespace {
 
@@ -228,6 +232,88 @@ bool streamMatchesSingleRule(const MediaStreamInfo &stream,
                       QStringList{normalizedRule});
 }
 
+bool containsAnyText(const QString &text, const QStringList &values) {
+    for (const QString &value : values) {
+        if (text.contains(value)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int streamMatchRank(const MediaStreamInfo &stream,
+                    const QString &normalizedRule) {
+    if (!streamMatchesSingleRule(stream, normalizedRule)) {
+        return -1;
+    }
+
+    
+    
+    
+    
+    if (normalizedRule == QStringLiteral("chi")) {
+        const QString searchText = streamSearchText(stream);
+        if (containsAnyText(
+                searchText,
+                {QStringLiteral("cantonese"), QStringLiteral("粤语"),
+                 QStringLiteral("廣東話"), QStringLiteral("hong kong"),
+                 QStringLiteral("香港"), QStringLiteral("macau"),
+                 QStringLiteral("macao"), QStringLiteral("澳门"),
+                 QStringLiteral("澳門"), QStringLiteral("taiwan"),
+                 QStringLiteral("台湾"), QStringLiteral("台灣"),
+                 QStringLiteral("traditional"), QStringLiteral("繁体"),
+                 QStringLiteral("繁體"), QStringLiteral("繁中")})) {
+            return 2;
+        }
+        if (containsAnyText(
+                searchText,
+                {QStringLiteral("mandarin"), QStringLiteral("普通话"),
+                 QStringLiteral("国语"), QStringLiteral("simplified"),
+                 QStringLiteral("简体"), QStringLiteral("简中"),
+                 QStringLiteral("zh-cn"), QStringLiteral("zh-hans"),
+                 QStringLiteral("chs"), QStringLiteral("cmn")})) {
+            return 0;
+        }
+        return 1;
+    }
+
+    return 0;
+}
+
+std::optional<int> readRememberedStreamIndex(const QString &key) {
+    if (key.isEmpty()) {
+        return std::nullopt;
+    }
+    const QString stored = ConfigStore::instance()->get<QString>(key).trimmed();
+    if (stored.isEmpty()) {
+        return std::nullopt;
+    }
+    bool ok = false;
+    const int index = stored.toInt(&ok);
+    return ok ? std::optional<int>(index) : std::nullopt;
+}
+
+QString streamSelectionKey(const QString &serverId, const QString &mediaId,
+                           const QString &mediaSourceId,
+                           const char *baseKey) {
+    if (serverId.trimmed().isEmpty() || mediaId.trimmed().isEmpty() ||
+        mediaSourceId.trimmed().isEmpty()) {
+        return {};
+    }
+    return ConfigKeys::forServerMediaSource(serverId, mediaId, mediaSourceId,
+                                            baseKey);
+}
+
+bool containsStreamIndex(const MediaSourceInfo &source, const QString &type,
+                         int streamIndex) {
+    for (const MediaStreamInfo &stream : source.mediaStreams) {
+        if (stream.type == type && stream.index == streamIndex) {
+            return true;
+        }
+    }
+    return false;
+}
+
 } 
 
 namespace PlayerPreferenceUtils {
@@ -285,23 +371,87 @@ int findPreferredStreamIndex(const QList<MediaStreamInfo> &mediaStreams,
     }
 
     for (const QString &rule : rules) {
-        for (const MediaStreamInfo &stream : mediaStreams) {
-            if (stream.type != streamType) {
+        int bestPosition = -1;
+        int bestRank = std::numeric_limits<int>::max();
+        for (int i = 0; i < mediaStreams.size(); ++i) {
+            if (mediaStreams[i].type != streamType) {
                 continue;
             }
-
-            if (streamMatchesSingleRule(stream, rule)) {
-                return stream.index;
+            const int rank = streamMatchRank(mediaStreams[i], rule);
+            if (rank >= 0 && rank < bestRank) {
+                bestPosition = i;
+                bestRank = rank;
             }
+        }
+        if (bestPosition >= 0) {
+            return mediaStreams[bestPosition].index;
         }
     }
 
     return -1;
 }
 
+QList<int> preferredStreamOrder(const QList<MediaStreamInfo> &mediaStreams,
+                                const QString &streamType,
+                                const QString &rawRules) {
+    QList<int> remaining;
+    for (int i = 0; i < mediaStreams.size(); ++i) {
+        if (mediaStreams[i].type == streamType) {
+            remaining.append(i);
+        }
+    }
+
+    const QStringList rules = splitLanguageRules(rawRules);
+    if (remaining.size() <= 1 || rules.isEmpty() ||
+        rules.contains(QStringLiteral("auto")) ||
+        (streamType == QStringLiteral("Subtitle") &&
+         rules.contains(QStringLiteral("none")))) {
+        return remaining;
+    }
+
+    QList<int> ordered;
+    ordered.reserve(remaining.size());
+    for (const QString &rule : rules) {
+        QList<int> matches;
+        for (const int position : remaining) {
+            if (streamMatchRank(mediaStreams[position], rule) >= 0) {
+                matches.append(position);
+            }
+        }
+
+        std::stable_sort(
+            matches.begin(), matches.end(),
+            [&mediaStreams, &rule](int left, int right) {
+                return streamMatchRank(mediaStreams[left], rule) <
+                       streamMatchRank(mediaStreams[right], rule);
+            });
+        for (const int position : matches) {
+            ordered.append(position);
+            remaining.removeOne(position);
+        }
+    }
+
+    ordered.append(remaining);
+    qDebug().noquote()
+        << QStringLiteral("[PlayerPreferenceUtils] Ordered media streams")
+               + QStringLiteral(" | type=%1").arg(streamType)
+               + QStringLiteral(" | rules=%1").arg(rawRules)
+               + QStringLiteral(" | streamIndexes=%1")
+                     .arg([&mediaStreams, &ordered]() {
+                         QStringList indexes;
+                         for (const int position : ordered) {
+                             indexes.append(
+                                 QString::number(mediaStreams[position].index));
+                         }
+                         return indexes.join(QLatin1Char(','));
+                     }());
+    return ordered;
+}
+
 void applyPreferredStreamRules(MediaSourceInfo &selectedSource,
                                const QString &audioRules,
-                               const QString &subtitleRules) {
+                               const QString &subtitleRules,
+                               const RememberedStreamSelection &remembered) {
     const int bestAudioIdx = findPreferredStreamIndex(
         selectedSource.mediaStreams, QStringLiteral("Audio"), audioRules);
     const int bestSubIdx = findPreferredStreamIndex(
@@ -324,7 +474,23 @@ void applyPreferredStreamRules(MediaSourceInfo &selectedSource,
         }
     }
 
-    if (bestAudioIdx >= 0) {
+    const bool rememberedAudioAvailable =
+        remembered.audioIndex.has_value() &&
+        containsStreamIndex(selectedSource, QStringLiteral("Audio"),
+                            *remembered.audioIndex);
+    const bool rememberedSubtitleAvailable =
+        remembered.subtitleIndex.has_value() &&
+        (*remembered.subtitleIndex < 0 ||
+         containsStreamIndex(selectedSource, QStringLiteral("Subtitle"),
+                             *remembered.subtitleIndex));
+
+    if (rememberedAudioAvailable) {
+        for (MediaStreamInfo &stream : selectedSource.mediaStreams) {
+            if (stream.type == QStringLiteral("Audio")) {
+                stream.isDefault = (stream.index == *remembered.audioIndex);
+            }
+        }
+    } else if (bestAudioIdx >= 0) {
         for (MediaStreamInfo &stream : selectedSource.mediaStreams) {
             if (stream.type == QStringLiteral("Audio")) {
                 stream.isDefault = (stream.index == bestAudioIdx);
@@ -333,7 +499,18 @@ void applyPreferredStreamRules(MediaSourceInfo &selectedSource,
     }
 
     QString subtitleDecision = QStringLiteral("keep-server-default");
-    if (subtitleDisabled) {
+    if (rememberedSubtitleAvailable) {
+        subtitleDecision = *remembered.subtitleIndex < 0
+                               ? QStringLiteral("disabled-by-remembered-selection")
+                               : QStringLiteral("remembered-selection");
+        for (MediaStreamInfo &stream : selectedSource.mediaStreams) {
+            if (stream.type == QStringLiteral("Subtitle")) {
+                stream.isDefault =
+                    *remembered.subtitleIndex >= 0 &&
+                    stream.index == *remembered.subtitleIndex;
+            }
+        }
+    } else if (subtitleDisabled) {
         subtitleDecision = QStringLiteral("disabled-by-rule");
         for (MediaStreamInfo &stream : selectedSource.mediaStreams) {
             if (stream.type == QStringLiteral("Subtitle")) {
@@ -360,10 +537,93 @@ void applyPreferredStreamRules(MediaSourceInfo &selectedSource,
         << QStringLiteral("[PlayerPreferenceUtils] Applied stream rules")
                + QStringLiteral(" | sourceId=%1").arg(selectedSource.id)
                + QStringLiteral(" | audioRules=%1").arg(audioRules)
-               + QStringLiteral(" | selectedAudioIndex=%1").arg(bestAudioIdx)
+               + QStringLiteral(" | selectedAudioIndex=%1")
+                     .arg(rememberedAudioAvailable ? *remembered.audioIndex
+                                                   : bestAudioIdx)
                + QStringLiteral(" | subtitleRules=%1").arg(subtitleRules)
-               + QStringLiteral(" | selectedSubtitleIndex=%1").arg(bestSubIdx)
+               + QStringLiteral(" | selectedSubtitleIndex=%1")
+                     .arg(rememberedSubtitleAvailable
+                              ? *remembered.subtitleIndex
+                              : bestSubIdx)
                + QStringLiteral(" | subtitleDecision=%1").arg(subtitleDecision);
+}
+
+static RememberedStreamSelection loadRememberedStreamSelection(
+    const QString &serverId, const QString &mediaId,
+    const QString &mediaSourceId) {
+    RememberedStreamSelection result;
+    result.audioIndex = readRememberedStreamIndex(streamSelectionKey(
+        serverId, mediaId, mediaSourceId, ConfigKeys::PlayerSelectedAudioStream));
+    result.subtitleIndex = readRememberedStreamIndex(streamSelectionKey(
+        serverId, mediaId, mediaSourceId,
+        ConfigKeys::PlayerSelectedSubtitleStream));
+    return result;
+}
+
+RememberedStreamSelection validatedRememberedStreamSelection(
+    const QString &serverId, const QString &mediaId,
+    const MediaSourceInfo &mediaSource) {
+    RememberedStreamSelection result =
+        loadRememberedStreamSelection(serverId, mediaId, mediaSource.id);
+
+    if (result.audioIndex.has_value() &&
+        !containsStreamIndex(mediaSource, QStringLiteral("Audio"),
+                             *result.audioIndex)) {
+        qWarning() << "[PlayerPreferenceUtils] Ignoring unavailable remembered audio stream"
+                   << "mediaId=" << mediaId << "sourceId=" << mediaSource.id
+                   << "streamIndex=" << *result.audioIndex;
+        result.audioIndex.reset();
+    }
+
+    if (result.subtitleIndex.has_value() && *result.subtitleIndex >= 0 &&
+        !containsStreamIndex(mediaSource, QStringLiteral("Subtitle"),
+                             *result.subtitleIndex)) {
+        qWarning() << "[PlayerPreferenceUtils] Ignoring unavailable remembered subtitle stream"
+                   << "mediaId=" << mediaId << "sourceId=" << mediaSource.id
+                   << "streamIndex=" << *result.subtitleIndex;
+        result.subtitleIndex.reset();
+    }
+
+    return result;
+}
+
+void rememberAudioStreamIndex(const QString &serverId, const QString &mediaId,
+                              const QString &mediaSourceId, int streamIndex) {
+    const QString key = streamSelectionKey(
+        serverId, mediaId, mediaSourceId, ConfigKeys::PlayerSelectedAudioStream);
+    if (key.isEmpty() || streamIndex < 0) {
+        return;
+    }
+    ConfigStore::instance()->set(key, QString::number(streamIndex));
+    qDebug() << "[PlayerPreferenceUtils] Remembered manual audio stream"
+             << "mediaId=" << mediaId << "sourceId=" << mediaSourceId
+             << "streamIndex=" << streamIndex;
+}
+
+void rememberSubtitleStreamIndex(const QString &serverId,
+                                 const QString &mediaId,
+                                 const QString &mediaSourceId,
+                                 int streamIndex) {
+    const QString key = streamSelectionKey(
+        serverId, mediaId, mediaSourceId,
+        ConfigKeys::PlayerSelectedSubtitleStream);
+    if (key.isEmpty() || streamIndex < -1) {
+        return;
+    }
+    ConfigStore::instance()->set(key, QString::number(streamIndex));
+    qDebug() << "[PlayerPreferenceUtils] Remembered manual subtitle stream"
+             << "mediaId=" << mediaId << "sourceId=" << mediaSourceId
+             << "streamIndex=" << streamIndex;
+}
+
+void applyRememberedOrPreferredStreamRules(
+    MediaSourceInfo &selectedSource, const QString &serverId,
+    const QString &mediaId, const QString &audioRules,
+    const QString &subtitleRules) {
+    applyPreferredStreamRules(
+        selectedSource, audioRules, subtitleRules,
+        validatedRememberedStreamSelection(serverId, mediaId,
+                                            selectedSource));
 }
 
 QStringList mpvLanguageCodesForRules(const QString &rawRules) {

--- a/src/qEmbyApp/utils/playerpreferenceutils.h
+++ b/src/qEmbyApp/utils/playerpreferenceutils.h
@@ -5,8 +5,14 @@
 #include <QString>
 #include <QStringList>
 #include <models/media/playbackinfo.h>
+#include <optional>
 
 namespace PlayerPreferenceUtils {
+
+struct RememberedStreamSelection {
+    std::optional<int> audioIndex;
+    std::optional<int> subtitleIndex;
+};
 
 QStringList splitLanguageRules(const QString &rawRules);
 
@@ -17,9 +23,29 @@ int findPreferredStreamIndex(const QList<MediaStreamInfo> &mediaStreams,
                              const QString &streamType,
                              const QString &rawRules);
 
+QList<int> preferredStreamOrder(const QList<MediaStreamInfo> &mediaStreams,
+                                const QString &streamType,
+                                const QString &rawRules);
+
 void applyPreferredStreamRules(MediaSourceInfo &selectedSource,
                                const QString &audioRules,
-                               const QString &subtitleRules);
+                               const QString &subtitleRules,
+                               const RememberedStreamSelection &remembered = {});
+
+RememberedStreamSelection validatedRememberedStreamSelection(
+    const QString &serverId, const QString &mediaId,
+    const MediaSourceInfo &mediaSource);
+void rememberAudioStreamIndex(const QString &serverId, const QString &mediaId,
+                              const QString &mediaSourceId, int streamIndex);
+void rememberSubtitleStreamIndex(const QString &serverId,
+                                 const QString &mediaId,
+                                 const QString &mediaSourceId,
+                                 int streamIndex);
+
+void applyRememberedOrPreferredStreamRules(
+    MediaSourceInfo &selectedSource, const QString &serverId,
+    const QString &mediaId, const QString &audioRules,
+    const QString &subtitleRules);
 
 QStringList mpvLanguageCodesForRules(const QString &rawRules);
 

--- a/src/qEmbyApp/utils/resumeitemresolver.cpp
+++ b/src/qEmbyApp/utils/resumeitemresolver.cpp
@@ -1,0 +1,298 @@
+#include "resumeitemresolver.h"
+
+#include "mediaitemutils.h"
+
+#include <QDebug>
+#include <QPointer>
+#include <QSet>
+#include <QStringList>
+
+#include <services/media/mediaservice.h>
+
+#include <exception>
+#include <utility>
+#include <vector>
+
+QList<MediaItem> ResumeItemResolver::buildFallbackItems(
+    QList<MediaItem> rawItems,
+    const QString &context)
+{
+    QList<MediaItem> displayItems;
+    displayItems.reserve(rawItems.size());
+
+    QSet<QString> seenSeriesIds;
+    int duplicateEpisodeCount = 0;
+    int fallbackWithoutImageCount = 0;
+
+    for (const MediaItem &item : std::as_const(rawItems))
+    {
+        const QString seriesId = item.seriesId.trimmed();
+        if (item.type == QStringLiteral("Episode") && !seriesId.isEmpty())
+        {
+            if (seenSeriesIds.contains(seriesId))
+            {
+                ++duplicateEpisodeCount;
+                continue;
+            }
+
+            seenSeriesIds.insert(seriesId);
+
+            
+            
+            
+            
+            MediaItem fallbackItem = item;
+            fallbackItem.id = seriesId;
+            fallbackItem.type = QStringLiteral("Series");
+            if (!item.seriesName.trimmed().isEmpty())
+            {
+                fallbackItem.name = item.seriesName.trimmed();
+            }
+            fallbackItem.seriesId.clear();
+            fallbackItem.seriesName.clear();
+            fallbackItem.parentIndexNumber = -1;
+            fallbackItem.indexNumber = -1;
+            fallbackItem.userData = MediaUserDataInfo {};
+
+            MediaImageInfo seriesImages;
+            seriesImages.primaryTag = item.images.parentPrimaryTag;
+            seriesImages.thumbTag = item.images.parentThumbTag;
+            seriesImages.backdropTag = item.images.parentBackdropTag;
+            seriesImages.primaryImageItemId = seriesId;
+            if (seriesImages.primaryTag.isEmpty() &&
+                seriesImages.thumbTag.isEmpty() &&
+                seriesImages.backdropTag.isEmpty())
+            {
+                ++fallbackWithoutImageCount;
+            }
+            fallbackItem.images = std::move(seriesImages);
+            fallbackItem.isResumeDisplayFallback = true;
+            displayItems.append(MediaItemUtils::withResumeContext(
+                std::move(fallbackItem), item));
+            continue;
+        }
+
+        displayItems.append(MediaItemUtils::withResumeContext(item, item));
+    }
+
+    QString logContext = context.trimmed();
+    if (logContext.isEmpty())
+    {
+        logContext = QStringLiteral("unknown");
+    }
+
+    qDebug() << "[ResumeItemResolver] built fallback items"
+             << "| context=" << logContext
+             << "| raw=" << rawItems.size()
+             << "| duplicateEpisodes=" << duplicateEpisodeCount
+             << "| fallbacksWithoutImage=" << fallbackWithoutImageCount
+             << "| display=" << displayItems.size();
+
+    return displayItems;
+}
+
+QCoro::Task<QList<MediaItem>> ResumeItemResolver::enrichSeriesCards(
+    MediaService *mediaService,
+    QList<MediaItem> displayItems,
+    QString context)
+{
+    QList<int> seriesDisplayIndexes;
+    QList<MediaItem> seriesResumeItems;
+    QStringList seriesIds;
+
+    for (int i = 0; i < displayItems.size(); ++i)
+    {
+        const MediaItem &item = displayItems.at(i);
+        QString seriesId;
+        if (item.isResumeDisplayFallback &&
+            item.type == QStringLiteral("Series"))
+        {
+            seriesId = item.id.trimmed();
+        }
+        else if (item.type == QStringLiteral("Episode"))
+        {
+            seriesId = item.seriesId.trimmed();
+        }
+
+        if (seriesId.isEmpty())
+        {
+            continue;
+        }
+
+        seriesDisplayIndexes.append(i);
+        seriesIds.append(seriesId);
+
+        MediaItem resumeItem = item;
+        if (item.hasResumeContext && !item.resumeItemId.trimmed().isEmpty())
+        {
+            resumeItem.id = item.resumeItemId.trimmed();
+            resumeItem.userData = item.resumeUserData;
+        }
+        seriesResumeItems.append(std::move(resumeItem));
+    }
+
+    context = context.trimmed();
+    if (context.isEmpty())
+    {
+        context = QStringLiteral("unknown");
+    }
+
+    qDebug() << "[ResumeItemResolver] enriching series cards"
+             << "| context=" << context
+             << "| display=" << displayItems.size()
+             << "| seriesCandidates=" << seriesResumeItems.size();
+
+    QPointer<MediaService> serviceGuard(mediaService);
+    int resolvedSeriesCount = 0;
+    int fallbackSeriesCount = 0;
+
+    std::vector<QCoro::Task<MediaItem>> detailTasks;
+    detailTasks.reserve(seriesResumeItems.size());
+    if (!serviceGuard)
+    {
+        fallbackSeriesCount = seriesResumeItems.size();
+        qWarning() << "[ResumeItemResolver] media service is unavailable; "
+                      "keeping projected series fallbacks"
+                   << "| context=" << context
+                   << "| fallbackSeries=" << fallbackSeriesCount;
+        co_return displayItems;
+    }
+
+    for (const QString &seriesId : std::as_const(seriesIds))
+    {
+        detailTasks.push_back(serviceGuard->getItemDetail(seriesId));
+    }
+
+    for (int i = 0; i < static_cast<int>(detailTasks.size()); ++i)
+    {
+        const MediaItem resumeItem = seriesResumeItems.at(i);
+        const QString seriesId = seriesIds.at(i);
+        const int displayIndex = seriesDisplayIndexes.at(i);
+
+        if (!serviceGuard)
+        {
+            fallbackSeriesCount += seriesResumeItems.size() - i;
+            qWarning() << "[ResumeItemResolver] media service was destroyed; "
+                          "keeping remaining projected series fallbacks"
+                       << "| context=" << context
+                       << "| remaining=" << seriesResumeItems.size() - i;
+            break;
+        }
+
+        try
+        {
+            MediaItem seriesItem = co_await std::move(detailTasks[i]);
+            if (!serviceGuard)
+            {
+                fallbackSeriesCount += seriesResumeItems.size() - i;
+                qWarning() << "[ResumeItemResolver] media service was destroyed "
+                              "during series resolution; keeping projected "
+                              "series fallbacks"
+                           << "| context=" << context
+                           << "| remaining=" << seriesResumeItems.size() - i;
+                break;
+            }
+
+            if (seriesItem.id.trimmed().isEmpty())
+            {
+                ++fallbackSeriesCount;
+                qWarning() << "[ResumeItemResolver] series detail returned an "
+                              "empty id; keeping projected series fallback"
+                           << "| context=" << context
+                           << "| seriesId=" << seriesId
+                           << "| resumeItemId=" << resumeItem.id;
+                continue;
+            }
+
+            displayItems[displayIndex] =
+                MediaItemUtils::withResumeContext(std::move(seriesItem),
+                                                  resumeItem);
+            ++resolvedSeriesCount;
+        }
+        catch (const std::exception &e)
+        {
+            ++fallbackSeriesCount;
+            qWarning() << "[ResumeItemResolver] failed to resolve series; "
+                          "keeping projected series fallback"
+                       << "| context=" << context
+                       << "| seriesId=" << seriesId
+                       << "| resumeItemId=" << resumeItem.id
+                       << "| error=" << e.what();
+        }
+        catch (...)
+        {
+            ++fallbackSeriesCount;
+            qWarning() << "[ResumeItemResolver] failed to resolve series with "
+                          "an unknown error; keeping projected series fallback"
+                       << "| context=" << context
+                       << "| seriesId=" << seriesId
+                       << "| resumeItemId=" << resumeItem.id;
+        }
+    }
+
+    qDebug() << "[ResumeItemResolver] resolution complete"
+             << "| context=" << context
+             << "| display=" << displayItems.size()
+             << "| resolvedSeries=" << resolvedSeriesCount
+             << "| fallbackSeries=" << fallbackSeriesCount;
+
+    co_return displayItems;
+}
+
+QList<MediaItem> ResumeItemResolver::preserveExistingResolvedCards(
+    QList<MediaItem> refreshedItems,
+    QList<MediaItem> existingItems,
+    const QString &context)
+{
+    int preservedCount = 0;
+
+    for (MediaItem &refreshedItem : refreshedItems)
+    {
+        if (!refreshedItem.isResumeDisplayFallback)
+        {
+            continue;
+        }
+
+        for (const MediaItem &existingItem : std::as_const(existingItems))
+        {
+            if (existingItem.id.trimmed() != refreshedItem.id.trimmed() ||
+                existingItem.isResumeDisplayFallback)
+            {
+                continue;
+            }
+
+            MediaItem resumeItem;
+            resumeItem.id = refreshedItem.resumeItemId.trimmed();
+            resumeItem.userData = refreshedItem.resumeUserData;
+            refreshedItem = MediaItemUtils::withResumeContext(existingItem,
+                                                               resumeItem);
+            ++preservedCount;
+            break;
+        }
+    }
+
+    QString logContext = context.trimmed();
+    if (logContext.isEmpty())
+    {
+        logContext = QStringLiteral("unknown");
+    }
+
+    qDebug() << "[ResumeItemResolver] preserved existing resolved cards"
+             << "| context=" << logContext
+             << "| existing=" << existingItems.size()
+             << "| refreshed=" << refreshedItems.size()
+             << "| preserved=" << preservedCount;
+
+    return refreshedItems;
+}
+
+QCoro::Task<QList<MediaItem>> ResumeItemResolver::resolve(
+    MediaService *mediaService,
+    QList<MediaItem> rawItems,
+    QString context)
+{
+    QList<MediaItem> displayItems =
+        buildFallbackItems(std::move(rawItems), context);
+    co_return co_await enrichSeriesCards(
+        mediaService, std::move(displayItems), std::move(context));
+}

--- a/src/qEmbyApp/utils/resumeitemresolver.h
+++ b/src/qEmbyApp/utils/resumeitemresolver.h
@@ -1,0 +1,32 @@
+#ifndef RESUMEITEMRESOLVER_H
+#define RESUMEITEMRESOLVER_H
+
+#include <QList>
+#include <QString>
+
+#include <models/media/mediaitem.h>
+#include <qcorotask.h>
+
+class MediaService;
+
+class ResumeItemResolver
+{
+public:
+    static QList<MediaItem> buildFallbackItems(
+        QList<MediaItem> rawItems,
+        const QString &context);
+    static QCoro::Task<QList<MediaItem>> enrichSeriesCards(
+        MediaService *mediaService,
+        QList<MediaItem> displayItems,
+        QString context);
+    static QList<MediaItem> preserveExistingResolvedCards(
+        QList<MediaItem> refreshedItems,
+        QList<MediaItem> existingItems,
+        const QString &context);
+    static QCoro::Task<QList<MediaItem>> resolve(
+        MediaService *mediaService,
+        QList<MediaItem> rawItems,
+        QString context);
+};
+
+#endif 

--- a/src/qEmbyApp/views/admin/manageview.cpp
+++ b/src/qEmbyApp/views/admin/manageview.cpp
@@ -128,7 +128,9 @@ void ManageView::setupUi() {
         page->setAttribute(Qt::WA_StyledBackground, true);
 
         auto *scroll = new QScrollArea();
-        scroll->setObjectName("SettingsScrollArea");
+        
+        
+        scroll->setObjectName("ManagePageScrollArea");
         scroll->setWidget(page);
         scroll->setWidgetResizable(true);
         scroll->setFrameShape(QFrame::NoFrame);
@@ -164,7 +166,13 @@ void ManageView::setupUi() {
     m_scrollAreas.append(transcodingPage->scrollArea());
     transcodingPage->scrollArea()->viewport()->installEventFilter(this);
 
-    m_stack->addWidget(wrapInScrollArea(new PageUsers(m_core, m_stack)));
+    
+    
+    auto *usersPage = new PageUsers(m_core, m_stack);
+    usersPage->setAttribute(Qt::WA_StyledBackground, true);
+    m_stack->addWidget(usersPage);
+    m_scrollAreas.append(usersPage->scrollArea());
+    usersPage->scrollArea()->viewport()->installEventFilter(this);
 
     auto *taskPage = new PageTasks(m_core, m_stack);
     taskPage->setAttribute(Qt::WA_StyledBackground, true);

--- a/src/qEmbyApp/views/admin/pageusers.h
+++ b/src/qEmbyApp/views/admin/pageusers.h
@@ -15,6 +15,7 @@ class PageUsers : public ManagePageBase {
     Q_OBJECT
 public:
     explicit PageUsers(QEmbyCore* core, QWidget* parent = nullptr);
+    QScrollArea* scrollArea() const { return m_scrollArea; }
 
 protected:
     void showEvent(QShowEvent* event) override;

--- a/src/qEmbyApp/views/baseview.cpp
+++ b/src/qEmbyApp/views/baseview.cpp
@@ -7,6 +7,7 @@
 #include <config/config_keys.h>
 #include <config/configstore.h>
 #include <models/media/playerlaunchcontext.h>
+#include <models/media/playbackinfo.h>
 #include "../components/addtoplaylistdialog.h"
 #include "../components/librarymetadataeditdialog.h"
 #include "../components/mediaidentifydialog.h"
@@ -33,13 +34,16 @@
 
 namespace {
 
-int resolvePreferredMediaSourceIndex(const QList<MediaSourceInfo>& mediaSources)
+int resolvePreferredMediaSourceIndex(const QList<MediaSourceInfo>& mediaSources,
+                                     const QString& serverId,
+                                     const QString& mediaId)
 {
     return MediaSourcePreferenceUtils::resolvePreferredMediaSourceIndex(
         mediaSources,
         ConfigStore::instance()
             ->get<QString>(ConfigKeys::PlayerPreferredVersion)
-            .trimmed());
+            .trimmed(),
+        MediaSourcePreferenceUtils::rememberedMediaSourceId(serverId, mediaId));
 }
 
 } 
@@ -119,6 +123,20 @@ QCoro::Task<MediaItem> BaseView::resolvePlaybackItem(MediaItem item)
         }
     }
 
+    
+    
+    
+    if (detail.mediaSources.size() > 1) {
+        PlaybackInfo playbackInfo =
+            co_await m_core->mediaService()->getPlaybackInfo(detail.id);
+        if (!safeThis) {
+            co_return {};
+        }
+        if (!playbackInfo.mediaSources.isEmpty()) {
+            detail.mediaSources = playbackInfo.mediaSources;
+        }
+    }
+
     co_return detail;
 }
 
@@ -169,11 +187,15 @@ QCoro::Task<void> BaseView::executePlay(MediaItem item)
         QString streamUrl;
 
         if (!detail.mediaSources.isEmpty()) {
+            const QString serverId =
+                m_core->serverManager() ? m_core->serverManager()->activeProfile().id
+                                        : QString();
             const int bestSourceIdx =
-                resolvePreferredMediaSourceIndex(detail.mediaSources);
+                resolvePreferredMediaSourceIndex(detail.mediaSources, serverId,
+                                                 detail.id);
             MediaSourceInfo selectedSource = detail.mediaSources[bestSourceIdx];
-            PlayerPreferenceUtils::applyPreferredStreamRules(
-                selectedSource,
+            PlayerPreferenceUtils::applyRememberedOrPreferredStreamRules(
+                selectedSource, serverId, detail.id,
                 ConfigStore::instance()->get<QString>(
                     ConfigKeys::PlayerAudioLang, "auto"),
                 ConfigStore::instance()->get<QString>(
@@ -214,11 +236,14 @@ QCoro::Task<void> BaseView::executeExternalPlay(MediaItem item,
             co_return;
         }
 
-        const int bestSourceIdx =
-            resolvePreferredMediaSourceIndex(detail.mediaSources);
+        const QString serverId =
+            m_core->serverManager() ? m_core->serverManager()->activeProfile().id
+                                    : QString();
+        const int bestSourceIdx = resolvePreferredMediaSourceIndex(
+            detail.mediaSources, serverId, detail.id);
         MediaSourceInfo selectedSource = detail.mediaSources[bestSourceIdx];
-        PlayerPreferenceUtils::applyPreferredStreamRules(
-            selectedSource,
+        PlayerPreferenceUtils::applyRememberedOrPreferredStreamRules(
+            selectedSource, serverId, detail.id,
             ConfigStore::instance()->get<QString>(
                 ConfigKeys::PlayerAudioLang, "auto"),
             ConfigStore::instance()->get<QString>(

--- a/src/qEmbyApp/views/media/detailview.cpp
+++ b/src/qEmbyApp/views/media/detailview.cpp
@@ -11,8 +11,8 @@
 #include "../../components/moderntoast.h"
 #include "../../managers/playbackmanager.h"
 #include "../../managers/thememanager.h"
-#include "../../utils/mediaitemutils.h"
 #include "../../utils/detailcacheutils.h"
+#include "../../utils/mediaitemutils.h"
 #include "../../utils/mediasourcepreferenceutils.h"
 #include "../../utils/numberextractor.h"
 #include "../../utils/playerpreferenceutils.h"
@@ -33,8 +33,8 @@
 #include <QGraphicsDropShadowEffect>
 #include <QGridLayout>
 #include <QGuiApplication>
-#include <QHash>
 #include <QHBoxLayout>
+#include <QHash>
 #include <QIcon>
 #include <QImage>
 #include <QIntValidator>
@@ -59,3714 +59,3974 @@
 
 #include <optional>
 
-namespace {
+namespace
+{
 
-QWidget *createTransparentReserveWidget(QWidget *parent, const char *objectName,
-                                        int height) {
-  auto *widget = new QWidget(parent);
-  widget->setObjectName(QString::fromLatin1(objectName));
-  widget->setFixedHeight(height);
-  widget->hide();
-  return widget;
+QString activeServerId(QEmbyCore *core)
+{
+    return core && core->serverManager() ? core->serverManager()->activeProfile().id : QString();
 }
 
-int reserveHeightFor(QWidget *widget, int fallbackHeight) {
-  if (!widget)
-    return fallbackHeight;
-
-  const int hintHeight = widget->sizeHint().height();
-  return qMax(fallbackHeight, hintHeight);
+int preferredSourceIndex(QEmbyCore *core, const MediaItem &item)
+{
+    return MediaSourcePreferenceUtils::resolvePreferredMediaSourceIndex(
+        item.mediaSources,
+        ConfigStore::instance()->get<QString>(ConfigKeys::PlayerPreferredVersion).trimmed(),
+        MediaSourcePreferenceUtils::rememberedMediaSourceId(activeServerId(core), item.id));
 }
 
-void showReserveWidget(QWidget *reserve, int height = -1) {
-  if (!reserve)
-    return;
-  if (height > 0 && reserve->height() != height)
-    reserve->setFixedHeight(height);
-  reserve->show();
+QWidget *createTransparentReserveWidget(QWidget *parent, const char *objectName, int height)
+{
+    auto *widget = new QWidget(parent);
+    widget->setObjectName(QString::fromLatin1(objectName));
+    widget->setFixedHeight(height);
+    widget->hide();
+    return widget;
 }
 
-void hideReserveWidget(QWidget *reserve) {
-  if (reserve)
-    reserve->hide();
+int reserveHeightFor(QWidget *widget, int fallbackHeight)
+{
+    if (!widget)
+        return fallbackHeight;
+
+    const int hintHeight = widget->sizeHint().height();
+    return qMax(fallbackHeight, hintHeight);
 }
 
-void prepareReservedSection(QWidget *reserve, MediaSectionWidget *section,
-                            int height = -1) {
-  showReserveWidget(reserve, height);
-  if (section)
-    section->clear();
+void showReserveWidget(QWidget *reserve, int height = -1)
+{
+    if (!reserve)
+        return;
+    if (height > 0 && reserve->height() != height)
+        reserve->setFixedHeight(height);
+    reserve->show();
 }
 
-void applyReservedSectionItems(QWidget *reserve, MediaSectionWidget *section,
-                               const QList<MediaItem> &items) {
-  if (!section) {
+void hideReserveWidget(QWidget *reserve)
+{
+    if (reserve)
+        reserve->hide();
+}
+
+void prepareReservedSection(QWidget *reserve, MediaSectionWidget *section, int height = -1)
+{
+    showReserveWidget(reserve, height);
+    if (section)
+        section->clear();
+}
+
+void applyReservedSectionItems(QWidget *reserve, MediaSectionWidget *section, const QList<MediaItem> &items)
+{
+    if (!section)
+    {
+        hideReserveWidget(reserve);
+        return;
+    }
+
+    if (items.isEmpty())
+    {
+        section->clear();
+        hideReserveWidget(reserve);
+        return;
+    }
+
     hideReserveWidget(reserve);
-    return;
-  }
-
-  if (items.isEmpty()) {
-    section->clear();
-    hideReserveWidget(reserve);
-    return;
-  }
-
-  hideReserveWidget(reserve);
-  section->setItems(items);
+    section->setItems(items);
 }
 
 
 
 
 
-
-
-QString computeSourcesFingerprint(const QList<MediaSourceInfo> &sources) {
-  if (sources.isEmpty())
-    return QStringLiteral("<empty>");
-  QStringList parts;
-  parts.reserve(sources.size());
-  for (const auto &src : sources) {
-    QStringList streamParts;
-    streamParts.reserve(src.mediaStreams.size());
-    for (const auto &s : src.mediaStreams) {
-      streamParts << QStringLiteral("%1:%2:%3:%4")
-                         .arg(s.type, QString::number(s.index), s.codec,
-                              s.language);
+QString computeSourcesFingerprint(const QList<MediaSourceInfo> &sources)
+{
+    if (sources.isEmpty())
+        return QStringLiteral("<empty>");
+    QStringList parts;
+    parts.reserve(sources.size());
+    for (const auto &src : sources)
+    {
+        QStringList streamParts;
+        streamParts.reserve(src.mediaStreams.size());
+        for (const auto &s : src.mediaStreams)
+        {
+            streamParts << QStringLiteral("%1:%2:%3:%4:%5:%6:%7:%8:%9:%10:%11")
+                               .arg(s.type)
+                               .arg(s.index)
+                               .arg(s.codec)
+                               .arg(s.language)
+                               .arg(s.title)
+                               .arg(s.displayTitle)
+                               .arg(s.profile)
+                               .arg(s.width)
+                               .arg(s.height)
+                               .arg(s.bitRate)
+                               .arg(s.realFrameRate);
+        }
+        parts << QStringLiteral("%1#%2#%3#%4#%5#%6#%7#%8#%9")
+                     .arg(src.id)
+                     .arg(src.name)
+                     .arg(src.path)
+                     .arg(src.container)
+                     .arg(src.size)
+                     .arg(src.dateCreated.toString(Qt::ISODateWithMs))
+                     .arg(src.dateModified.toString(Qt::ISODateWithMs))
+                     .arg(src.mediaStreams.size())
+                     .arg(streamParts.join(QLatin1Char('|')));
     }
-    parts << QStringLiteral("%1#%2#%3")
-                 .arg(src.id, QString::number(src.mediaStreams.size()),
-                      streamParts.join(QLatin1Char('|')));
-  }
-  return parts.join(QLatin1Char(';'));
+    return parts.join(QLatin1Char(';'));
 }
 
 
 
 
-QString computeBottomInfoFingerprint(const MediaItem &item,
-                                     const QList<MediaSourceInfo> &sources) {
-  QStringList studioParts;
-  studioParts.reserve(item.studios.size());
-  for (const auto &s : item.studios)
-    studioParts << s.name;
+QString computeBottomInfoFingerprint(const MediaItem &item, const QList<MediaSourceInfo> &sources)
+{
+    QStringList studioParts;
+    studioParts.reserve(item.studios.size());
+    for (const auto &s : item.studios)
+        studioParts << s.name;
 
-  QStringList urlParts;
-  urlParts.reserve(item.externalUrls.size());
-  for (const auto &u : item.externalUrls)
-    urlParts << (u.name + QLatin1Char('=') + u.url);
+    QStringList urlParts;
+    urlParts.reserve(item.externalUrls.size());
+    for (const auto &u : item.externalUrls)
+        urlParts << (u.name + QLatin1Char('=') + u.url);
 
-  return QStringLiteral("%1|tags=%2|studios=%3|urls=%4|src=%5")
-      .arg(item.id, item.tags.join(QLatin1Char(',')),
-           studioParts.join(QLatin1Char(',')),
-           urlParts.join(QLatin1Char(',')), computeSourcesFingerprint(sources));
+    return QStringLiteral("%1|tags=%2|studios=%3|urls=%4|src=%5")
+        .arg(item.id, item.tags.join(QLatin1Char(',')), studioParts.join(QLatin1Char(',')),
+             urlParts.join(QLatin1Char(',')), computeSourcesFingerprint(sources));
 }
 
-QString formatDetailReleaseDate(const MediaItem &item) {
-  QString dateText = item.premiereDate.trimmed();
-  if (!dateText.isEmpty()) {
-    const int timeSeparator = dateText.indexOf(QLatin1Char('T'));
-    if (timeSeparator > 0)
-      dateText = dateText.left(timeSeparator);
+QString formatDetailReleaseDate(const MediaItem &item)
+{
+    QString dateText = item.premiereDate.trimmed();
+    if (!dateText.isEmpty())
+    {
+        const int timeSeparator = dateText.indexOf(QLatin1Char('T'));
+        if (timeSeparator > 0)
+            dateText = dateText.left(timeSeparator);
 
-    
-    const int dateLen = dateText.length();
-    if (dateLen > 0) {
-      const QString dateOnly = dateText.left(qMin(dateLen, 10));
-      const QDate date = QDate::fromString(dateOnly, Qt::ISODate);
-      if (date.isValid())
-        return date.toString(QStringLiteral("yyyy-MM-dd"));
-      return dateOnly;
+        
+        const int dateLen = dateText.length();
+        if (dateLen > 0)
+        {
+            const QString dateOnly = dateText.left(qMin(dateLen, 10));
+            const QDate date = QDate::fromString(dateOnly, Qt::ISODate);
+            if (date.isValid())
+                return date.toString(QStringLiteral("yyyy-MM-dd"));
+            return dateOnly;
+        }
     }
-  }
 
-  if (item.productionYear > 0)
-    return QString::number(item.productionYear);
+    if (item.productionYear > 0)
+        return QString::number(item.productionYear);
 
-  return QString();
+    return QString();
 }
 
-QString formatEpisodeTag(const MediaItem &item) {
-  QString tag;
-  if (item.parentIndexNumber >= 0) {
-    tag += QStringLiteral("S%1").arg(item.parentIndexNumber, 2, 10,
-                                     QLatin1Char('0'));
-  }
-  if (item.indexNumber >= 0) {
-    tag += QStringLiteral("E%1").arg(item.indexNumber, 2, 10,
-                                     QLatin1Char('0'));
-  }
-  return tag;
-}
-
-MediaItem resolveSeasonPlaybackEpisode(const QList<MediaItem> &episodes) {
-  for (const MediaItem &episode : episodes) {
-    if (episode.userData.playbackPositionTicks > 0 &&
-        !episode.userData.played && episode.userData.playedPercentage < 99.0) {
-      return episode;
+QString formatEpisodeTag(const MediaItem &item)
+{
+    QString tag;
+    if (item.parentIndexNumber >= 0)
+    {
+        tag += QStringLiteral("S%1").arg(item.parentIndexNumber, 2, 10, QLatin1Char('0'));
     }
-  }
-
-  for (const MediaItem &episode : episodes) {
-    if (!episode.userData.played)
-      return episode;
-  }
-
-  return episodes.isEmpty() ? MediaItem{} : episodes.first();
+    if (item.indexNumber >= 0)
+    {
+        tag += QStringLiteral("E%1").arg(item.indexNumber, 2, 10, QLatin1Char('0'));
+    }
+    return tag;
 }
 
-MediaItem withSeedContext(MediaItem cachedItem, const MediaItem &seedItem) {
-  if (seedItem.id.isEmpty() || seedItem.id != cachedItem.id)
+MediaItem resolveSeasonPlaybackEpisode(const QList<MediaItem> &episodes)
+{
+    for (const MediaItem &episode : episodes)
+    {
+        if (episode.userData.playbackPositionTicks > 0 && !episode.userData.played &&
+            episode.userData.playedPercentage < 99.0)
+        {
+            return episode;
+        }
+    }
+
+    for (const MediaItem &episode : episodes)
+    {
+        if (!episode.userData.played)
+            return episode;
+    }
+
+    return episodes.isEmpty() ? MediaItem{} : episodes.first();
+}
+
+MediaItem withSeedContext(MediaItem cachedItem, const MediaItem &seedItem)
+{
+    if (seedItem.id.isEmpty() || seedItem.id != cachedItem.id)
+        return cachedItem;
+
+    if (cachedItem.name.trimmed().isEmpty())
+        cachedItem.name = seedItem.name;
+    if (cachedItem.type.trimmed().isEmpty())
+        cachedItem.type = seedItem.type;
+    if (cachedItem.mediaType.trimmed().isEmpty())
+        cachedItem.mediaType = seedItem.mediaType;
+    if (cachedItem.overview.trimmed().isEmpty())
+        cachedItem.overview = seedItem.overview;
+    if (cachedItem.genres.isEmpty())
+        cachedItem.genres = seedItem.genres;
+    if (cachedItem.taglines.isEmpty())
+        cachedItem.taglines = seedItem.taglines;
+    if (cachedItem.mediaSources.isEmpty())
+        cachedItem.mediaSources = seedItem.mediaSources;
+    if (cachedItem.images.primaryTag.isEmpty() && cachedItem.images.thumbTag.isEmpty() &&
+        cachedItem.images.backdropTag.isEmpty() && cachedItem.images.logoTag.isEmpty())
+    {
+        cachedItem.images = seedItem.images;
+    }
+
+    cachedItem.playlistId = seedItem.playlistId;
+    cachedItem.playlistItemId = seedItem.playlistItemId;
+    cachedItem.hasResumeContext = seedItem.hasResumeContext;
+    cachedItem.resumeItemId = seedItem.resumeItemId;
+    cachedItem.resumeUserData = seedItem.resumeUserData;
     return cachedItem;
-
-  if (cachedItem.name.trimmed().isEmpty())
-    cachedItem.name = seedItem.name;
-  if (cachedItem.type.trimmed().isEmpty())
-    cachedItem.type = seedItem.type;
-  if (cachedItem.mediaType.trimmed().isEmpty())
-    cachedItem.mediaType = seedItem.mediaType;
-  if (cachedItem.overview.trimmed().isEmpty())
-    cachedItem.overview = seedItem.overview;
-  if (cachedItem.genres.isEmpty())
-    cachedItem.genres = seedItem.genres;
-  if (cachedItem.taglines.isEmpty())
-    cachedItem.taglines = seedItem.taglines;
-  if (cachedItem.mediaSources.isEmpty())
-    cachedItem.mediaSources = seedItem.mediaSources;
-  if (cachedItem.images.primaryTag.isEmpty() &&
-      cachedItem.images.thumbTag.isEmpty() &&
-      cachedItem.images.backdropTag.isEmpty() &&
-      cachedItem.images.logoTag.isEmpty()) {
-    cachedItem.images = seedItem.images;
-  }
-
-  cachedItem.playlistId = seedItem.playlistId;
-  cachedItem.playlistItemId = seedItem.playlistItemId;
-  cachedItem.hasResumeContext = seedItem.hasResumeContext;
-  cachedItem.resumeItemId = seedItem.resumeItemId;
-  cachedItem.resumeUserData = seedItem.resumeUserData;
-  return cachedItem;
 }
 
-bool mediaItemListsEqual(const QList<MediaItem> &left,
-                         const QList<MediaItem> &right) {
-  if (left.size() != right.size())
-    return false;
+bool mediaItemListsEqual(const QList<MediaItem> &left, const QList<MediaItem> &right)
+{
+    if (left.size() != right.size())
+        return false;
 
-  for (int i = 0; i < left.size(); ++i) {
-    if (DetailCacheUtils::fingerprint(left[i]) !=
-        DetailCacheUtils::fingerprint(right[i])) {
-      return false;
+    for (int i = 0; i < left.size(); ++i)
+    {
+        if (DetailCacheUtils::fingerprint(left[i]) != DetailCacheUtils::fingerprint(right[i]))
+        {
+            return false;
+        }
     }
-  }
-  return true;
-}
-
-QCoro::Task<bool> mediaItemListsEqualAsync(QList<MediaItem> left,
-                                           QList<MediaItem> right) {
-  co_return co_await QtConcurrent::run(
-      [left = std::move(left), right = std::move(right)]() mutable {
-        return mediaItemListsEqual(left, right);
-      });
-}
-
-QString castFingerprint(const MediaItem &item) {
-  QStringList parts;
-  parts.reserve(item.people.size());
-  for (const auto &person : item.people) {
-    parts << QStringLiteral("%1:%2:%3:%4")
-                 .arg(person.id, person.name, person.type, person.role);
-  }
-  return parts.join(QLatin1Char('|'));
-}
-
-bool episodesBelongToSeason(const QList<MediaItem> &episodes,
-                            const MediaItem &season) {
-  if (episodes.isEmpty() || season.indexNumber < 0)
     return true;
-
-  for (const MediaItem &episode : episodes) {
-    if (episode.parentIndexNumber < 0)
-      continue;
-    if (episode.parentIndexNumber != season.indexNumber)
-      return false;
-  }
-  return true;
 }
 
-bool cacheEntryHasAnySecondaryData(
-    const DetailCacheUtils::DetailCacheEntry &entry) {
-  return entry.hasPlayableItem || entry.hasSeasons || entry.hasSeasonEpisodes ||
-         entry.hasSimilarItems || entry.hasCollections ||
-         entry.hasAdditionalParts || !entry.item.people.isEmpty();
+QCoro::Task<bool> mediaItemListsEqualAsync(QList<MediaItem> left, QList<MediaItem> right)
+{
+    auto future = QtConcurrent::run(
+        [left = std::move(left), right = std::move(right)]() mutable
+        { return mediaItemListsEqual(left, right); });
+    co_return co_await future;
 }
 
-struct CachedDetailImages {
-  std::optional<QImage> poster;
-  std::optional<QImage> backdrop;
-  std::optional<QImage> logo;
+QString castFingerprint(const MediaItem &item)
+{
+    QStringList parts;
+    parts.reserve(item.people.size());
+    for (const auto &person : item.people)
+    {
+        parts << QStringLiteral("%1:%2:%3:%4").arg(person.id, person.name, person.type, person.role);
+    }
+    return parts.join(QLatin1Char('|'));
+}
+
+bool episodesBelongToSeason(const QList<MediaItem> &episodes, const MediaItem &season)
+{
+    if (episodes.isEmpty() || season.indexNumber < 0)
+        return true;
+
+    for (const MediaItem &episode : episodes)
+    {
+        if (episode.parentIndexNumber < 0)
+            continue;
+        if (episode.parentIndexNumber != season.indexNumber)
+            return false;
+    }
+    return true;
+}
+
+bool cacheEntryHasAnySecondaryData(const DetailCacheUtils::DetailCacheEntry &entry)
+{
+    return entry.hasPlayableItem || entry.hasSeasons || entry.hasSeasonEpisodes || entry.hasSimilarItems ||
+           entry.hasCollections || entry.hasAdditionalParts || !entry.item.people.isEmpty();
+}
+
+struct CachedDetailImages
+{
+    std::optional<QImage> poster;
+    std::optional<QImage> backdrop;
+    std::optional<QImage> logo;
 };
 
-void saveDetailCacheAsync(QString serverId, QString userId, MediaItem item,
-                          QString fingerprint) {
-  if (serverId.isEmpty() || userId.isEmpty() || item.id.isEmpty())
-    return;
+void saveDetailCacheAsync(QString serverId, QString userId, MediaItem item, QString fingerprint)
+{
+    if (serverId.isEmpty() || userId.isEmpty() || item.id.isEmpty())
+        return;
 
-  (void)QtConcurrent::run([serverId = std::move(serverId),
-                           userId = std::move(userId), item = std::move(item),
-                           fingerprint = std::move(fingerprint)]() mutable {
-    QString errorString;
-    const QString itemId = item.id;
-    DetailCacheUtils::DetailCacheEntry entry;
-    const auto existing = DetailCacheUtils::load(serverId, userId, itemId);
-    if (existing.has_value())
-      entry = *existing;
-    entry.item = item;
-    if (entry.hasPlayableItem && !entry.playableItemFromServer) {
-      entry.hasPlayableItem = false;
-      entry.playableItem = MediaItem{};
-    }
-    const bool saved =
-        DetailCacheUtils::save(serverId, userId, entry, &errorString);
-    if (saved) {
-      qDebug() << "[DetailView] Detail cache saved"
-               << "itemId=" << itemId
-               << "fingerprint=" << fingerprint.left(12);
-    } else {
-      qWarning() << "[DetailView] Detail cache save failed"
-                 << "itemId=" << itemId << "error=" << errorString;
-    }
-  });
+    (void)QtConcurrent::run(
+        [serverId = std::move(serverId), userId = std::move(userId), item = std::move(item),
+         fingerprint = std::move(fingerprint)]() mutable
+        {
+            QString errorString;
+            const QString itemId = item.id;
+            DetailCacheUtils::DetailCacheEntry entry;
+            const auto existing = DetailCacheUtils::load(serverId, userId, itemId);
+            if (existing.has_value())
+                entry = *existing;
+            entry.item = item;
+            if (entry.hasPlayableItem && !entry.playableItemFromServer)
+            {
+                entry.hasPlayableItem = false;
+                entry.playableItem = MediaItem{};
+            }
+            const bool saved = DetailCacheUtils::save(serverId, userId, entry, &errorString);
+            if (saved)
+            {
+                qDebug() << "[DetailView] Detail cache saved"
+                         << "itemId=" << itemId << "fingerprint=" << fingerprint.left(12);
+            }
+            else
+            {
+                qWarning() << "[DetailView] Detail cache save failed"
+                           << "itemId=" << itemId << "error=" << errorString;
+            }
+        });
 }
 
-void saveDetailCacheEntryAsync(QString serverId, QString userId,
-                               DetailCacheUtils::DetailCacheEntry entry,
-                               QString reason) {
-  if (serverId.isEmpty() || userId.isEmpty() || entry.item.id.isEmpty())
-    return;
+void saveDetailCacheEntryAsync(QString serverId, QString userId, DetailCacheUtils::DetailCacheEntry entry,
+                               QString reason)
+{
+    if (serverId.isEmpty() || userId.isEmpty() || entry.item.id.isEmpty())
+        return;
 
-  (void)QtConcurrent::run([serverId = std::move(serverId),
-                           userId = std::move(userId), entry = std::move(entry),
-                           reason = std::move(reason)]() mutable {
-    QString errorString;
-    const QString itemId = entry.item.id;
-    const auto existing = DetailCacheUtils::load(serverId, userId, itemId);
-    if (existing.has_value()) {
-      if (!entry.hasPlayableItem && existing->hasPlayableItem &&
-          existing->playableItemFromServer) {
-        entry.hasPlayableItem = true;
-        entry.playableItem = existing->playableItem;
-        entry.playableItemFromServer = true;
-      }
-      if (!entry.hasSeasons && existing->hasSeasons) {
-        entry.hasSeasons = true;
-        entry.seasons = existing->seasons;
-      }
-      if (!entry.hasSeasonEpisodes && existing->hasSeasonEpisodes) {
-        entry.hasSeasonEpisodes = true;
-        entry.seasonEpisodes = existing->seasonEpisodes;
-        entry.seasonIndex = existing->seasonIndex;
-        entry.seasonId = existing->seasonId;
-      }
-      if (!entry.hasSimilarItems && existing->hasSimilarItems) {
-        entry.hasSimilarItems = true;
-        entry.similarItems = existing->similarItems;
-      }
-      if (!entry.hasCollections && existing->hasCollections) {
-        entry.hasCollections = true;
-        entry.collections = existing->collections;
-      }
-      if (!entry.hasAdditionalParts && existing->hasAdditionalParts) {
-        entry.hasAdditionalParts = true;
-        entry.additionalParts = existing->additionalParts;
-      }
-    }
-    if (entry.hasPlayableItem && !entry.playableItemFromServer) {
-      entry.hasPlayableItem = false;
-      entry.playableItem = MediaItem{};
-    }
-    const QString itemFp = DetailCacheUtils::fingerprint(entry.item);
-    const QString sectionsFp = DetailCacheUtils::sectionsFingerprint(entry);
-    const bool saved =
-        DetailCacheUtils::save(serverId, userId, entry, &errorString);
-    if (saved) {
-      qDebug() << "[DetailView] Detail cache snapshot saved"
-               << "itemId=" << itemId << "reason=" << reason
-               << "fingerprint=" << itemFp.left(12)
-               << "sections=" << sectionsFp.left(12);
-    } else {
-      qWarning() << "[DetailView] Detail cache snapshot save failed"
-                 << "itemId=" << itemId << "reason=" << reason
-                 << "error=" << errorString;
-    }
-  });
+    (void)QtConcurrent::run(
+        [serverId = std::move(serverId), userId = std::move(userId), entry = std::move(entry),
+         reason = std::move(reason)]() mutable
+        {
+            QString errorString;
+            const QString itemId = entry.item.id;
+            const auto existing = DetailCacheUtils::load(serverId, userId, itemId);
+            if (existing.has_value())
+            {
+                if (!entry.hasPlayableItem && existing->hasPlayableItem && existing->playableItemFromServer)
+                {
+                    entry.hasPlayableItem = true;
+                    entry.playableItem = existing->playableItem;
+                    entry.playableItemFromServer = true;
+                }
+                if (!entry.hasSeasons && existing->hasSeasons)
+                {
+                    entry.hasSeasons = true;
+                    entry.seasons = existing->seasons;
+                }
+                if (!entry.hasSeasonEpisodes && existing->hasSeasonEpisodes)
+                {
+                    entry.hasSeasonEpisodes = true;
+                    entry.seasonEpisodes = existing->seasonEpisodes;
+                    entry.seasonIndex = existing->seasonIndex;
+                    entry.seasonId = existing->seasonId;
+                }
+                if (!entry.hasSimilarItems && existing->hasSimilarItems)
+                {
+                    entry.hasSimilarItems = true;
+                    entry.similarItems = existing->similarItems;
+                }
+                if (!entry.hasCollections && existing->hasCollections)
+                {
+                    entry.hasCollections = true;
+                    entry.collections = existing->collections;
+                }
+                if (!entry.hasAdditionalParts && existing->hasAdditionalParts)
+                {
+                    entry.hasAdditionalParts = true;
+                    entry.additionalParts = existing->additionalParts;
+                }
+            }
+            if (entry.hasPlayableItem && !entry.playableItemFromServer)
+            {
+                entry.hasPlayableItem = false;
+                entry.playableItem = MediaItem{};
+            }
+            const QString itemFp = DetailCacheUtils::fingerprint(entry.item);
+            const QString sectionsFp = DetailCacheUtils::sectionsFingerprint(entry);
+            const bool saved = DetailCacheUtils::save(serverId, userId, entry, &errorString);
+            if (saved)
+            {
+                qDebug() << "[DetailView] Detail cache snapshot saved"
+                         << "itemId=" << itemId << "reason=" << reason << "fingerprint=" << itemFp.left(12)
+                         << "sections=" << sectionsFp.left(12);
+            }
+            else
+            {
+                qWarning() << "[DetailView] Detail cache snapshot save failed"
+                           << "itemId=" << itemId << "reason=" << reason << "error=" << errorString;
+            }
+        });
 }
 
-void saveDetailImageAsync(QString serverId, QString userId,
-                          QString ownerItemId, QString role,
-                          QString imageItemId, QString imageType,
-                          QString imageTag, int maxWidth, QImage image) {
-  if (serverId.isEmpty() || userId.isEmpty() || ownerItemId.isEmpty() ||
-      imageTag.isEmpty() || image.isNull())
-    return;
+void saveDetailImageAsync(QString serverId, QString userId, QString ownerItemId, QString role, QString imageItemId,
+                          QString imageType, QString imageTag, int maxWidth, QImage image)
+{
+    if (serverId.isEmpty() || userId.isEmpty() || ownerItemId.isEmpty() || imageTag.isEmpty() || image.isNull())
+        return;
 
-  (void)QtConcurrent::run([serverId = std::move(serverId),
-                           userId = std::move(userId),
-                           ownerItemId = std::move(ownerItemId),
-                           role = std::move(role),
-                           imageItemId = std::move(imageItemId),
-                           imageType = std::move(imageType),
-                           imageTag = std::move(imageTag), maxWidth,
-                           image = std::move(image)]() mutable {
-    QString errorString;
-    const bool saved = DetailCacheUtils::saveImage(
-        serverId, userId, ownerItemId, role, imageItemId, imageType, imageTag,
-        maxWidth, image, &errorString);
-    if (!saved) {
-      qWarning() << "[DetailView] Detail image cache save failed"
-                 << "itemId=" << ownerItemId << "role=" << role
-                 << "error=" << errorString;
-    }
-  });
+    (void)QtConcurrent::run(
+        [serverId = std::move(serverId), userId = std::move(userId), ownerItemId = std::move(ownerItemId),
+         role = std::move(role), imageItemId = std::move(imageItemId), imageType = std::move(imageType),
+         imageTag = std::move(imageTag), maxWidth, image = std::move(image)]() mutable
+        {
+            QString errorString;
+            const bool saved = DetailCacheUtils::saveImage(serverId, userId, ownerItemId, role, imageItemId, imageType,
+                                                           imageTag, maxWidth, image, &errorString);
+            if (!saved)
+            {
+                qWarning() << "[DetailView] Detail image cache save failed"
+                           << "itemId=" << ownerItemId << "role=" << role << "error=" << errorString;
+            }
+        });
 }
 
 } 
 
-DetailView::DetailView(QEmbyCore *core, QWidget *parent)
-    : BaseView(core, parent) {
-  setAttribute(Qt::WA_StyledBackground, true);
-  setObjectName("detail-view");
-  setProperty("showGlobalSearch", true);
-  setupUi();
+DetailView::DetailView(QEmbyCore *core, QWidget *parent) : BaseView(core, parent)
+{
+    setAttribute(Qt::WA_StyledBackground, true);
+    setObjectName("detail-view");
+    setProperty("showGlobalSearch", true);
+    setupUi();
 }
 
-void DetailView::scrollToTop() {
-  if (m_mainScrollArea && m_mainScrollArea->verticalScrollBar()) {
-    if (m_vScrollController) {
-      m_vScrollController->scrollTo(0, false);
-    } else {
-      m_mainScrollArea->verticalScrollBar()->setValue(0);
-    }
-  }
-}
-
-void DetailView::setupUi() {
-  auto *mainLayout = new QVBoxLayout(this);
-  mainLayout->setContentsMargins(0, 0, 0, 0);
-
-  m_mainScrollArea = new QScrollArea(this);
-  m_mainScrollArea->setWidgetResizable(true);
-  m_mainScrollArea->setFrameShape(QFrame::NoFrame);
-  m_mainScrollArea->setObjectName("detail-scrollarea");
-  m_mainScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  m_mainScrollArea->setStyleSheet("QScrollArea { background: transparent; }");
-
-  m_vScrollController =
-      new SmoothScrollController(m_mainScrollArea->verticalScrollBar(), this);
-  m_vScrollController->setDuration(170);
-
-  m_contentWidget = new DetailContentWidget(m_mainScrollArea);
-  m_contentWidget->setObjectName("detail-content-container");
-
-  auto *contentLayout = new QVBoxLayout(m_contentWidget);
-  contentLayout->setContentsMargins(0, 0, 0, 10);
-  contentLayout->setSpacing(0);
-
-  QWidget *infoContainer = new QWidget(m_contentWidget);
-  infoContainer->setObjectName("detail-info-container");
-  infoContainer->setStyleSheet(
-      "QWidget#detail-info-container { background: transparent; }");
-
-  m_infoLayout = new QGridLayout(infoContainer);
-  m_infoLayout->setContentsMargins(40, 40, 40, 0);
-  m_infoLayout->setHorizontalSpacing(40);
-  m_infoLayout->setVerticalSpacing(0);
-  m_infoLayout->setRowMinimumHeight(0, 110);
-
-  m_logoLabel = new QLabel(infoContainer);
-  m_logoLabel->setObjectName("detail-logo-label");
-  m_logoLabel->setAlignment(Qt::AlignRight | Qt::AlignTop);
-  m_infoLayout->addWidget(m_logoLabel, 0, 1, 1, 2,
-                          Qt::AlignRight | Qt::AlignTop);
-
-  m_posterLabel = new QLabel(infoContainer);
-  m_posterLabel->setFixedSize(250, 375);
-  m_posterLabel->setObjectName("detail-poster-label");
-  m_posterLabel->setAlignment(Qt::AlignCenter);
-
-  
-  
-  
-  m_posterShadow = new QGraphicsDropShadowEffect(this);
-  m_posterShadow->setBlurRadius(20);
-  m_posterShadow->setColor(QColor(0, 0, 0, 80));
-  m_posterShadow->setOffset(0, 8);
-  m_posterShadow->setEnabled(false);
-  m_posterLabel->setGraphicsEffect(m_posterShadow);
-  m_infoLayout->addWidget(m_posterLabel, 1, 0, 1, 1, Qt::AlignTop);
-
-  m_textContainer = new QWidget(infoContainer);
-  m_textContainer->setMaximumWidth(1200);
-  m_textContainer->setSizePolicy(QSizePolicy::Expanding,
-                                 QSizePolicy::Preferred);
-  auto *textLayout = new QVBoxLayout(m_textContainer);
-  textLayout->setContentsMargins(0, 0, 0, 0);
-  textLayout->setSpacing(10);
-  textLayout->setAlignment(Qt::AlignTop);
-
-  m_titleLabel = new QLabel(m_textContainer);
-  m_titleLabel->setObjectName("detail-title");
-  m_titleLabel->setWordWrap(true);
-
-  m_metaRowWidget = new QWidget(m_textContainer);
-  m_metaRowWidget->setObjectName("detail-meta-row");
-  auto *metaLayout = new QHBoxLayout(m_metaRowWidget);
-  metaLayout->setContentsMargins(0, 0, 0, 0);
-  metaLayout->setSpacing(6);
-
-  m_ratingStarLabel = new QLabel(m_metaRowWidget);
-  m_ratingStarLabel->setFixedWidth(16);
-  m_ratingStarLabel->setAlignment(Qt::AlignCenter);
-  m_ratingStarLabel->setPixmap(
-      QIcon(":/svg/dark/star-filled.svg").pixmap(16, 16));
-  m_ratingStarLabel->setContentsMargins(0, 2, 0, 0);
-  m_ratingStarLabel->hide();
-
-  m_metaLabel = new QLabel(m_metaRowWidget);
-  m_metaLabel->setObjectName("detail-meta");
-  m_metaLabel->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
-
-  m_numberButton = new QPushButton(m_metaRowWidget);
-  m_numberButton->setObjectName("detail-number-chip");
-  m_numberButton->setCursor(Qt::PointingHandCursor);
-  m_numberButton->setFocusPolicy(Qt::NoFocus);
-  m_numberButton->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed);
-  m_numberButton->hide();
-  connect(m_numberButton, &QPushButton::clicked, this,
-          &DetailView::copyDisplayedNumber);
-
-  metaLayout->addWidget(m_ratingStarLabel);
-  metaLayout->addWidget(m_metaLabel, 0, Qt::AlignLeft);
-  metaLayout->addWidget(m_numberButton, 0, Qt::AlignLeft);
-  metaLayout->addStretch(1);
-  m_metaRowWidget->hide();
-
-  m_tagsWidget = new QWidget(m_textContainer);
-  m_tagsWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
-  m_tagsLayout = new FlowLayout(m_tagsWidget, 0, 8, 8);
-
-  m_actionWidget = new DetailActionWidget(m_textContainer);
-  connect(m_actionWidget, &DetailActionWidget::playRequested, this,
-          [this]() -> QCoro::Task<void> {
-            co_await executePlay(m_currentPlayableItem, 0);
-          });
-  connect(m_actionWidget, &DetailActionWidget::resumeRequested, this,
-          [this]() -> QCoro::Task<void> {
-            co_await executePlay(
-                m_currentPlayableItem,
-                m_currentPlayableItem.userData.playbackPositionTicks);
-          });
-  connect(m_actionWidget, &DetailActionWidget::favoriteRequested, this,
-          [this]() {
-            if (!m_currentMediaItem.id.isEmpty())
-              handleFavoriteRequested(m_currentMediaItem);
-          });
-  connect(m_actionWidget, &DetailActionWidget::playedToggleRequested, this,
-          [this]() {
-            const MediaItem &target =
-                m_currentPlayableItem.type == "Episode" ? m_currentPlayableItem
-                                                        : m_currentMediaItem;
-            if (target.id.isEmpty())
-              return;
-            if (target.userData.played)
-              handleMarkUnplayedRequested(target);
-            else
-              handleMarkPlayedRequested(target);
-          });
-  connect(ThemeManager::instance(), &ThemeManager::themeChanged, this,
-          [this]() {
-            const MediaItem &target =
-                m_currentPlayableItem.type == "Episode" ? m_currentPlayableItem
-                                                        : m_currentMediaItem;
-            if (!target.id.isEmpty())
-              m_actionWidget->setPlayedState(target.userData.played);
-          });
-  connect(m_actionWidget, &DetailActionWidget::sourceVersionChanged, this,
-          &DetailView::onVersionChanged);
-  connect(m_actionWidget, &DetailActionWidget::externalPlayRequested, this,
-          [this](const QString &playerPath) -> QCoro::Task<void> {
-            co_await executeExternalPlay(m_currentPlayableItem, playerPath);
-          });
-
-  m_taglineLabel = new QLabel(m_textContainer);
-  m_taglineLabel->setObjectName("detail-tagline");
-
-  m_overviewLabel = new QLabel(m_textContainer);
-  m_overviewLabel->setObjectName("detail-overview");
-  m_overviewLabel->setWordWrap(true);
-  m_overviewLabel->setSizePolicy(QSizePolicy::Preferred,
-                                 QSizePolicy::Preferred);
-  m_overviewLabel->setAlignment(Qt::AlignTop | Qt::AlignLeft);
-  m_overviewLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
-  connect(m_overviewLabel, &QLabel::linkActivated, this,
-          &DetailView::onOverviewMoreClicked);
-
-  textLayout->addWidget(m_titleLabel);
-  textLayout->addWidget(m_metaRowWidget);
-  textLayout->addWidget(m_tagsWidget);
-  textLayout->addWidget(m_actionWidget);
-  textLayout->addSpacing(4);
-  textLayout->addWidget(m_taglineLabel);
-  textLayout->addWidget(m_overviewLabel);
-  textLayout->addSpacing(10);
-
-  m_infoLayout->addWidget(m_textContainer, 1, 1, 1, 1, Qt::AlignTop);
-  m_infoLayout->setColumnStretch(0, 0);
-  m_infoLayout->setColumnStretch(1, 10);
-  m_infoLayout->setColumnStretch(2, 1);
-  contentLayout->addWidget(infoContainer);
-
-  
-  
-  
-  m_seasonWidget =
-      new MediaSectionWidget(tr("Seasons"), m_core, m_contentWidget);
-  m_seasonWidget->setCardStyle(MediaCardDelegate::Poster);
-  m_seasonWidget->setGalleryHeight(300);
-
-  
-  m_episodeWidget =
-      new MediaSectionWidget(tr("Episodes"), m_core, m_contentWidget);
-  m_episodeWidget->setCardStyle(MediaCardDelegate::LibraryTile);
-  m_episodeWidget->gallery()->setHoverControls(
-      MediaCardDelegate::HoverControlPlay |
-      MediaCardDelegate::HoverControlMore);
-  
-  
-  {
-    int imgH = 100;
-    int imgW = qRound(imgH * 16.0 / 9.0); 
-    const QSize episodeTileSize(imgW + 16, 8 + imgH + 6 + 20); 
-    m_episodeTileWidth = episodeTileSize.width();
-    m_episodeWidget->setTileSize(episodeTileSize);
-  }
-  m_episodeWidget->setGalleryHeight(145);
-
-  
-  m_episodeHeaderControls = new QWidget(m_episodeWidget);
-  m_episodeHeaderControls->setObjectName("detail-episode-header-controls");
-  m_episodeHeaderControls->setSizePolicy(QSizePolicy::Fixed,
-                                         QSizePolicy::Fixed);
-  auto *episodeHeaderLayout = new QHBoxLayout(m_episodeHeaderControls);
-  episodeHeaderLayout->setContentsMargins(0, 0, 0, 0);
-  episodeHeaderLayout->setSpacing(6);
-  episodeHeaderLayout->setSizeConstraint(QLayout::SetFixedSize);
-
-  m_seasonSwitcher = new ModernMenuButton(m_episodeHeaderControls);
-  m_seasonSwitcher->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-  m_seasonSwitcher->hide(); 
-
-  m_episodeJumpEdit = new QLineEdit(m_episodeHeaderControls);
-  m_episodeJumpEdit->setObjectName("detail-episode-jump-edit");
-  m_episodeJumpEdit->setPlaceholderText(tr("Ep #"));
-  m_episodeJumpEdit->setToolTip(tr("Jump to episode number"));
-  m_episodeJumpEdit->setAlignment(Qt::AlignCenter);
-  m_episodeJumpEdit->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-  m_episodeJumpEdit->setFixedWidth(64);
-  m_episodeJumpEdit->setFixedHeight(m_seasonSwitcher->sizeHint().height());
-  m_episodeJumpEdit->setMaxLength(4);
-  m_episodeJumpValidator = new QIntValidator(1, 9999, m_episodeJumpEdit);
-  m_episodeJumpEdit->setValidator(m_episodeJumpValidator);
-  m_episodeJumpEdit->hide(); 
-
-  episodeHeaderLayout->addWidget(m_seasonSwitcher, 0, Qt::AlignVCenter);
-  episodeHeaderLayout->addWidget(m_episodeJumpEdit, 0, Qt::AlignVCenter);
-  m_episodeHeaderControls->hide();
-  m_episodeWidget->setHeaderWidget(m_episodeHeaderControls);
-  m_episodeHeaderControls->hide();
-
-  m_episodeSectionReserveWidget = createTransparentReserveWidget(
-      m_contentWidget, "detail-episode-section-reserve",
-      reserveHeightFor(m_episodeWidget, 190));
-  m_seasonSectionReserveWidget = createTransparentReserveWidget(
-      m_contentWidget, "detail-season-section-reserve",
-      reserveHeightFor(m_seasonWidget, 320));
-
-  connect(m_seasonSwitcher, &ModernMenuButton::currentIndexChanged, this,
-          [this](int idx) {
-            if (idx >= 0 && idx != m_currentSeasonIndex) {
-              markManualSeriesSelection(QStringLiteral("season-switcher"));
-              m_currentSeasonIndex = idx;
-              QCoro::connect(switchToSeason(idx, true), this, []() {});
-            }
-          });
-  connect(m_episodeJumpEdit, &QLineEdit::editingFinished, this,
-          &DetailView::submitEpisodeJump);
-
-  m_castWidget =
-      new MediaSectionWidget(tr("Cast & Crew"), m_core, m_contentWidget);
-  m_castWidget->setCardStyle(MediaCardDelegate::Cast);
-  m_castWidget->setGalleryHeight(280);
-
-  m_castSectionReserveWidget = new QWidget(m_contentWidget);
-  m_castSectionReserveWidget->setObjectName("detail-cast-section-reserve");
-  m_castSectionReserveWidget->setFixedHeight(
-      qMax(320, m_castWidget->sizeHint().height()));
-  m_castSectionReserveWidget->hide();
-
-  m_additionalPartsWidget =
-      new MediaSectionWidget(tr("Additional Parts"), m_core, m_contentWidget);
-  m_additionalPartsWidget->setCardStyle(MediaCardDelegate::Poster);
-  m_additionalPartsWidget->setGalleryHeight(300);
-  m_additionalPartsSectionReserveWidget = createTransparentReserveWidget(
-      m_contentWidget, "detail-additional-section-reserve",
-      reserveHeightFor(m_additionalPartsWidget, 350));
-
-  m_collectionWidget =
-      new MediaSectionWidget(tr("Collection"), m_core, m_contentWidget);
-  m_collectionWidget->setCardStyle(MediaCardDelegate::Poster);
-  m_collectionWidget->setGalleryHeight(300);
-  m_collectionSectionReserveWidget = createTransparentReserveWidget(
-      m_contentWidget, "detail-collection-section-reserve",
-      reserveHeightFor(m_collectionWidget, 350));
-
-  m_similarWidget =
-      new MediaSectionWidget(tr("More Like This"), m_core, m_contentWidget);
-  m_similarWidget->setCardStyle(MediaCardDelegate::Poster);
-  m_similarWidget->setGalleryHeight(300);
-  m_similarSectionReserveWidget = createTransparentReserveWidget(
-      m_contentWidget, "detail-similar-section-reserve",
-      reserveHeightFor(m_similarWidget, 350));
-
-  m_seasonWidget->gallery()->listView()->viewport()->installEventFilter(this);
-  m_episodeWidget->gallery()->listView()->viewport()->installEventFilter(this);
-  m_castWidget->gallery()->listView()->viewport()->installEventFilter(this);
-  m_additionalPartsWidget->gallery()
-      ->listView()
-      ->viewport()
-      ->installEventFilter(this);
-  m_collectionWidget->gallery()->listView()->viewport()->installEventFilter(
-      this);
-  m_similarWidget->gallery()->listView()->viewport()->installEventFilter(this);
-
-  auto connectGallerySignals = [this](MediaSectionWidget *widget) {
-    connect(widget, &MediaSectionWidget::playRequested, this,
-            &BaseView::handlePlayRequested);
-    connect(widget, &MediaSectionWidget::favoriteRequested, this,
-            &BaseView::handleFavoriteRequested);
-    connect(widget, &MediaSectionWidget::moreMenuRequested, this,
-            &BaseView::handleMoreMenuRequested);
-  };
-
-  connectGallerySignals(m_castWidget);
-  connectGallerySignals(m_additionalPartsWidget);
-  connectGallerySignals(m_collectionWidget);
-  connectGallerySignals(m_similarWidget);
-
-  connect(m_seasonWidget, &MediaSectionWidget::playRequested, this,
-          [this](MediaItem item) -> QCoro::Task<void> {
-            if (item.type == "Season") {
-              markManualSeriesSelection(QStringLiteral("season-play"));
-              co_await executePlaySeason(item);
-            } else {
-              handlePlayRequested(item);
-            }
-          });
-  connect(m_seasonWidget, &MediaSectionWidget::favoriteRequested, this,
-          &BaseView::handleFavoriteRequested);
-  connect(m_seasonWidget, &MediaSectionWidget::moreMenuRequested, this,
-          &BaseView::handleMoreMenuRequested);
-
-  connect(m_episodeWidget, &MediaSectionWidget::playRequested, this,
-          [this](MediaItem item) -> QCoro::Task<void> {
-            if (item.type == "Episode") {
-              markManualSeriesSelection(QStringLiteral("episode-play"));
-              co_await applySeriesPlayableItem(item, false);
-              if (m_currentPlayableItem.id == item.id) {
-                co_await executePlay(
-                    m_currentPlayableItem,
-                    m_currentPlayableItem.userData.playbackPositionTicks);
-              }
-            } else {
-              handlePlayRequested(item);
-            }
-          });
-  connect(m_episodeWidget, &MediaSectionWidget::favoriteRequested, this,
-          &BaseView::handleFavoriteRequested);
-  connect(m_episodeWidget, &MediaSectionWidget::moreMenuRequested, this,
-          [this](const MediaItem &item, const QPoint &globalPos) {
-            MediaActionMenu menu(item, m_core, this,
-                                 {CardContextMenuAction::MarkPlayed,
-                                  CardContextMenuAction::MarkUnplayed});
-            CardContextMenuRequest request = menu.execRequest(globalPos);
-            dispatchCardContextMenuRequest(item, request);
-          });
-
-  auto commonClicked = [this](const MediaItem &item) {
-    if (item.type == "BoxSet" || item.type == "Playlist" ||
-        item.type == "Folder")
-      Q_EMIT navigateToFolder(item.id, item.name);
-    else if (item.type == "Person")
-      Q_EMIT navigateToPerson(item.id, item.name);
-    else
-      Q_EMIT navigateToDetail(item.id, item.name, item);
-  };
-
-  
-  connect(m_seasonWidget, &MediaSectionWidget::itemClicked, this,
-          [this](const MediaItem &item) {
-            if (item.type == "Season")
-              Q_EMIT navigateToSeason(m_currentItemId, item.id, item.name);
-            else
-              Q_EMIT navigateToDetail(item.id, item.name, item);
-          });
-
-  
-  connect(m_episodeWidget, &MediaSectionWidget::itemClicked, this,
-          [this, commonClicked](const MediaItem &item) {
-            if (item.type == "Episode") {
-              markManualSeriesSelection(QStringLiteral("episode-click"));
-              QCoro::connect(applySeriesPlayableItem(item, true), this,
-                             []() {});
-            } else {
-              commonClicked(item);
-            }
-          });
-
-  connect(m_castWidget, &MediaSectionWidget::itemClicked, this,
-          [this](const MediaItem &item) {
-            Q_EMIT navigateToPerson(item.id, item.name);
-          });
-  connect(m_additionalPartsWidget, &MediaSectionWidget::itemClicked, this,
-          commonClicked);
-  connect(m_collectionWidget, &MediaSectionWidget::itemClicked, this,
-          [this, commonClicked](const MediaItem &item) {
-            if (!item.id.isEmpty()) {
-              qDebug() << "[DetailView] Navigate collection membership"
-                       << "itemId=" << item.id << "name=" << item.name
-                       << "type=" << item.type
-                       << "collectionType=" << item.collectionType;
-              Q_EMIT navigateToFolder(item.id, item.name);
-              return;
-            }
-            commonClicked(item);
-          });
-  connect(m_similarWidget, &MediaSectionWidget::itemClicked, this,
-          commonClicked);
-
-  contentLayout->addWidget(m_episodeSectionReserveWidget);
-  contentLayout->addWidget(m_episodeWidget);
-  contentLayout->addWidget(m_seasonSectionReserveWidget);
-  contentLayout->addWidget(m_seasonWidget);
-  contentLayout->addWidget(m_castSectionReserveWidget);
-  contentLayout->addWidget(m_castWidget);
-  contentLayout->addWidget(m_additionalPartsSectionReserveWidget);
-  contentLayout->addWidget(m_additionalPartsWidget);
-  contentLayout->addWidget(m_collectionSectionReserveWidget);
-  contentLayout->addWidget(m_collectionWidget);
-  contentLayout->addWidget(m_similarSectionReserveWidget);
-  contentLayout->addWidget(m_similarWidget);
-
-  m_bottomInfoWidget = new DetailBottomInfoWidget(m_contentWidget);
-  connect(m_bottomInfoWidget, &DetailBottomInfoWidget::filterClicked, this,
-          [this](const QString &type, const QString &value) {
-            Q_EMIT navigateToFilteredView(type, value);
-          });
-  m_bottomInfoReserveWidget = createTransparentReserveWidget(
-      m_contentWidget, "detail-bottom-info-reserve", 220);
-  contentLayout->addWidget(m_bottomInfoReserveWidget);
-  contentLayout->addWidget(m_bottomInfoWidget);
-
-  contentLayout->addStretch();
-  m_mainScrollArea->setWidget(m_contentWidget);
-  mainLayout->addWidget(m_mainScrollArea);
-  m_mainScrollArea->viewport()->installEventFilter(this);
-}
-
-QCoro::Task<void> DetailView::loadItem(const QString &itemId,
-                                       const MediaItem &seedItem) {
-  QPointer<DetailView> safeThis(this);
-  setDeferredPresentationBatchActive(false);
-  m_currentItemId = itemId;
-  
-  
-  m_skipNextSilentRefresh = true;
-  m_pendingDeferredFetchId = itemId;
-  m_pendingFetchedItem = MediaItem{};
-  m_pendingFetchReady = false;
-  m_pendingAnimationGuardDone = false;
-  m_pendingFetchedItemFromCache = false;
-  m_deferBottomInfoReveal = false;
-  m_currentPlayableItem = MediaItem{};
-  m_currentSeasonEpisodes.clear();
-  updateEpisodeJumpControl(0);
-  
-  m_appliedSourcesFingerprint.clear();
-  m_appliedBottomInfoFingerprint.clear();
-  m_detailCacheServerId.clear();
-  m_detailCacheUserId.clear();
-  m_cachedDetailFingerprint.clear();
-  m_cachedSectionsFingerprint.clear();
-  m_cachedSeriesPlayableItem = MediaItem{};
-  m_cachedSeriesSeasons.clear();
-  m_cachedSeasonEpisodes.clear();
-  m_cachedSimilarItems.clear();
-  m_cachedCollections.clear();
-  m_cachedAdditionalParts.clear();
-  m_cachedSeasonId.clear();
-  m_manualSelectedSeasonId.clear();
-  m_manualSelectedEpisodeId.clear();
-  m_cachedSeasonIndex = -1;
-  m_manualSelectedSeasonIndex = -1;
-  m_hasManualSeriesSelection = false;
-  m_hasCachedSeriesPlayableItem = false;
-  m_hasCachedSeriesSeasons = false;
-  m_hasCachedSeasonEpisodes = false;
-  m_hasCachedSimilarItems = false;
-  m_hasCachedCollections = false;
-  m_hasCachedAdditionalParts = false;
-  m_hasCachedCastData = false;
-  m_appliedCachedCastToUi = false;
-  m_appliedCachedSeriesSeasonsToUi = false;
-  m_appliedCachedSeasonEpisodesToUi = false;
-  m_appliedCachedSimilarItemsToUi = false;
-  m_appliedCachedCollectionsToUi = false;
-  m_appliedCachedAdditionalPartsToUi = false;
-  m_appliedCastFingerprint.clear();
-  m_appliedSeriesPlayableFingerprint.clear();
-
-  if (m_core && m_core->serverManager()) {
-    const ServerProfile profile = m_core->serverManager()->activeProfile();
-    m_detailCacheServerId = profile.id;
-    m_detailCacheUserId = profile.userId;
-  }
-
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  const bool hasSeed = !seedItem.id.isEmpty();
-  
-  
-  
-  m_deferBottomInfoReveal = hasSeed;
-
-  if (hasSeed) {
-    m_currentPlayableItem = seedItem;
-    applySeedToUi(seedItem);
-    if (seedItem.type == "Series") {
-      prepareReservedSection(m_episodeSectionReserveWidget, m_episodeWidget,
-                             reserveHeightFor(m_episodeWidget, 190));
-      prepareReservedSection(m_seasonSectionReserveWidget, m_seasonWidget,
-                             reserveHeightFor(m_seasonWidget, 320));
-    } else {
-      hideReserveWidget(m_episodeSectionReserveWidget);
-      hideReserveWidget(m_seasonSectionReserveWidget);
-      m_seasonWidget->clear();
-      m_episodeWidget->clear();
-    }
-  } else {
-    
-    m_titleLabel->setText(tr("Loading..."));
-    m_logoLabel->clear();
-    m_logoLabel->hide();
-    m_metaLabel->clear();
-    updateDisplayNumber(QString());
-    m_metaRowWidget->hide();
-    m_overviewLabel->clear();
-    m_taglineLabel->hide();
-
-    m_currentBackdropPix = QPixmap();
-    m_currentPosterPix = QPixmap();
-    updateBackdrop();
-    m_posterLabel->setPixmap(QPixmap());
-
-    m_actionWidget->clear();
-    m_bottomInfoWidget->clear();
-    clearLayout(m_tagsLayout);
-
-    m_seasonWidget->clear();
-    m_episodeWidget->clear();
-    hideReserveWidget(m_episodeSectionReserveWidget);
-    hideReserveWidget(m_seasonSectionReserveWidget);
-
-    m_seriesSeasons.clear();
-    m_currentSeasonIndex = 0;
-    if (m_seasonSwitcher) {
-      QSignalBlocker blocker(m_seasonSwitcher);
-      m_seasonSwitcher->clear();
-      m_seasonSwitcher->hide();
-    }
-    updateEpisodeHeaderControlsVisibility();
-  }
-
-  
-  
-  prepareReservedSection(m_castSectionReserveWidget, m_castWidget,
-                         reserveHeightFor(m_castWidget, 320));
-  prepareReservedSection(m_additionalPartsSectionReserveWidget,
-                         m_additionalPartsWidget,
-                         reserveHeightFor(m_additionalPartsWidget, 350));
-  prepareReservedSection(m_collectionSectionReserveWidget, m_collectionWidget,
-                         reserveHeightFor(m_collectionWidget, 350));
-  prepareReservedSection(m_similarSectionReserveWidget, m_similarWidget,
-                         reserveHeightFor(m_similarWidget, 350));
-
-  scrollToTop();
-
-  
-  
-  if (!itemId.isEmpty()) {
-    QCoro::connect(loadDetailCacheAndStartPrefetch(
-                       itemId, seedItem, m_detailCacheServerId,
-                       m_detailCacheUserId),
-                   this, []() {});
-  }
-
-  
-  
-  QTimer::singleShot(380, this, [safeThis, itemId]() {
-    if (!safeThis || safeThis->m_pendingDeferredFetchId != itemId)
-      return;
-    if (safeThis->m_posterShadow)
-      safeThis->m_posterShadow->setEnabled(true);
-    safeThis->m_pendingAnimationGuardDone = true;
-    safeThis->maybeFlushDeferredUpdate(itemId);
-  });
-
-  co_return;
-}
-
-QCoro::Task<void>
-DetailView::loadDetailCacheAndStartPrefetch(QString itemId, MediaItem seedItem,
-                                            QString cacheServerId,
-                                            QString cacheUserId) {
-  QPointer<DetailView> safeThis(this);
-  QString targetId = std::move(itemId);
-  MediaItem seed = std::move(seedItem);
-  QString serverId = std::move(cacheServerId);
-  QString userId = std::move(cacheUserId);
-  QString cachedFingerprint;
-
-  if (!serverId.isEmpty() && !userId.isEmpty() && !targetId.isEmpty()) {
-    const auto cachedEntry = co_await QtConcurrent::run(
-        [serverId, userId, targetId]() mutable {
-          return DetailCacheUtils::load(serverId, userId, targetId);
-        });
-    if (!safeThis || safeThis->m_currentItemId != targetId)
-      co_return;
-
-    if (cachedEntry.has_value()) {
-      MediaItem cachedItem = withSeedContext(cachedEntry->item, seed);
-      cachedFingerprint = cachedEntry->fingerprint;
-
-      safeThis->m_cachedDetailFingerprint = cachedEntry->fingerprint;
-      safeThis->m_cachedSectionsFingerprint =
-          cachedEntry->sectionsFingerprint;
-      safeThis->m_cachedSeriesPlayableItem =
-          withSeedContext(cachedEntry->playableItem, MediaItem{});
-      safeThis->m_cachedSeriesSeasons = cachedEntry->seasons;
-      safeThis->m_cachedSeasonEpisodes = cachedEntry->seasonEpisodes;
-      safeThis->m_cachedSimilarItems = cachedEntry->similarItems;
-      safeThis->m_cachedCollections = cachedEntry->collections;
-      safeThis->m_cachedAdditionalParts = cachedEntry->additionalParts;
-      safeThis->m_cachedSeasonId = cachedEntry->seasonId;
-      safeThis->m_cachedSeasonIndex = cachedEntry->seasonIndex;
-      safeThis->m_manualSelectedSeasonId.clear();
-      safeThis->m_manualSelectedSeasonIndex = -1;
-      safeThis->m_manualSelectedEpisodeId.clear();
-      safeThis->m_hasCachedSeriesPlayableItem =
-          cachedEntry->hasPlayableItem && cachedEntry->playableItemFromServer;
-      if (!safeThis->m_hasCachedSeriesPlayableItem)
-        safeThis->m_cachedSeriesPlayableItem = MediaItem{};
-      safeThis->m_hasCachedSeriesSeasons = cachedEntry->hasSeasons;
-      safeThis->m_hasCachedSeasonEpisodes =
-          cachedEntry->hasSeasonEpisodes;
-      safeThis->m_hasCachedSimilarItems = cachedEntry->hasSimilarItems;
-      safeThis->m_hasCachedCollections = cachedEntry->hasCollections;
-      safeThis->m_hasCachedAdditionalParts =
-          cachedEntry->hasAdditionalParts;
-      safeThis->m_hasCachedCastData = !cachedItem.people.isEmpty();
-      const bool hasCachedSecondaryData =
-          cacheEntryHasAnySecondaryData(*cachedEntry);
-
-      if (!cachedItem.name.trimmed().isEmpty()) {
-        safeThis->m_pendingFetchedItem = cachedItem;
-        safeThis->m_pendingFetchReady = true;
-        safeThis->m_pendingFetchedItemFromCache = true;
-
-        
-        
-        const bool hasSeedUi =
-            safeThis->m_currentMediaItem.id == targetId &&
-            !safeThis->m_currentMediaItem.name.trimmed().isEmpty();
-        if (!hasSeedUi) {
-          safeThis->applySeedToUi(cachedItem);
+void DetailView::scrollToTop()
+{
+    if (m_mainScrollArea && m_mainScrollArea->verticalScrollBar())
+    {
+        if (m_vScrollController)
+        {
+            m_vScrollController->scrollTo(0, false);
         }
-        safeThis->maybeFlushDeferredUpdate(targetId);
-
-        qDebug() << "[DetailView] Detail cache hit"
-                 << "itemId=" << targetId
-                 << "fingerprint=" << cachedFingerprint.left(12)
-                 << "hasSecondaryCache=" << hasCachedSecondaryData
-                 << "deferredSeedApply=" << hasSeedUi;
-      } else {
-        cachedFingerprint.clear();
-        safeThis->m_cachedDetailFingerprint.clear();
-        safeThis->m_cachedSectionsFingerprint.clear();
-        safeThis->m_cachedSeriesPlayableItem = MediaItem{};
-        safeThis->m_cachedSeriesSeasons.clear();
-        safeThis->m_cachedSeasonEpisodes.clear();
-        safeThis->m_cachedSimilarItems.clear();
-        safeThis->m_cachedCollections.clear();
-        safeThis->m_cachedAdditionalParts.clear();
-        safeThis->m_cachedSeasonId.clear();
-        safeThis->m_manualSelectedSeasonId.clear();
-        safeThis->m_manualSelectedEpisodeId.clear();
-        safeThis->m_cachedSeasonIndex = -1;
-        safeThis->m_manualSelectedSeasonIndex = -1;
-        safeThis->m_hasCachedSeriesPlayableItem = false;
-        safeThis->m_hasCachedSeriesSeasons = false;
-        safeThis->m_hasCachedSeasonEpisodes = false;
-        safeThis->m_hasCachedSimilarItems = false;
-        safeThis->m_hasCachedCollections = false;
-        safeThis->m_hasCachedAdditionalParts = false;
-        safeThis->m_hasCachedCastData = false;
-        qWarning() << "[DetailView] Ignore incomplete detail cache"
-                   << "itemId=" << targetId
-                   << "file=" << cachedEntry->filePath;
-      }
-    } else {
-      qDebug() << "[DetailView] Detail cache miss"
-               << "itemId=" << targetId;
-    }
-  }
-
-  if (!safeThis || safeThis->m_currentItemId != targetId)
-    co_return;
-
-  if (safeThis->m_core && safeThis->m_core->mediaService()) {
-    QCoro::connect(safeThis->prefetchItemDetail(targetId, serverId, userId,
-                                                cachedFingerprint),
-                   safeThis.data(), []() {});
-  }
-}
-
-QCoro::Task<void> DetailView::prefetchItemDetail(QString itemId,
-                                                 QString cacheServerId,
-                                                 QString cacheUserId,
-                                                 QString cachedFingerprint) {
-  QPointer<DetailView> safeThis(this);
-  QString targetId = std::move(itemId);
-  QString serverId = std::move(cacheServerId);
-  QString userId = std::move(cacheUserId);
-  QString previousFingerprint = std::move(cachedFingerprint);
-
-  try {
-    MediaItem item =
-        co_await m_core->mediaService()->getItemDetail(targetId);
-    const QString fetchedFingerprint = co_await QtConcurrent::run(
-        [item]() mutable { return DetailCacheUtils::fingerprint(item); });
-    const bool differsFromCache =
-        previousFingerprint.isEmpty() ||
-        fetchedFingerprint != previousFingerprint;
-
-    if (differsFromCache) {
-      saveDetailCacheAsync(serverId, userId, item, fetchedFingerprint);
-    } else {
-      qDebug() << "[DetailView] Detail cache unchanged"
-               << "itemId=" << targetId
-               << "fingerprint=" << fetchedFingerprint.left(12);
-    }
-
-    if (!safeThis || (safeThis->m_pendingDeferredFetchId != targetId &&
-                      safeThis->m_currentItemId != targetId)) {
-      
-      co_return;
-    }
-
-    safeThis->m_cachedDetailFingerprint = fetchedFingerprint;
-
-    if (safeThis->m_pendingDeferredFetchId == targetId) {
-      if (!differsFromCache && safeThis->m_pendingFetchReady &&
-          safeThis->m_pendingFetchedItemFromCache) {
-        safeThis->maybeFlushDeferredUpdate(targetId);
-        co_return;
-      }
-
-      
-      
-      safeThis->m_pendingFetchedItem = std::move(item);
-      safeThis->m_pendingFetchReady = true;
-      safeThis->m_pendingFetchedItemFromCache = false;
-      safeThis->maybeFlushDeferredUpdate(targetId);
-      co_return;
-    }
-
-    
-    if (safeThis->m_currentItemId == targetId && differsFromCache) {
-      qDebug() << "[DetailView] Applying refreshed detail after cache"
-               << "itemId=" << targetId;
-      QCoro::connect(safeThis->executeDeferredUpdate(std::move(item), true),
-                     safeThis.data(), []() {});
-    }
-  } catch (...) {
-    if (safeThis && safeThis->m_pendingDeferredFetchId == targetId) {
-      if (!safeThis->m_pendingFetchReady &&
-          safeThis->m_currentMediaItem.id != targetId) {
-        safeThis->m_pendingDeferredFetchId.clear();
-        const QString errorText = tr("Error Loading Item");
-        QMetaObject::invokeMethod(
-            safeThis.data(),
-            [safeThis, targetId, errorText]() {
-              if (safeThis && safeThis->m_currentItemId == targetId)
-                safeThis->m_titleLabel->setText(errorText);
-            },
-            Qt::QueuedConnection);
-      } else {
-        qDebug() << "[DetailView] Detail refresh failed; using existing data"
-                 << "itemId=" << targetId;
-      }
-    }
-  }
-}
-
-void DetailView::maybeFlushDeferredUpdate(const QString &itemId) {
-  if (m_pendingDeferredFetchId != itemId)
-    return;
-  if (!m_pendingFetchReady || !m_pendingAnimationGuardDone)
-    return;
-
-  
-  m_pendingDeferredFetchId.clear();
-
-  MediaItem item = m_pendingFetchedItem;
-  const bool fromCache = m_pendingFetchedItemFromCache;
-  m_pendingFetchedItem = MediaItem{};
-  m_pendingFetchReady = false;
-  m_pendingAnimationGuardDone = false;
-  m_pendingFetchedItemFromCache = false;
-
-  if (item.type != "Series" || m_currentPlayableItem.type != "Episode" ||
-      m_currentPlayableItem.id.isEmpty()) {
-    m_currentPlayableItem = item;
-  }
-  qDebug() << "[DetailView] Deferred detail update"
-           << "itemId=" << itemId << "fromCache=" << fromCache;
-  QCoro::connect(executeDeferredUpdate(std::move(item)), this, []() {});
-}
-
-QCoro::Task<void> DetailView::executeDeferredUpdate(MediaItem item,
-                                                    bool isSilentRefresh) {
-  QPointer<DetailView> safeThis(this);
-  const QString targetId = item.id;
-  const QString detectedType = item.type;
-  const bool batchPresentation = isVisible();
-
-  if (batchPresentation) {
-    
-    
-    
-    setDeferredPresentationBatchActive(true);
-    QTimer::singleShot(160, this, [safeThis]() {
-      if (safeThis && safeThis->m_deferredPresentationBatchActive)
-        safeThis->setDeferredPresentationBatchActive(false);
-    });
-  }
-
-  
-  
-  
-  co_await updateUi(item, isSilentRefresh);
-  if (!safeThis)
-    co_return;
-  safeThis->persistDetailCacheSnapshot(QStringLiteral("detail-ui"));
-
-  if (isSilentRefresh) {
-    safeThis->setDeferredPresentationBatchActive(false);
-    co_return;
-  }
-
-  if (batchPresentation) {
-    QTimer::singleShot(0, safeThis.data(),
-                       [safeThis, targetId, detectedType]() {
-                         if (!safeThis)
-                           return;
-                         safeThis->finishDeferredPresentationBatch(targetId,
-                                                                   detectedType);
-                       });
-  } else {
-    safeThis->startSecondaryFetches(targetId, detectedType);
-  }
-}
-
-void DetailView::setDeferredPresentationBatchActive(bool active) {
-  m_deferredPresentationBatchActive = active;
-}
-
-void DetailView::finishDeferredPresentationBatch(
-    const QString &targetId, const QString &detectedType) {
-  if (m_currentItemId != targetId) {
-    setDeferredPresentationBatchActive(false);
-    return;
-  }
-
-  updateTagLayoutHeight();
-  updateEpisodeJumpControl(m_currentSeasonEpisodes.size());
-
-  if (m_contentWidget && m_contentWidget->layout())
-    m_contentWidget->layout()->activate();
-  if (layout())
-    layout()->activate();
-
-  setDeferredPresentationBatchActive(false);
-
-  startSecondaryFetches(targetId, detectedType);
-}
-
-void DetailView::startSecondaryFetches(const QString &targetId,
-                                       const QString &detectedType) {
-  if (targetId.isEmpty() || !m_core || !m_core->mediaService())
-    return;
-
-  const auto startNetworkFetches = [this, targetId, detectedType]() {
-    qDebug() << "[DetailView][network] Start secondary fetches"
-             << "itemId=" << targetId << "type=" << detectedType;
-    QCoro::connect(
-        executeFetchSecondaries(QPointer<DetailView>(this), m_core, targetId,
-                                detectedType),
-        this, []() {});
-  };
-
-  if (detectedType == "Series") {
-    const bool hasCachedSeriesSecondaryUi =
-        m_hasCachedCastData || m_hasCachedSeriesPlayableItem ||
-        m_hasCachedSeriesSeasons || m_hasCachedSeasonEpisodes ||
-        m_hasCachedSimilarItems || m_hasCachedCollections ||
-        m_hasCachedAdditionalParts;
-    startNetworkFetches();
-    if (hasCachedSeriesSecondaryUi) {
-      applyCachedSecondaryData(targetId, detectedType);
-    } else {
-      qDebug() << "[DetailView][cache-ui] Skip cached secondary data"
-               << "itemId=" << targetId << "type=" << detectedType
-               << "reason=" << "no-cached-series-secondary-data";
-    }
-    return;
-  }
-
-  applyCachedSecondaryData(targetId, detectedType);
-  startNetworkFetches();
-}
-
-void DetailView::applyCachedSecondaryData(const QString &targetId,
-                                          const QString &detectedType,
-                                          bool revealBottomInfo) {
-  if (targetId != m_currentItemId)
-    return;
-
-  qDebug() << "[DetailView][cache-ui] Applying cached secondary data"
-           << "itemId=" << targetId << "type=" << detectedType
-           << "sections=" << m_cachedSectionsFingerprint.left(12);
-
-  if (detectedType == "Series") {
-    if (!m_hasManualSeriesSelection && m_hasCachedSeriesPlayableItem &&
-        m_cachedSeriesPlayableItem.type == "Episode" &&
-        !m_cachedSeriesPlayableItem.id.isEmpty()) {
-      if (m_currentPlayableItem.id != m_cachedSeriesPlayableItem.id)
-        applySeriesPlayableItemToUi(m_cachedSeriesPlayableItem);
-    }
-
-    if (m_hasCachedSeriesSeasons && !m_appliedCachedSeriesSeasonsToUi) {
-      m_seriesSeasons = m_cachedSeriesSeasons;
-      int targetSeasonIdx = 0;
-      const int cachedEpisodeSeasonIndex = m_cachedSeasonIndex;
-      const QString cachedEpisodeSeasonId = m_cachedSeasonId;
-      bool selectedSeasonResolved = false;
-      if (m_hasManualSeriesSelection && m_currentSeasonIndex >= 0 &&
-          m_currentSeasonIndex < m_seriesSeasons.size()) {
-        targetSeasonIdx = m_currentSeasonIndex;
-        selectedSeasonResolved = true;
-      }
-      const int playableParentIdx = m_currentPlayableItem.parentIndexNumber;
-      if (!selectedSeasonResolved && !m_hasManualSeriesSelection &&
-          playableParentIdx >= 0) {
-        for (int i = 0; i < m_seriesSeasons.size(); ++i) {
-          if (m_seriesSeasons[i].indexNumber == playableParentIdx) {
-            targetSeasonIdx = i;
-            break;
-          }
+        else
+        {
+            m_mainScrollArea->verticalScrollBar()->setValue(0);
         }
-      }
-      if (!m_seriesSeasons.isEmpty()) {
-        targetSeasonIdx = qBound(0, targetSeasonIdx,
-                                 m_seriesSeasons.size() - 1);
-        m_currentSeasonIndex = targetSeasonIdx;
-        updateSeasonSwitcher(targetSeasonIdx);
-      }
-
-      if (m_hasCachedSeasonEpisodes &&
-          cachedEpisodeSeasonIndex == targetSeasonIdx &&
-          cachedEpisodeSeasonId ==
-              (m_seriesSeasons.isEmpty()
-                   ? QString()
-                   : m_seriesSeasons[targetSeasonIdx].id) &&
-          !m_seriesSeasons.isEmpty() &&
-          episodesBelongToSeason(m_cachedSeasonEpisodes,
-                                 m_seriesSeasons[targetSeasonIdx])) {
-        m_currentSeasonEpisodes = m_cachedSeasonEpisodes;
-        if (!m_appliedCachedSeasonEpisodesToUi && m_episodeWidget) {
-          applyReservedSectionItems(m_episodeSectionReserveWidget,
-                                    m_episodeWidget,
-                                    m_currentSeasonEpisodes);
-          updateEpisodeJumpControl(m_currentSeasonEpisodes.size());
-          const QString highlightedEpisodeId = m_currentPlayableItem.id;
-          if (!highlightedEpisodeId.isEmpty()) {
-            m_episodeWidget->gallery()->setHighlightedItemId(
-                highlightedEpisodeId);
-            m_episodeWidget->gallery()->scrollToItemId(highlightedEpisodeId);
-          }
-        }
-        m_appliedCachedSeasonEpisodesToUi = true;
-      }
-
-      if (m_seasonWidget) {
-        m_seasonWidget->setTitle(tr("Seasons"));
-        m_seasonWidget->setCardStyle(MediaCardDelegate::Poster);
-        m_seasonWidget->setGalleryHeight(300);
-        applyReservedSectionItems(m_seasonSectionReserveWidget, m_seasonWidget,
-                                  m_seriesSeasons);
-        m_appliedCachedSeriesSeasonsToUi = true;
-      }
     }
-  }
-
-  
-  if (m_hasCachedCastData && !m_appliedCachedCastToUi) {
-    applyCastSection(m_currentMediaItem);
-    m_appliedCachedCastToUi = true;
-  }
-  if (revealBottomInfo && m_deferBottomInfoReveal) {
-    m_deferBottomInfoReveal = false;
-    hideReserveWidget(m_bottomInfoReserveWidget);
-    if (m_bottomInfoWidget)
-      m_bottomInfoWidget->show();
-  }
-
-  
-  
-  
-  if (m_hasCachedAdditionalParts && !m_appliedCachedAdditionalPartsToUi) {
-    applyReservedSectionItems(m_additionalPartsSectionReserveWidget,
-                              m_additionalPartsWidget,
-                              m_cachedAdditionalParts);
-    m_appliedCachedAdditionalPartsToUi = true;
-  } else if (!m_hasCachedAdditionalParts &&
-             (m_hasCachedCollections || m_hasCachedSimilarItems)) {
-    applyReservedSectionItems(m_additionalPartsSectionReserveWidget,
-                              m_additionalPartsWidget, {});
-  }
-
-  if (m_hasCachedCollections && !m_appliedCachedCollectionsToUi) {
-    applyCollectionGalleryLayout(m_cachedCollections);
-    applyReservedSectionItems(m_collectionSectionReserveWidget,
-                              m_collectionWidget, m_cachedCollections);
-    m_appliedCachedCollectionsToUi = true;
-  } else if (!m_hasCachedCollections && m_hasCachedSimilarItems) {
-    applyReservedSectionItems(m_collectionSectionReserveWidget,
-                              m_collectionWidget, {});
-  }
-
-  if (m_hasCachedSimilarItems && !m_appliedCachedSimilarItemsToUi) {
-    applyReservedSectionItems(m_similarSectionReserveWidget, m_similarWidget,
-                              m_cachedSimilarItems);
-    m_appliedCachedSimilarItemsToUi = true;
-  }
 }
 
-void DetailView::persistDetailCacheSnapshot(const QString &reason) {
-  if (m_detailCacheServerId.isEmpty() || m_detailCacheUserId.isEmpty() ||
-      m_currentMediaItem.id.isEmpty())
-    return;
+void DetailView::setupUi()
+{
+    auto *mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
 
-  DetailCacheUtils::DetailCacheEntry entry;
-  entry.item = m_currentMediaItem;
-  const bool isSeries = m_currentMediaItem.type == "Series";
-  entry.hasPlayableItem = isSeries && m_currentPlayableItem.type == "Episode" &&
-                          !m_currentPlayableItem.id.isEmpty();
-  if (entry.hasPlayableItem)
-    entry.playableItem = m_currentPlayableItem;
-  entry.hasSeasons = isSeries && m_hasCachedSeriesSeasons;
-  entry.seasons = m_cachedSeriesSeasons;
-  entry.hasSeasonEpisodes = isSeries && m_hasCachedSeasonEpisodes;
-  entry.seasonEpisodes = m_cachedSeasonEpisodes;
-  entry.seasonIndex = isSeries ? m_cachedSeasonIndex : -1;
-  entry.seasonId = isSeries ? m_cachedSeasonId : QString();
-  entry.playableItemFromServer = entry.hasPlayableItem;
-  entry.hasSimilarItems = m_hasCachedSimilarItems;
-  entry.similarItems = m_cachedSimilarItems;
-  entry.hasCollections = m_hasCachedCollections;
-  entry.collections = m_cachedCollections;
-  entry.hasAdditionalParts = m_hasCachedAdditionalParts;
-  entry.additionalParts = m_cachedAdditionalParts;
+    m_mainScrollArea = new QScrollArea(this);
+    m_mainScrollArea->setWidgetResizable(true);
+    m_mainScrollArea->setFrameShape(QFrame::NoFrame);
+    m_mainScrollArea->setObjectName("detail-scrollarea");
+    m_mainScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_mainScrollArea->setStyleSheet("QScrollArea { background: transparent; }");
 
-  saveDetailCacheEntryAsync(m_detailCacheServerId, m_detailCacheUserId, entry,
-                            reason);
-}
+    m_vScrollController = new SmoothScrollController(m_mainScrollArea->verticalScrollBar(), this);
+    m_vScrollController->setDuration(170);
 
-void DetailView::updateMetaRow(const MediaItem &item,
-                               const QString &leadingMeta) {
-  QStringList metas;
-  if (item.communityRating > 0) {
-    m_ratingStarLabel->show();
-    metas << QString::number(item.communityRating, 'f', 1);
-  } else {
+    m_contentWidget = new DetailContentWidget(m_mainScrollArea);
+    m_contentWidget->setObjectName("detail-content-container");
+
+    auto *contentLayout = new QVBoxLayout(m_contentWidget);
+    contentLayout->setContentsMargins(0, 0, 0, 10);
+    contentLayout->setSpacing(0);
+
+    QWidget *infoContainer = new QWidget(m_contentWidget);
+    infoContainer->setObjectName("detail-info-container");
+    infoContainer->setStyleSheet("QWidget#detail-info-container { background: transparent; }");
+
+    m_infoLayout = new QGridLayout(infoContainer);
+    m_infoLayout->setContentsMargins(40, 40, 40, 0);
+    m_infoLayout->setHorizontalSpacing(40);
+    m_infoLayout->setVerticalSpacing(0);
+    m_infoLayout->setRowMinimumHeight(0, 110);
+
+    m_logoLabel = new QLabel(infoContainer);
+    m_logoLabel->setObjectName("detail-logo-label");
+    m_logoLabel->setAlignment(Qt::AlignRight | Qt::AlignTop);
+    m_infoLayout->addWidget(m_logoLabel, 0, 1, 1, 2, Qt::AlignRight | Qt::AlignTop);
+
+    m_posterLabel = new QLabel(infoContainer);
+    m_posterLabel->setFixedSize(250, 375);
+    m_posterLabel->setObjectName("detail-poster-label");
+    m_posterLabel->setAlignment(Qt::AlignCenter);
+
+    
+    
+    
+    m_posterShadow = new QGraphicsDropShadowEffect(this);
+    m_posterShadow->setBlurRadius(20);
+    m_posterShadow->setColor(QColor(0, 0, 0, 80));
+    m_posterShadow->setOffset(0, 8);
+    m_posterShadow->setEnabled(false);
+    m_posterLabel->setGraphicsEffect(m_posterShadow);
+    m_infoLayout->addWidget(m_posterLabel, 1, 0, 1, 1, Qt::AlignTop);
+
+    m_textContainer = new QWidget(infoContainer);
+    m_textContainer->setMaximumWidth(1200);
+    m_textContainer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    auto *textLayout = new QVBoxLayout(m_textContainer);
+    textLayout->setContentsMargins(0, 0, 0, 0);
+    textLayout->setSpacing(10);
+    textLayout->setAlignment(Qt::AlignTop);
+
+    m_titleLabel = new QLabel(m_textContainer);
+    m_titleLabel->setObjectName("detail-title");
+    m_titleLabel->setWordWrap(true);
+
+    m_metaRowWidget = new QWidget(m_textContainer);
+    m_metaRowWidget->setObjectName("detail-meta-row");
+    auto *metaLayout = new QHBoxLayout(m_metaRowWidget);
+    metaLayout->setContentsMargins(0, 0, 0, 0);
+    metaLayout->setSpacing(6);
+
+    m_ratingStarLabel = new QLabel(m_metaRowWidget);
+    m_ratingStarLabel->setFixedWidth(16);
+    m_ratingStarLabel->setAlignment(Qt::AlignCenter);
+    m_ratingStarLabel->setPixmap(QIcon(":/svg/dark/star-filled.svg").pixmap(16, 16));
+    m_ratingStarLabel->setContentsMargins(0, 2, 0, 0);
     m_ratingStarLabel->hide();
-  }
-  if (!leadingMeta.isEmpty())
-    metas << leadingMeta;
-  const QString releaseDate = formatDetailReleaseDate(item);
-  if (!releaseDate.isEmpty())
-    metas << releaseDate;
-  if (item.runTimeTicks > 0)
-    metas << formatRunTime(item.runTimeTicks);
-  if (!item.officialRating.isEmpty())
-    metas << item.officialRating;
 
-  m_metaLabel->setText(metas.join("  \u2022  "));
-  m_metaRowWidget->show();
-}
+    m_metaLabel = new QLabel(m_metaRowWidget);
+    m_metaLabel->setObjectName("detail-meta");
+    m_metaLabel->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
 
+    m_numberButton = new QPushButton(m_metaRowWidget);
+    m_numberButton->setObjectName("detail-number-chip");
+    m_numberButton->setCursor(Qt::PointingHandCursor);
+    m_numberButton->setFocusPolicy(Qt::NoFocus);
+    m_numberButton->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed);
+    m_numberButton->hide();
+    connect(m_numberButton, &QPushButton::clicked, this, &DetailView::copyDisplayedNumber);
 
+    metaLayout->addWidget(m_ratingStarLabel);
+    metaLayout->addWidget(m_metaLabel, 0, Qt::AlignLeft);
+    metaLayout->addWidget(m_numberButton, 0, Qt::AlignLeft);
+    metaLayout->addStretch(1);
+    m_metaRowWidget->hide();
 
+    m_tagsWidget = new QWidget(m_textContainer);
+    m_tagsWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+    m_tagsLayout = new FlowLayout(m_tagsWidget, 0, 8, 8);
 
+    m_actionWidget = new DetailActionWidget(m_textContainer);
+    connect(m_actionWidget, &DetailActionWidget::playRequested, this,
+            [this]() -> QCoro::Task<void> { co_await executePlay(m_currentPlayableItem, 0); });
+    connect(m_actionWidget, &DetailActionWidget::resumeRequested, this, [this]() -> QCoro::Task<void>
+            { co_await executePlay(m_currentPlayableItem, m_currentPlayableItem.userData.playbackPositionTicks); });
+    connect(m_actionWidget, &DetailActionWidget::favoriteRequested, this,
+            [this]()
+            {
+                if (!m_currentMediaItem.id.isEmpty())
+                    handleFavoriteRequested(m_currentMediaItem);
+            });
+    connect(m_actionWidget, &DetailActionWidget::playedToggleRequested, this,
+            [this]()
+            {
+                const MediaItem &target =
+                    m_currentPlayableItem.type == "Episode" ? m_currentPlayableItem : m_currentMediaItem;
+                if (target.id.isEmpty())
+                    return;
+                if (target.userData.played)
+                    handleMarkUnplayedRequested(target);
+                else
+                    handleMarkPlayedRequested(target);
+            });
+    connect(ThemeManager::instance(), &ThemeManager::themeChanged, this,
+            [this]()
+            {
+                const MediaItem &target =
+                    m_currentPlayableItem.type == "Episode" ? m_currentPlayableItem : m_currentMediaItem;
+                if (!target.id.isEmpty())
+                    m_actionWidget->setPlayedState(target.userData.played);
+            });
+    connect(m_actionWidget, &DetailActionWidget::sourceVersionChanged, this, &DetailView::onVersionChanged);
+    connect(m_actionWidget, &DetailActionWidget::audioStreamChanged, this,
+            [this](int streamIndex)
+            {
+                const MediaItem &item =
+                    m_currentMediaItem.type == "Series" && !m_currentPlayableItem.id.isEmpty()
+                        ? m_currentPlayableItem
+                        : m_currentMediaItem;
+                const int sourceIndex = m_actionWidget->currentSourceIndex();
+                if (sourceIndex < 0 || sourceIndex >= item.mediaSources.size())
+                    return;
+                PlayerPreferenceUtils::rememberAudioStreamIndex(
+                    activeServerId(m_core), item.id,
+                    item.mediaSources[sourceIndex].id, streamIndex);
+            });
+    connect(m_actionWidget, &DetailActionWidget::subtitleStreamChanged, this,
+            [this](int streamIndex)
+            {
+                const MediaItem &item =
+                    m_currentMediaItem.type == "Series" && !m_currentPlayableItem.id.isEmpty()
+                        ? m_currentPlayableItem
+                        : m_currentMediaItem;
+                const int sourceIndex = m_actionWidget->currentSourceIndex();
+                if (sourceIndex < 0 || sourceIndex >= item.mediaSources.size())
+                    return;
+                PlayerPreferenceUtils::rememberSubtitleStreamIndex(
+                    activeServerId(m_core), item.id,
+                    item.mediaSources[sourceIndex].id, streamIndex);
+            });
+    connect(m_actionWidget, &DetailActionWidget::externalPlayRequested, this,
+            [this](const QString &playerPath) -> QCoro::Task<void>
+            { co_await executeExternalPlay(m_currentPlayableItem, playerPath); });
 
+    m_taglineLabel = new QLabel(m_textContainer);
+    m_taglineLabel->setObjectName("detail-tagline");
 
-void DetailView::applySeedToUi(const MediaItem &seed) {
-  m_currentMediaItem = seed;
-  m_titleLabel->setText(seed.name);
+    m_overviewLabel = new QLabel(m_textContainer);
+    m_overviewLabel->setObjectName("detail-overview");
+    m_overviewLabel->setWordWrap(true);
+    m_overviewLabel->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    m_overviewLabel->setAlignment(Qt::AlignTop | Qt::AlignLeft);
+    m_overviewLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
+    connect(m_overviewLabel, &QLabel::linkActivated, this, &DetailView::onOverviewMoreClicked);
 
-  
-  updateMetaRow(seed, formatEpisodeTag(seed));
+    textLayout->addWidget(m_titleLabel);
+    textLayout->addWidget(m_metaRowWidget);
+    textLayout->addWidget(m_tagsWidget);
+    textLayout->addWidget(m_actionWidget);
+    textLayout->addSpacing(4);
+    textLayout->addWidget(m_taglineLabel);
+    textLayout->addWidget(m_overviewLabel);
+    textLayout->addSpacing(10);
 
-  
-  const bool shouldShowNumber = shouldShowDisplayNumber(seed);
-  const QString displayNumber =
-      shouldShowNumber ? extractDisplayNumber(seed) : QString();
-  updateDisplayNumber(displayNumber);
+    m_infoLayout->addWidget(m_textContainer, 1, 1, 1, 1, Qt::AlignTop);
+    m_infoLayout->setColumnStretch(0, 0);
+    m_infoLayout->setColumnStretch(1, 10);
+    m_infoLayout->setColumnStretch(2, 1);
+    contentLayout->addWidget(infoContainer);
 
-  
-  QString text = seed.overview;
-  text.replace(QRegularExpression("<br\\s*/?>",
-                                  QRegularExpression::CaseInsensitiveOption),
-               "\n");
-  text.replace("</p>", "\n\n");
-  text.remove(QRegularExpression("<[^>]*>"));
-  QTextDocument doc;
-  doc.setHtml(text);
-  QString cleanText = doc.toPlainText();
-  cleanText.replace(QChar::LineSeparator, '\n');
-  cleanText.remove(QRegularExpression("<[^>]*>"));
-  m_cleanOverviewText = cleanText;
-  m_lastOverviewWidth = -1;
-  updateOverviewElidedText();
-
-  
-  if (!seed.taglines.isEmpty()) {
-    m_taglineLabel->setText(seed.taglines.first());
-    m_taglineLabel->show();
-  } else {
-    m_taglineLabel->hide();
-  }
-
-  
-  m_isFavorite = seed.isFavorite();
-  m_actionWidget->setFavoriteState(m_isFavorite);
-  m_actionWidget->setPlayedState(seed.userData.played);
-
-  
-  
-  
-  
-  if (seed.type == "Series") {
-    m_actionWidget->setSeriesLoadingMode();
-  } else {
-    m_actionWidget->setupNormalMode(seed);
-  }
-
-  
-  
-  
-  
-  
-  if (!seed.mediaSources.isEmpty()) {
-    m_actionWidget->setSources(seed.mediaSources, 0);
-    if (!seed.mediaSources.first().mediaStreams.isEmpty()) {
-      m_actionWidget->setStreams(seed.mediaSources.first());
-    }
-    m_appliedSourcesFingerprint = computeSourcesFingerprint(seed.mediaSources);
-  } else {
-    m_actionWidget->setSources(QList<MediaSourceInfo>{}, 0);
-    m_actionWidget->setStreams(MediaSourceInfo{});
-    m_appliedSourcesFingerprint =
-        computeSourcesFingerprint(QList<MediaSourceInfo>{});
-  }
-  m_actionWidget->refreshExtPlayerButton();
-
-  
-  
-  
-  buildTagButtons(seed.genres);
-
-  
-  
-  
-  
-  
-  
-  QList<MediaSourceInfo> seedDefaultSource;
-  if (!seed.mediaSources.isEmpty())
-    seedDefaultSource.append(seed.mediaSources.first());
-  m_bottomInfoWidget->setInfo(seed, seedDefaultSource);
-  m_bottomInfoWidget->setVisible(!m_deferBottomInfoReveal);
-  if (m_deferBottomInfoReveal) {
-    showReserveWidget(m_bottomInfoReserveWidget,
-                      reserveHeightFor(m_bottomInfoWidget, 220));
-  } else {
-    hideReserveWidget(m_bottomInfoReserveWidget);
-  }
-  m_appliedBottomInfoFingerprint =
-      computeBottomInfoFingerprint(seed, seedDefaultSource);
-
-  
-  
-  m_currentBackdropPix = QPixmap();
-  updateBackdrop();
-
-  
-  
-  
-  
-  
-  QCoro::connect(executeLoadImages(QPointer<DetailView>(this), m_core, seed,
-                                   false),
-                 this, []() {});
-}
-
-
-
-
-
-void DetailView::buildTagButtons(const QStringList &genres) {
-  if (!m_tagsWidget || !m_tagsLayout)
-    return;
-
-  
-  if (m_tagsLayout->count() == genres.size()) {
-    bool same = true;
-    for (int i = 0; i < genres.size(); ++i) {
-      QLayoutItem *layoutItem = m_tagsLayout->itemAt(i);
-      QWidget *w = layoutItem ? layoutItem->widget() : nullptr;
-      auto *btn = qobject_cast<QPushButton *>(w);
-      if (!btn || btn->text() != genres[i]) {
-        same = false;
-        break;
-      }
-    }
-    if (same)
-      return;
-  }
-
-  m_tagsWidget->setUpdatesEnabled(false);
-  clearLayout(m_tagsLayout);
-  for (const QString &genre : genres) {
-    auto *tagBtn = new DetailTagButton(genre, m_tagsWidget);
-    connect(tagBtn, &QPushButton::clicked, this,
-            [this, genre]() { Q_EMIT navigateToFilteredView("Genre", genre); });
-    m_tagsLayout->addWidget(tagBtn);
-  }
-  m_tagsWidget->setUpdatesEnabled(true);
-  updateTagLayoutHeight();
-  QTimer::singleShot(0, this, [this]() { updateTagLayoutHeight(); });
-}
-
-void DetailView::applyCastSection(const MediaItem &item) {
-  if (!m_castWidget)
-    return;
-
-  const QString fp = castFingerprint(item);
-  if (!fp.isEmpty() && fp == m_appliedCastFingerprint)
-    return;
-
-  if (item.people.isEmpty()) {
-    applyReservedSectionItems(m_castSectionReserveWidget, m_castWidget, {});
-    m_appliedCastFingerprint = fp;
-    return;
-  }
-
-  QList<MediaItem> castItems;
-  castItems.reserve(item.people.size());
-  for (const auto &person : item.people) {
-    MediaItem fakeItem;
-    fakeItem.id = person.id;
-    fakeItem.name = person.name;
-    fakeItem.images.primaryTag = person.primaryImageTag;
     
-    QStringList personParts;
-    if (!person.type.isEmpty()) {
-      
-      static const QHash<QString, const char *> typeMap = {
-          {"Actor", QT_TR_NOOP("Actor")},
-          {"Director", QT_TR_NOOP("Director")},
-          {"Writer", QT_TR_NOOP("Writer")},
-          {"Producer", QT_TR_NOOP("Producer")},
-          {"Composer", QT_TR_NOOP("Composer")},
-          {"Conductor", QT_TR_NOOP("Conductor")},
-          {"GuestStar", QT_TR_NOOP("GuestStar")},
-          {"Editor", QT_TR_NOOP("Editor")},
-          {"Lyricist", QT_TR_NOOP("Lyricist")},
-      };
-      auto it = typeMap.constFind(person.type);
-      personParts << (it != typeMap.constEnd() ? tr(it.value())
-                                               : person.type);
+    
+    
+    m_seasonWidget = new MediaSectionWidget(tr("Seasons"), m_core, m_contentWidget);
+    m_seasonWidget->setCardStyle(MediaCardDelegate::Poster);
+    m_seasonWidget->setGalleryHeight(300);
+
+    
+    m_episodeWidget = new MediaSectionWidget(tr("Episodes"), m_core, m_contentWidget);
+    m_episodeWidget->setCardStyle(MediaCardDelegate::LibraryTile);
+    m_episodeWidget->gallery()->setHoverControls(MediaCardDelegate::HoverControlPlay |
+                                                 MediaCardDelegate::HoverControlMore);
+    
+    
+    {
+        int imgH = 100;
+        int imgW = qRound(imgH * 16.0 / 9.0);                      
+        const QSize episodeTileSize(imgW + 16, 8 + imgH + 6 + 20); 
+        m_episodeTileWidth = episodeTileSize.width();
+        m_episodeWidget->setTileSize(episodeTileSize);
     }
-    if (!person.role.isEmpty())
-      personParts << person.role;
-    fakeItem.overview = personParts.join(" · ");
-    fakeItem.type = "Person";
-    castItems.append(fakeItem);
-  }
+    m_episodeWidget->setGalleryHeight(145);
 
-  applyReservedSectionItems(m_castSectionReserveWidget, m_castWidget,
-                            castItems);
-  m_appliedCastFingerprint = fp;
-}
+    
+    m_episodeHeaderControls = new QWidget(m_episodeWidget);
+    m_episodeHeaderControls->setObjectName("detail-episode-header-controls");
+    m_episodeHeaderControls->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    auto *episodeHeaderLayout = new QHBoxLayout(m_episodeHeaderControls);
+    episodeHeaderLayout->setContentsMargins(0, 0, 0, 0);
+    episodeHeaderLayout->setSpacing(6);
+    episodeHeaderLayout->setSizeConstraint(QLayout::SetFixedSize);
 
-void DetailView::applyCollectionGalleryLayout(
-    const QList<MediaItem> &collections) {
-  int landscapeSignals = 0;
-  int portraitSignals = 0;
+    m_seasonSwitcher = new ModernMenuButton(m_episodeHeaderControls);
+    m_seasonSwitcher->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    m_seasonSwitcher->hide(); 
 
-  const auto hasLandscapeArtwork = [](const MediaItem &item) {
-    const double primaryAspectRatio = item.images.primaryImageAspectRatio;
-    if (primaryAspectRatio > 1.05)
-      return true;
-    if (primaryAspectRatio > 0.0)
-      return false;
+    m_episodeJumpEdit = new QLineEdit(m_episodeHeaderControls);
+    m_episodeJumpEdit->setObjectName("detail-episode-jump-edit");
+    m_episodeJumpEdit->setPlaceholderText(tr("Ep #"));
+    m_episodeJumpEdit->setToolTip(tr("Jump to episode number"));
+    m_episodeJumpEdit->setAlignment(Qt::AlignCenter);
+    m_episodeJumpEdit->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    m_episodeJumpEdit->setFixedWidth(64);
+    m_episodeJumpEdit->setFixedHeight(m_seasonSwitcher->sizeHint().height());
+    m_episodeJumpEdit->setMaxLength(4);
+    m_episodeJumpValidator = new QIntValidator(1, 9999, m_episodeJumpEdit);
+    m_episodeJumpEdit->setValidator(m_episodeJumpValidator);
+    m_episodeJumpEdit->hide(); 
 
-    if (!item.images.primaryTag.isEmpty())
-      return false;
+    episodeHeaderLayout->addWidget(m_seasonSwitcher, 0, Qt::AlignVCenter);
+    episodeHeaderLayout->addWidget(m_episodeJumpEdit, 0, Qt::AlignVCenter);
+    m_episodeHeaderControls->hide();
+    m_episodeWidget->setHeaderWidget(m_episodeHeaderControls);
+    m_episodeHeaderControls->hide();
 
-    return !item.images.thumbTag.isEmpty() ||
-           !item.images.backdropTag.isEmpty() ||
-           !item.images.parentThumbTag.isEmpty() ||
-           !item.images.parentBackdropTag.isEmpty();
-  };
+    m_episodeSectionReserveWidget = createTransparentReserveWidget(m_contentWidget, "detail-episode-section-reserve",
+                                                                   reserveHeightFor(m_episodeWidget, 190));
+    m_seasonSectionReserveWidget = createTransparentReserveWidget(m_contentWidget, "detail-season-section-reserve",
+                                                                  reserveHeightFor(m_seasonWidget, 320));
 
-  for (const MediaItem &collection : collections) {
-    if (hasLandscapeArtwork(collection)) {
-      ++landscapeSignals;
-    } else if (!collection.images.primaryTag.isEmpty() ||
-               collection.images.primaryImageAspectRatio > 0.0) {
-      ++portraitSignals;
-    }
-  }
+    connect(m_seasonSwitcher, &ModernMenuButton::currentIndexChanged, this,
+            [this](int idx)
+            {
+                if (idx >= 0 && idx != m_currentSeasonIndex)
+                {
+                    markManualSeriesSelection(QStringLiteral("season-switcher"));
+                    m_currentSeasonIndex = idx;
+                    QCoro::connect(switchToSeason(idx, true), this, []() {});
+                }
+            });
+    connect(m_episodeJumpEdit, &QLineEdit::editingFinished, this, &DetailView::submitEpisodeJump);
 
-  const bool useLandscapeCards =
-      landscapeSignals > 0 && landscapeSignals > portraitSignals;
+    m_castWidget = new MediaSectionWidget(tr("Cast & Crew"), m_core, m_contentWidget);
+    m_castWidget->setCardStyle(MediaCardDelegate::Cast);
+    m_castWidget->setGalleryHeight(280);
 
-  if (useLandscapeCards) {
-    m_collectionWidget->setCardStyle(MediaCardDelegate::LibraryTile);
-    m_collectionWidget->setGalleryHeight(230);
-  } else {
+    m_castSectionReserveWidget = new QWidget(m_contentWidget);
+    m_castSectionReserveWidget->setObjectName("detail-cast-section-reserve");
+    m_castSectionReserveWidget->setFixedHeight(qMax(320, m_castWidget->sizeHint().height()));
+    m_castSectionReserveWidget->hide();
+
+    m_additionalPartsWidget = new MediaSectionWidget(tr("Additional Parts"), m_core, m_contentWidget);
+    m_additionalPartsWidget->setCardStyle(MediaCardDelegate::Poster);
+    m_additionalPartsWidget->setGalleryHeight(300);
+    m_additionalPartsSectionReserveWidget = createTransparentReserveWidget(
+        m_contentWidget, "detail-additional-section-reserve", reserveHeightFor(m_additionalPartsWidget, 350));
+
+    m_collectionWidget = new MediaSectionWidget(tr("Collection"), m_core, m_contentWidget);
     m_collectionWidget->setCardStyle(MediaCardDelegate::Poster);
     m_collectionWidget->setGalleryHeight(300);
-  }
+    m_collectionSectionReserveWidget = createTransparentReserveWidget(
+        m_contentWidget, "detail-collection-section-reserve", reserveHeightFor(m_collectionWidget, 350));
 
-  qDebug() << "[DetailView] Collection gallery layout"
-           << "itemCount=" << collections.size()
-           << "landscapeSignals=" << landscapeSignals
-           << "portraitSignals=" << portraitSignals
-           << "style="
-           << (useLandscapeCards ? "LibraryTile" : "Poster");
+    m_similarWidget = new MediaSectionWidget(tr("More Like This"), m_core, m_contentWidget);
+    m_similarWidget->setCardStyle(MediaCardDelegate::Poster);
+    m_similarWidget->setGalleryHeight(300);
+    m_similarSectionReserveWidget = createTransparentReserveWidget(m_contentWidget, "detail-similar-section-reserve",
+                                                                   reserveHeightFor(m_similarWidget, 350));
+
+    m_seasonWidget->gallery()->listView()->viewport()->installEventFilter(this);
+    m_episodeWidget->gallery()->listView()->viewport()->installEventFilter(this);
+    m_castWidget->gallery()->listView()->viewport()->installEventFilter(this);
+    m_additionalPartsWidget->gallery()->listView()->viewport()->installEventFilter(this);
+    m_collectionWidget->gallery()->listView()->viewport()->installEventFilter(this);
+    m_similarWidget->gallery()->listView()->viewport()->installEventFilter(this);
+
+    auto connectGallerySignals = [this](MediaSectionWidget *widget)
+    {
+        connect(widget, &MediaSectionWidget::playRequested, this, &BaseView::handlePlayRequested);
+        connect(widget, &MediaSectionWidget::favoriteRequested, this, &BaseView::handleFavoriteRequested);
+        connect(widget, &MediaSectionWidget::moreMenuRequested, this, &BaseView::handleMoreMenuRequested);
+    };
+
+    connectGallerySignals(m_castWidget);
+    connectGallerySignals(m_additionalPartsWidget);
+    connectGallerySignals(m_collectionWidget);
+    connectGallerySignals(m_similarWidget);
+
+    connect(m_seasonWidget, &MediaSectionWidget::playRequested, this,
+            [this](MediaItem item) -> QCoro::Task<void>
+            {
+                if (item.type == "Season")
+                {
+                    markManualSeriesSelection(QStringLiteral("season-play"));
+                    co_await executePlaySeason(item);
+                }
+                else
+                {
+                    handlePlayRequested(item);
+                }
+            });
+    connect(m_seasonWidget, &MediaSectionWidget::favoriteRequested, this, &BaseView::handleFavoriteRequested);
+    connect(m_seasonWidget, &MediaSectionWidget::moreMenuRequested, this, &BaseView::handleMoreMenuRequested);
+
+    connect(m_episodeWidget, &MediaSectionWidget::playRequested, this,
+            [this](MediaItem item) -> QCoro::Task<void>
+            {
+                if (item.type == "Episode")
+                {
+                    markManualSeriesSelection(QStringLiteral("episode-play"));
+                    co_await applySeriesPlayableItem(item, false);
+                    if (m_currentPlayableItem.id == item.id)
+                    {
+                        co_await executePlay(m_currentPlayableItem,
+                                             m_currentPlayableItem.userData.playbackPositionTicks);
+                    }
+                }
+                else
+                {
+                    handlePlayRequested(item);
+                }
+            });
+    connect(m_episodeWidget, &MediaSectionWidget::favoriteRequested, this, &BaseView::handleFavoriteRequested);
+    connect(m_episodeWidget, &MediaSectionWidget::moreMenuRequested, this,
+            [this](const MediaItem &item, const QPoint &globalPos)
+            {
+                MediaActionMenu menu(item, m_core, this,
+                                     {CardContextMenuAction::MarkPlayed, CardContextMenuAction::MarkUnplayed});
+                CardContextMenuRequest request = menu.execRequest(globalPos);
+                dispatchCardContextMenuRequest(item, request);
+            });
+
+    auto commonClicked = [this](const MediaItem &item)
+    {
+        if (item.type == "BoxSet" || item.type == "Playlist" || item.type == "Folder")
+            Q_EMIT navigateToFolder(item.id, item.name);
+        else if (item.type == "Person")
+            Q_EMIT navigateToPerson(item.id, item.name);
+        else
+            Q_EMIT navigateToDetail(item.id, item.name, item);
+    };
+
+    
+    connect(m_seasonWidget, &MediaSectionWidget::itemClicked, this,
+            [this](const MediaItem &item)
+            {
+                if (item.type == "Season")
+                    Q_EMIT navigateToSeason(m_currentItemId, item.id, item.name);
+                else
+                    Q_EMIT navigateToDetail(item.id, item.name, item);
+            });
+
+    
+    connect(m_episodeWidget, &MediaSectionWidget::itemClicked, this,
+            [this, commonClicked](const MediaItem &item)
+            {
+                if (item.type == "Episode")
+                {
+                    markManualSeriesSelection(QStringLiteral("episode-click"));
+                    QCoro::connect(applySeriesPlayableItem(item, true), this, []() {});
+                }
+                else
+                {
+                    commonClicked(item);
+                }
+            });
+
+    connect(m_castWidget, &MediaSectionWidget::itemClicked, this,
+            [this](const MediaItem &item) { Q_EMIT navigateToPerson(item.id, item.name); });
+    connect(m_additionalPartsWidget, &MediaSectionWidget::itemClicked, this, commonClicked);
+    connect(m_collectionWidget, &MediaSectionWidget::itemClicked, this,
+            [this, commonClicked](const MediaItem &item)
+            {
+                if (!item.id.isEmpty())
+                {
+                    qDebug() << "[DetailView] Navigate collection membership"
+                             << "itemId=" << item.id << "name=" << item.name << "type=" << item.type
+                             << "collectionType=" << item.collectionType;
+                    Q_EMIT navigateToFolder(item.id, item.name);
+                    return;
+                }
+                commonClicked(item);
+            });
+    connect(m_similarWidget, &MediaSectionWidget::itemClicked, this, commonClicked);
+
+    contentLayout->addWidget(m_episodeSectionReserveWidget);
+    contentLayout->addWidget(m_episodeWidget);
+    contentLayout->addWidget(m_seasonSectionReserveWidget);
+    contentLayout->addWidget(m_seasonWidget);
+    contentLayout->addWidget(m_castSectionReserveWidget);
+    contentLayout->addWidget(m_castWidget);
+    contentLayout->addWidget(m_additionalPartsSectionReserveWidget);
+    contentLayout->addWidget(m_additionalPartsWidget);
+    contentLayout->addWidget(m_collectionSectionReserveWidget);
+    contentLayout->addWidget(m_collectionWidget);
+    contentLayout->addWidget(m_similarSectionReserveWidget);
+    contentLayout->addWidget(m_similarWidget);
+
+    m_bottomInfoWidget = new DetailBottomInfoWidget(m_contentWidget);
+    connect(m_bottomInfoWidget, &DetailBottomInfoWidget::filterClicked, this,
+            [this](const QString &type, const QString &value) { Q_EMIT navigateToFilteredView(type, value); });
+    m_bottomInfoReserveWidget = createTransparentReserveWidget(m_contentWidget, "detail-bottom-info-reserve", 220);
+    contentLayout->addWidget(m_bottomInfoReserveWidget);
+    contentLayout->addWidget(m_bottomInfoWidget);
+
+    contentLayout->addStretch();
+    m_mainScrollArea->setWidget(m_contentWidget);
+    mainLayout->addWidget(m_mainScrollArea);
+    m_mainScrollArea->viewport()->installEventFilter(this);
 }
 
+void DetailView::loadItem(QString itemId, MediaItem seedItem)
+{
+    QPointer<DetailView> safeThis(this);
+    setDeferredPresentationBatchActive(false);
+    m_currentItemId = itemId;
+    
+    
+    m_skipNextSilentRefresh = true;
+    m_pendingDeferredFetchId = itemId;
+    m_pendingFetchedItem = MediaItem{};
+    m_pendingFetchReady = false;
+    m_pendingAnimationGuardDone = false;
+    m_pendingFetchedItemFromCache = false;
+    m_deferBottomInfoReveal = false;
+    m_currentPlayableItem = MediaItem{};
+    m_currentSeasonEpisodes.clear();
+    updateEpisodeJumpControl(0);
+    
+    m_appliedSourcesFingerprint.clear();
+    m_appliedBottomInfoFingerprint.clear();
+    m_detailCacheServerId.clear();
+    m_detailCacheUserId.clear();
+    m_cachedDetailFingerprint.clear();
+    m_cachedSectionsFingerprint.clear();
+    m_cachedSeriesPlayableItem = MediaItem{};
+    m_cachedSeriesSeasons.clear();
+    m_cachedSeasonEpisodes.clear();
+    m_cachedSimilarItems.clear();
+    m_cachedCollections.clear();
+    m_cachedAdditionalParts.clear();
+    m_cachedSeasonId.clear();
+    m_manualSelectedSeasonId.clear();
+    m_manualSelectedEpisodeId.clear();
+    m_cachedSeasonIndex = -1;
+    m_manualSelectedSeasonIndex = -1;
+    m_hasManualSeriesSelection = false;
+    m_hasCachedSeriesPlayableItem = false;
+    m_hasCachedSeriesSeasons = false;
+    m_hasCachedSeasonEpisodes = false;
+    m_hasCachedSimilarItems = false;
+    m_hasCachedCollections = false;
+    m_hasCachedAdditionalParts = false;
+    m_hasCachedCastData = false;
+    m_appliedCachedCastToUi = false;
+    m_appliedCachedSeriesSeasonsToUi = false;
+    m_appliedCachedSeasonEpisodesToUi = false;
+    m_appliedCachedSimilarItemsToUi = false;
+    m_appliedCachedCollectionsToUi = false;
+    m_appliedCachedAdditionalPartsToUi = false;
+    m_appliedCastFingerprint.clear();
+    m_appliedSeriesPlayableFingerprint.clear();
 
-
-
-
-
-
-QCoro::Task<void>
-DetailView::executeFetchSecondaries(QPointer<DetailView> safeThis,
-                                    QEmbyCore *core, QString targetId,
-                                    QString itemType) {
-  if (!safeThis)
-    co_return;
-
-  
-  
-  if (itemType == "Series") {
-    if (!safeThis->m_hasManualSeriesSelection &&
-        safeThis->m_hasCachedSeriesPlayableItem &&
-        safeThis->m_cachedSeriesPlayableItem.type == "Episode" &&
-        !safeThis->m_cachedSeriesPlayableItem.id.isEmpty()) {
-      safeThis->applySeriesPlayableItemToUi(
-          safeThis->m_cachedSeriesPlayableItem);
-      qDebug() << "[DetailView][cache-ui] Applied cached series playable item"
-               << "seriesId=" << targetId
-               << "episodeId=" << safeThis->m_cachedSeriesPlayableItem.id;
+    if (m_core && m_core->serverManager())
+    {
+        const ServerProfile profile = m_core->serverManager()->activeProfile();
+        m_detailCacheServerId = profile.id;
+        m_detailCacheUserId = profile.userId;
     }
-    qDebug() << "[DetailView][network] Fetch series next-up"
-             << "seriesId=" << targetId
-             << "applyToUi=" << !safeThis->m_hasManualSeriesSelection;
-    co_await safeThis->fetchSeriesNextUp(
-        targetId, !safeThis->m_hasManualSeriesSelection);
-    if (!safeThis || safeThis->m_currentItemId != targetId)
-      co_return;
-
-    
-    qDebug() << "[DetailView][network] Fetch series seasons"
-             << "seriesId=" << targetId;
-    auto seasons = co_await core->mediaService()->getSeasons(targetId);
-    if (!safeThis || safeThis->m_currentItemId != targetId)
-      co_return;
-
-    bool seasonsUnchanged = false;
-    if (safeThis->m_appliedCachedSeriesSeasonsToUi) {
-      seasonsUnchanged = co_await mediaItemListsEqualAsync(
-          safeThis->m_cachedSeriesSeasons, seasons);
-      if (!safeThis || safeThis->m_currentItemId != targetId)
-        co_return;
-    }
-    safeThis->m_seriesSeasons = seasons;
-    safeThis->m_cachedSeriesSeasons = seasons;
-    safeThis->m_hasCachedSeriesSeasons = true;
 
     
     
-    int targetSeasonIdx = 0;
-    bool selectedSeasonResolved = false;
-    if (safeThis->m_hasManualSeriesSelection &&
-        !safeThis->m_manualSelectedSeasonId.isEmpty()) {
-      for (int i = 0; i < seasons.size(); ++i) {
-        if (seasons[i].id == safeThis->m_manualSelectedSeasonId) {
-          targetSeasonIdx = i;
-          selectedSeasonResolved = true;
-          break;
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    const bool hasSeed = !seedItem.id.isEmpty();
+    
+    
+    
+    m_deferBottomInfoReveal = hasSeed;
+
+    if (hasSeed)
+    {
+        m_currentPlayableItem = seedItem;
+        applySeedToUi(seedItem);
+        if (seedItem.type == "Series")
+        {
+            prepareReservedSection(m_episodeSectionReserveWidget, m_episodeWidget,
+                                   reserveHeightFor(m_episodeWidget, 190));
+            prepareReservedSection(m_seasonSectionReserveWidget, m_seasonWidget, reserveHeightFor(m_seasonWidget, 320));
         }
-      }
-    }
-    if (!selectedSeasonResolved &&
-        safeThis->m_hasManualSeriesSelection &&
-        safeThis->m_manualSelectedSeasonIndex >= 0 &&
-        safeThis->m_manualSelectedSeasonIndex < seasons.size()) {
-      targetSeasonIdx = safeThis->m_manualSelectedSeasonIndex;
-      selectedSeasonResolved = true;
-    }
-    if (!selectedSeasonResolved &&
-        safeThis->m_hasManualSeriesSelection &&
-        safeThis->m_currentSeasonIndex >= 0 &&
-        safeThis->m_currentSeasonIndex < seasons.size()) {
-      targetSeasonIdx = safeThis->m_currentSeasonIndex;
-      selectedSeasonResolved = true;
-    }
-    int playableParentIdx = safeThis->m_currentPlayableItem.parentIndexNumber;
-    if (!selectedSeasonResolved &&
-        !safeThis->m_hasManualSeriesSelection && playableParentIdx >= 0) {
-      for (int i = 0; i < seasons.size(); ++i) {
-        if (seasons[i].indexNumber == playableParentIdx) {
-          targetSeasonIdx = i;
-          break;
+        else
+        {
+            hideReserveWidget(m_episodeSectionReserveWidget);
+            hideReserveWidget(m_seasonSectionReserveWidget);
+            m_seasonWidget->clear();
+            m_episodeWidget->clear();
         }
-      }
     }
-    if (!seasons.isEmpty())
-      targetSeasonIdx = qBound(0, targetSeasonIdx, seasons.size() - 1);
-    safeThis->m_currentSeasonIndex = targetSeasonIdx;
+    else
+    {
+        
+        m_titleLabel->setText(tr("Loading..."));
+        m_logoLabel->clear();
+        m_logoLabel->hide();
+        m_metaLabel->clear();
+        updateDisplayNumber(QString());
+        m_metaRowWidget->hide();
+        m_overviewLabel->clear();
+        m_taglineLabel->hide();
+
+        m_currentBackdropPix = QPixmap();
+        m_currentPosterPix = QPixmap();
+        updateBackdrop();
+        m_posterLabel->setPixmap(QPixmap());
+
+        m_actionWidget->clear();
+        m_bottomInfoWidget->clear();
+        clearLayout(m_tagsLayout);
+
+        m_seasonWidget->clear();
+        m_episodeWidget->clear();
+        hideReserveWidget(m_episodeSectionReserveWidget);
+        hideReserveWidget(m_seasonSectionReserveWidget);
+
+        m_seriesSeasons.clear();
+        m_currentSeasonIndex = 0;
+        if (m_seasonSwitcher)
+        {
+            QSignalBlocker blocker(m_seasonSwitcher);
+            m_seasonSwitcher->clear();
+            m_seasonSwitcher->hide();
+        }
+        updateEpisodeHeaderControlsVisibility();
+    }
 
     
-    if (!seasons.isEmpty() && safeThis->m_episodeWidget) {
-      safeThis->updateSeasonSwitcher(targetSeasonIdx);
+    
+    prepareReservedSection(m_castSectionReserveWidget, m_castWidget, reserveHeightFor(m_castWidget, 320));
+    prepareReservedSection(m_additionalPartsSectionReserveWidget, m_additionalPartsWidget,
+                           reserveHeightFor(m_additionalPartsWidget, 350));
+    prepareReservedSection(m_collectionSectionReserveWidget, m_collectionWidget,
+                           reserveHeightFor(m_collectionWidget, 350));
+    prepareReservedSection(m_similarSectionReserveWidget, m_similarWidget, reserveHeightFor(m_similarWidget, 350));
 
-      const QString playableItemId =
-          safeThis->m_hasManualSeriesSelection &&
-                  !safeThis->m_manualSelectedEpisodeId.isEmpty()
-              ? safeThis->m_manualSelectedEpisodeId
-              : safeThis->m_currentPlayableItem.id;
-      co_await safeThis->loadEpisodesForSeason(
-          targetSeasonIdx, playableItemId, !playableItemId.isEmpty(),
-          safeThis->m_hasManualSeriesSelection);
-    } else if (safeThis->m_episodeWidget) {
-      applyReservedSectionItems(safeThis->m_episodeSectionReserveWidget,
-                                safeThis->m_episodeWidget, {});
-    }
-    if (!safeThis || safeThis->m_currentItemId != targetId)
-      co_return;
+    scrollToTop();
 
     
-    if (safeThis->m_seasonWidget && !seasonsUnchanged) {
-      safeThis->m_seasonWidget->setTitle(tr("Seasons"));
-      safeThis->m_seasonWidget->setCardStyle(MediaCardDelegate::Poster);
-      safeThis->m_seasonWidget->setGalleryHeight(300);
-      applyReservedSectionItems(safeThis->m_seasonSectionReserveWidget,
-                                safeThis->m_seasonWidget, seasons);
-    }
-  }
-
-  
-  if (safeThis->m_currentItemId != targetId)
-    co_return;
-  qDebug() << "[DetailView][ui] Apply cast section"
-           << "itemId=" << targetId
-           << "afterSeriesSections=" << (itemType == "Series");
-  safeThis->applyCastSection(safeThis->m_currentMediaItem);
-  if (safeThis->m_deferBottomInfoReveal) {
-    safeThis->m_deferBottomInfoReveal = false;
-    hideReserveWidget(safeThis->m_bottomInfoReserveWidget);
-    if (safeThis->m_bottomInfoWidget)
-      safeThis->m_bottomInfoWidget->show();
-  }
-  if (!safeThis)
-    co_return;
-
-  
-  
-  
-  try {
-    qDebug() << "[DetailView][network] Fetch similar items"
-             << "itemId=" << targetId;
-    QList<MediaItem> similar =
-        co_await core->mediaService()->getSimilarItems(targetId, 15);
-    if (!safeThis || safeThis->m_currentItemId != targetId)
-      co_return;
-
-    bool similarUnchanged = false;
-    if (safeThis->m_appliedCachedSimilarItemsToUi) {
-      similarUnchanged = co_await mediaItemListsEqualAsync(
-          safeThis->m_cachedSimilarItems, similar);
-      if (!safeThis || safeThis->m_currentItemId != targetId)
-        co_return;
-    }
-    safeThis->m_cachedSimilarItems = similar;
-    safeThis->m_hasCachedSimilarItems = true;
-    if (!similarUnchanged) {
-      applyReservedSectionItems(safeThis->m_similarSectionReserveWidget,
-                                safeThis->m_similarWidget, similar);
-    }
-  } catch (...) {
-    if (safeThis && safeThis->m_currentItemId == targetId &&
-        !safeThis->m_appliedCachedSimilarItemsToUi) {
-      applyReservedSectionItems(safeThis->m_similarSectionReserveWidget,
-                                safeThis->m_similarWidget, {});
-    }
-  }
-  if (!safeThis)
-    co_return;
-
-  
-  
-  try {
-    qDebug() << "[DetailView][network] Fetch item collections"
-             << "itemId=" << targetId;
-    QList<MediaItem> collections =
-        co_await core->mediaService()->getItemCollections(targetId);
-    if (!safeThis || safeThis->m_currentItemId != targetId)
-      co_return;
-
-    bool collectionsUnchanged = false;
-    if (safeThis->m_appliedCachedCollectionsToUi) {
-      collectionsUnchanged = co_await mediaItemListsEqualAsync(
-          safeThis->m_cachedCollections, collections);
-      if (!safeThis || safeThis->m_currentItemId != targetId)
-        co_return;
-    }
-    safeThis->m_cachedCollections = collections;
-    safeThis->m_hasCachedCollections = true;
-    if (!collectionsUnchanged) {
-      safeThis->applyCollectionGalleryLayout(collections);
-      applyReservedSectionItems(safeThis->m_collectionSectionReserveWidget,
-                                safeThis->m_collectionWidget, collections);
-    }
-  } catch (...) {
-    if (safeThis && safeThis->m_currentItemId == targetId &&
-        !safeThis->m_appliedCachedCollectionsToUi) {
-      applyReservedSectionItems(safeThis->m_collectionSectionReserveWidget,
-                                safeThis->m_collectionWidget, {});
-    }
-  }
-  if (!safeThis)
-    co_return;
-
-  
-  try {
-    qDebug() << "[DetailView][network] Fetch additional parts"
-             << "itemId=" << targetId;
-    QList<MediaItem> additionalParts =
-        co_await core->mediaService()->getAdditionalParts(targetId);
-    if (!safeThis || safeThis->m_currentItemId != targetId)
-      co_return;
-
-    bool additionalPartsUnchanged = false;
-    if (safeThis->m_appliedCachedAdditionalPartsToUi) {
-      additionalPartsUnchanged = co_await mediaItemListsEqualAsync(
-          safeThis->m_cachedAdditionalParts, additionalParts);
-      if (!safeThis || safeThis->m_currentItemId != targetId)
-        co_return;
-    }
-    safeThis->m_cachedAdditionalParts = additionalParts;
-    safeThis->m_hasCachedAdditionalParts = true;
-    if (!additionalPartsUnchanged) {
-      applyReservedSectionItems(safeThis->m_additionalPartsSectionReserveWidget,
-                                safeThis->m_additionalPartsWidget,
-                                additionalParts);
-    }
-  } catch (...) {
-    if (safeThis && safeThis->m_currentItemId == targetId &&
-        !safeThis->m_appliedCachedAdditionalPartsToUi) {
-      applyReservedSectionItems(
-          safeThis->m_additionalPartsSectionReserveWidget,
-          safeThis->m_additionalPartsWidget, {});
-    }
-  }
-
-  if (safeThis && safeThis->m_currentItemId == targetId)
-    safeThis->persistDetailCacheSnapshot(QStringLiteral("secondaries"));
-}
-
-QCoro::Task<void> DetailView::fetchSeriesNextUp(const QString &targetId,
-                                                bool applyToUi) {
-  QPointer<DetailView> safeThis(this);
-  try {
-    MediaItem playableItem;
-    qDebug() << "[DetailView][network] Fetch next-up"
-             << "seriesId=" << targetId;
-    auto nextUp = co_await m_core->mediaService()->getNextUp(targetId);
-
-    if (!nextUp.isEmpty())
-      playableItem = nextUp.first();
-    else {
-      qDebug() << "[DetailView][network] Fetch seasons for next-up fallback"
-               << "seriesId=" << targetId;
-      auto seasons = co_await m_core->mediaService()->getSeasons(targetId);
-      if (!seasons.isEmpty()) {
-        qDebug() << "[DetailView][network] Fetch episodes for next-up fallback"
-                 << "seriesId=" << targetId
-                 << "seasonId=" << seasons.first().id;
-        auto episodes = co_await m_core->mediaService()->getEpisodes(
-            targetId, seasons.first().id);
-        if (!episodes.isEmpty())
-          playableItem = episodes.first();
-      }
+    
+    if (!itemId.isEmpty())
+    {
+        QCoro::connect(loadDetailCacheAndStartPrefetch(itemId, seedItem, m_detailCacheServerId, m_detailCacheUserId),
+                       this, []() {});
     }
 
-    if (safeThis && safeThis->m_currentItemId == targetId &&
-        !playableItem.id.isEmpty()) {
-      safeThis->m_cachedSeriesPlayableItem = playableItem;
-      safeThis->m_hasCachedSeriesPlayableItem = true;
+    
+    
+    QTimer::singleShot(380, this,
+                       [safeThis, itemId]()
+                       {
+                           if (!safeThis || safeThis->m_pendingDeferredFetchId != itemId)
+                               return;
+                           if (safeThis->m_posterShadow)
+                               safeThis->m_posterShadow->setEnabled(true);
+                           safeThis->m_pendingAnimationGuardDone = true;
+                           safeThis->maybeFlushDeferredUpdate(itemId);
+                       });
 
-      if (!applyToUi || safeThis->m_hasManualSeriesSelection) {
-        qDebug() << "[DetailView][network] Updated server next-up cache without "
-                    "changing manual selection"
-                 << "seriesId=" << targetId
-                 << "episodeId=" << playableItem.id
-                 << "applyToUi=" << applyToUi
-                 << "manualSelection="
-                 << safeThis->m_hasManualSeriesSelection;
-        safeThis->persistDetailCacheSnapshot(
-            QStringLiteral("series-server-next-up"));
-        co_return;
-      }
-
-      co_await safeThis->applySeriesPlayableItem(playableItem);
-    }
-  } catch (...) {
-  }
-}
-
-void DetailView::applySeriesPlayableItemToUi(const MediaItem &playableItem,
-                                             bool scrollToEpisode) {
-  if (playableItem.id.isEmpty() || m_currentMediaItem.type != "Series")
     return;
-
-  const QString playableFingerprint =
-      DetailCacheUtils::fingerprint(playableItem);
-  const bool playableUnchanged =
-      !m_appliedSeriesPlayableFingerprint.isEmpty() &&
-      playableFingerprint == m_appliedSeriesPlayableFingerprint;
-  m_currentPlayableItem = playableItem;
-  const QString episodeTag = formatEpisodeTag(playableItem);
-
-  if (!playableUnchanged) {
-    const QString actionTag =
-        episodeTag.isEmpty() ? playableItem.name : episodeTag;
-    m_actionWidget->setupSeriesMode(playableItem, actionTag);
-    updateMetaRow(m_currentMediaItem, episodeTag);
-
-    m_actionWidget->setSources(playableItem.mediaSources, 0);
-    m_appliedSourcesFingerprint =
-        computeSourcesFingerprint(playableItem.mediaSources);
-
-    QList<MediaSourceInfo> selectedSources;
-    if (!playableItem.mediaSources.isEmpty()) {
-      int sourceIndex = m_actionWidget->currentSourceIndex();
-      if (sourceIndex >= playableItem.mediaSources.size())
-        sourceIndex = 0;
-
-      const MediaSourceInfo &selectedSource =
-          playableItem.mediaSources[sourceIndex];
-      m_actionWidget->setStreams(selectedSource);
-      selectedSources.append(selectedSource);
-    } else {
-      m_actionWidget->setStreams(MediaSourceInfo{});
-    }
-
-    if (!selectedSources.isEmpty()) {
-      const QString bottomInfoFingerprint =
-          computeBottomInfoFingerprint(playableItem, selectedSources);
-      if (bottomInfoFingerprint != m_appliedBottomInfoFingerprint) {
-        m_bottomInfoWidget->setInfo(playableItem, selectedSources);
-        m_appliedBottomInfoFingerprint = bottomInfoFingerprint;
-        m_bottomInfoWidget->setVisible(!m_deferBottomInfoReveal);
-        if (m_deferBottomInfoReveal) {
-          showReserveWidget(m_bottomInfoReserveWidget,
-                            reserveHeightFor(m_bottomInfoWidget, 220));
-        } else {
-          hideReserveWidget(m_bottomInfoReserveWidget);
-        }
-      } else {
-        m_bottomInfoWidget->setVisible(!m_deferBottomInfoReveal);
-      }
-    }
-
-    m_appliedSeriesPlayableFingerprint = playableFingerprint;
-  }
-
-  m_actionWidget->refreshExtPlayerButton();
-  m_actionWidget->setPlayedState(playableItem.userData.played);
-  if (m_episodeWidget) {
-    m_episodeWidget->gallery()->setHighlightedItemId(playableItem.id);
-    if (scrollToEpisode)
-      m_episodeWidget->gallery()->scrollToItemId(playableItem.id);
-  }
-
-  qDebug() << "[DetailView] Apply series playable item"
-           << "seriesId=" << m_currentItemId << "episodeId=" << playableItem.id
-           << "episodeTag=" << episodeTag
-           << "sourceCount=" << playableItem.mediaSources.size();
 }
 
-QCoro::Task<void> DetailView::applySeriesPlayableItem(MediaItem playableItem,
-                                                      bool scrollToEpisode) {
-  if (playableItem.id.isEmpty() || m_currentMediaItem.type != "Series")
-    co_return;
+QCoro::Task<void> DetailView::loadDetailCacheAndStartPrefetch(QString itemId, MediaItem seedItem, QString cacheServerId,
+                                                              QString cacheUserId)
+{
+    QPointer<DetailView> safeThis(this);
+    QString targetId = std::move(itemId);
+    MediaItem seed = std::move(seedItem);
+    QString serverId = std::move(cacheServerId);
+    QString userId = std::move(cacheUserId);
+    QString cachedFingerprint;
 
-  QPointer<DetailView> safeThis(this);
-  const QString seriesId = m_currentItemId;
-  const QString playableItemId = playableItem.id;
-
-  applySeriesPlayableItemToUi(playableItem, scrollToEpisode);
-  rememberSeriesSelection(playableItem, QStringLiteral("series-selection"),
-                          true);
-
-  const bool needsPlaybackInfo =
-      playableItem.mediaSources.isEmpty() ||
-      playableItem.mediaSources.first().mediaStreams.isEmpty();
-  if (!needsPlaybackInfo)
-    co_return;
-
-  try {
-    PlaybackInfo info =
-        co_await m_core->mediaService()->getPlaybackInfo(playableItemId);
-    if (!safeThis || safeThis->m_currentItemId != seriesId ||
-        safeThis->m_currentMediaItem.type != "Series" ||
-        safeThis->m_currentPlayableItem.id != playableItemId)
-      co_return;
-    if (!info.mediaSources.isEmpty()) {
-      playableItem.mediaSources = info.mediaSources;
-      safeThis->applySeriesPlayableItemToUi(playableItem, false);
-      safeThis->rememberSeriesSelection(
-          playableItem, QStringLiteral("series-selection-playback-info"),
-          true);
-    }
-  } catch (...) {
-  }
-}
-
-QCoro::Task<void> DetailView::onVersionChanged(int index) {
-  const bool usePlayableItem =
-      m_currentMediaItem.type == "Series" && !m_currentPlayableItem.id.isEmpty();
-  MediaItem actionItem = usePlayableItem ? m_currentPlayableItem
-                                         : m_currentMediaItem;
-  if (index < 0 || index >= actionItem.mediaSources.size())
-    co_return;
-  MediaSourceInfo source = actionItem.mediaSources[index];
-  QPointer<DetailView> safeThis(this);
-  const QString expectedPageId = m_currentItemId;
-  const QString actionItemId = actionItem.id;
-
-  if (source.mediaStreams.isEmpty()) {
-    try {
-      PlaybackInfo info =
-          co_await m_core->mediaService()->getPlaybackInfo(actionItemId);
-      if (!safeThis || safeThis->m_currentItemId != expectedPageId)
-        co_return;
-      if (!info.mediaSources.isEmpty()) {
-        if (usePlayableItem) {
-          if (safeThis->m_currentPlayableItem.id != actionItemId)
+    if (!serverId.isEmpty() && !userId.isEmpty() && !targetId.isEmpty())
+    {
+        auto cacheFuture = QtConcurrent::run(
+            [serverId, userId, targetId]() mutable
+            { return DetailCacheUtils::load(serverId, userId, targetId); });
+        const auto cachedEntry = co_await cacheFuture;
+        if (!safeThis || safeThis->m_currentItemId != targetId)
             co_return;
-          safeThis->m_currentPlayableItem.mediaSources = info.mediaSources;
-          actionItem = safeThis->m_currentPlayableItem;
-        } else {
-          safeThis->m_currentMediaItem.mediaSources = info.mediaSources;
 
-          
-          
-          safeThis->m_currentPlayableItem.mediaSources = info.mediaSources;
-          actionItem = safeThis->m_currentMediaItem;
-        }
-
-        int selectedIndex = index;
-        if (selectedIndex >= actionItem.mediaSources.size())
-          selectedIndex = 0;
-        if (selectedIndex < actionItem.mediaSources.size()) {
-          source = actionItem.mediaSources[selectedIndex];
-        }
-      }
-    } catch (...) {
-      co_return;
-    }
-  }
-  if (!safeThis || source.mediaStreams.isEmpty())
-    co_return;
-
-  safeThis->m_actionWidget->setStreams(source);
-  QList<MediaSourceInfo> singleSource;
-  singleSource.append(source);
-  const MediaItem infoItem =
-      usePlayableItem ? safeThis->m_currentPlayableItem
-                      : safeThis->m_currentMediaItem;
-  safeThis->m_bottomInfoWidget->setInfo(infoItem, singleSource);
-  hideReserveWidget(safeThis->m_bottomInfoReserveWidget);
-}
-
-QCoro::Task<void> DetailView::executePlay(MediaItem targetItem,
-                                          long long startTicks) {
-  if (targetItem.id.isEmpty())
-    co_return;
-  try {
-    MediaItem actualItem = targetItem;
-    if (actualItem.mediaSources.isEmpty()) {
-      PlaybackInfo info =
-          co_await m_core->mediaService()->getPlaybackInfo(actualItem.id);
-      actualItem.mediaSources = info.mediaSources;
-    }
-    if (actualItem.mediaSources.isEmpty())
-      co_return;
-
-    int sourceIdx = 0;
-    int selectedAudioIdx = -1;
-    int selectedSubIdx = -1;
-    const bool useUiSelection = isCurrentActionItem(actualItem.id);
-
-    if (useUiSelection) {
-      
-      sourceIdx = m_actionWidget->currentSourceIndex();
-      selectedAudioIdx = m_actionWidget->currentAudioIndex();
-      selectedSubIdx = m_actionWidget->currentSubtitleIndex();
-    } else {
-      sourceIdx = MediaSourcePreferenceUtils::resolvePreferredMediaSourceIndex(
-          actualItem.mediaSources,
-          ConfigStore::instance()
-              ->get<QString>(ConfigKeys::PlayerPreferredVersion)
-              .trimmed());
-    }
-
-    if (sourceIdx >= actualItem.mediaSources.size())
-      sourceIdx = 0;
-    MediaSourceInfo modifiedSource = actualItem.mediaSources[sourceIdx];
-
-    if (useUiSelection) {
-      
-      
-      
-      for (auto &stream : modifiedSource.mediaStreams) {
-        if (stream.type == "Audio" && selectedAudioIdx >= 0)
-          stream.isDefault = (stream.index == selectedAudioIdx);
-        else if (stream.type == "Subtitle" && selectedSubIdx >= 0)
-          stream.isDefault = (stream.index == selectedSubIdx);
-      }
-    } else {
-      PlayerPreferenceUtils::applyPreferredStreamRules(
-          modifiedSource,
-          ConfigStore::instance()->get<QString>(ConfigKeys::PlayerAudioLang,
-                                                "auto"),
-          ConfigStore::instance()->get<QString>(ConfigKeys::PlayerSubLang,
-                                                "auto"));
-    }
-
-    QString streamUrl =
-        m_core->mediaService()->getStreamUrl(actualItem.id, modifiedSource.id);
-
-    const QString playTitle =
-        MediaItemUtils::playbackTitle(actualItem, m_currentMediaItem.name);
-
-    
-    PlaybackManager::instance()->startInternalPlayback(
-        actualItem.id, playTitle, streamUrl, startTicks,
-        QVariant::fromValue(modifiedSource));
-  } catch (...) {
-  }
-}
-
-QCoro::Task<void> DetailView::executePlaySeason(MediaItem seasonItem) {
-  if (seasonItem.id.isEmpty() || m_currentItemId.isEmpty() || !m_core ||
-      !m_core->mediaService())
-    co_return;
-
-  QPointer<DetailView> safeThis(this);
-  const QString seriesId = m_currentItemId;
-  const QString seasonId = seasonItem.id;
-
-  try {
-    QList<MediaItem> episodes =
-        co_await m_core->mediaService()->getEpisodes(seriesId, seasonId);
-    if (!safeThis || safeThis->m_currentItemId != seriesId)
-      co_return;
-
-    MediaItem targetEpisode = resolveSeasonPlaybackEpisode(episodes);
-    if (targetEpisode.id.isEmpty())
-      co_return;
-
-    qDebug() << "[DetailView] Play season"
-             << "seriesId=" << seriesId << "seasonId=" << seasonId
-             << "episodeId=" << targetEpisode.id
-             << "episodeTag=" << formatEpisodeTag(targetEpisode)
-             << "episodeCount=" << episodes.size()
-             << "startTicks="
-             << targetEpisode.userData.playbackPositionTicks;
-
-    co_await safeThis->applySeriesPlayableItem(targetEpisode, false);
-    if (!safeThis || safeThis->m_currentItemId != seriesId)
-      co_return;
-
-    const MediaItem playbackItem =
-        safeThis->m_currentPlayableItem.id == targetEpisode.id
-            ? safeThis->m_currentPlayableItem
-            : targetEpisode;
-    co_await safeThis->executePlay(
-        playbackItem, playbackItem.userData.playbackPositionTicks);
-  } catch (...) {
-  }
-}
-
-QCoro::Task<void> DetailView::executeExternalPlay(MediaItem targetItem,
-                                                  QString playerPath) {
-  if (targetItem.id.isEmpty() || playerPath.isEmpty())
-    co_return;
-  try {
-    MediaItem actualItem = targetItem;
-    if (actualItem.mediaSources.isEmpty()) {
-      PlaybackInfo info =
-          co_await m_core->mediaService()->getPlaybackInfo(actualItem.id);
-      actualItem.mediaSources = info.mediaSources;
-    }
-    if (actualItem.mediaSources.isEmpty())
-      co_return;
-
-    
-    int sourceIdx = 0;
-    const bool useUiSelection = isCurrentActionItem(actualItem.id);
-    if (useUiSelection) {
-      sourceIdx = m_actionWidget->currentSourceIndex();
-    }
-    if (sourceIdx >= actualItem.mediaSources.size())
-      sourceIdx = 0;
-    MediaSourceInfo modifiedSource = actualItem.mediaSources[sourceIdx];
-
-    if (useUiSelection) {
-      int selectedAudioIdx = m_actionWidget->currentAudioIndex();
-      int selectedSubIdx = m_actionWidget->currentSubtitleIndex();
-      for (auto &stream : modifiedSource.mediaStreams) {
-        if (stream.type == "Audio" && selectedAudioIdx >= 0)
-          stream.isDefault = (stream.index == selectedAudioIdx);
-        else if (stream.type == "Subtitle" && selectedSubIdx >= 0)
-          stream.isDefault = (stream.index == selectedSubIdx);
-      }
-    } else {
-      PlayerPreferenceUtils::applyPreferredStreamRules(
-          modifiedSource,
-          ConfigStore::instance()->get<QString>(ConfigKeys::PlayerAudioLang,
-                                                "auto"),
-          ConfigStore::instance()->get<QString>(ConfigKeys::PlayerSubLang,
-                                                "auto"));
-    }
-
-    QString streamUrl =
-        m_core->mediaService()->getStreamUrl(actualItem.id, modifiedSource.id);
-
-    const QString playTitle =
-        MediaItemUtils::playbackTitle(actualItem, m_currentMediaItem.name);
-
-    long long startTicks = actualItem.userData.playbackPositionTicks;
-    PlaybackManager::instance()->startExternalPlayback(
-        playerPath, actualItem.id, playTitle, streamUrl, startTicks,
-        QVariant::fromValue(modifiedSource));
-  } catch (...) {
-  }
-}
-
-void DetailView::updateBackdrop() {
-  if (m_contentWidget)
-    static_cast<DetailContentWidget *>(m_contentWidget)
-        ->setBackdrop(m_currentBackdropPix);
-}
-
-void DetailView::updateTagLayoutHeight() {
-  if (!m_tagsWidget || !m_tagsLayout)
-    return;
-
-  int targetWidth = m_tagsWidget->width();
-  if (targetWidth <= 0 && m_textContainer) {
-    targetWidth = m_textContainer->contentsRect().width();
-  }
-
-  if (targetWidth <= 0) {
-    m_tagsWidget->updateGeometry();
-    QTimer::singleShot(50, this, [this]() { updateTagLayoutHeight(); });
-    return;
-  }
-
-  m_tagsLayout->invalidate();
-  const int targetHeight = m_tagsLayout->heightForWidth(targetWidth);
-  if (m_tagsWidget->minimumHeight() != targetHeight) {
-    m_tagsWidget->setMinimumHeight(targetHeight);
-  }
-  m_tagsWidget->updateGeometry();
-
-  if (m_textContainer) {
-    m_textContainer->updateGeometry();
-  }
-}
-
-void DetailView::resizeEvent(QResizeEvent *event) {
-  QWidget::resizeEvent(event);
-  if (m_overviewLabel && m_overviewLabel->width() > 10 &&
-      qAbs(m_overviewLabel->width() - m_lastOverviewWidth) > 5) {
-    m_lastOverviewWidth = m_overviewLabel->width();
-    updateOverviewElidedText();
-  }
-  updateTagLayoutHeight();
-  updateEpisodeJumpControl(m_currentSeasonEpisodes.size());
-}
-
-bool DetailView::eventFilter(QObject *obj, QEvent *event) {
-  if (m_mainScrollArea && obj == m_mainScrollArea->viewport() &&
-      event->type() == QEvent::Resize) {
-    QResizeEvent *re = static_cast<QResizeEvent *>(event);
-    int newWidth = re->size().width();
-    if (m_contentWidget && newWidth > 100 &&
-        m_contentWidget->maximumWidth() != newWidth) {
-      m_contentWidget->setMaximumWidth(newWidth);
-      QTimer::singleShot(0, this, [this]() {
-        updateTagLayoutHeight();
-        updateEpisodeJumpControl(m_currentSeasonEpisodes.size());
-      });
-    }
-  }
-  if (m_episodeWidget && m_episodeWidget->gallery() &&
-      obj == m_episodeWidget->gallery()->listView()->viewport() &&
-      event->type() == QEvent::Resize) {
-    QTimer::singleShot(0, this, [this]() {
-      updateEpisodeJumpControl(m_currentSeasonEpisodes.size());
-    });
-  }
-  if (event->type() == QEvent::Wheel) {
-    bool isHorizontalViewport =
-        obj->parent() &&
-        obj->parent()->property("isHorizontalListView").toBool();
-    bool isMainViewport =
-        (m_mainScrollArea && obj == m_mainScrollArea->viewport());
-    if (isHorizontalViewport || isMainViewport) {
-      QWheelEvent *we = static_cast<QWheelEvent *>(event);
-      if (m_vScrollController) {
-        m_vScrollController->scrollByWheelEvent(we, Qt::Vertical);
-      }
-      return true;
-    }
-  }
-  return QWidget::eventFilter(obj, event);
-}
-
-void DetailView::showEvent(QShowEvent *event) {
-  BaseView::showEvent(event);
-
-  
-  
-  if (m_skipNextSilentRefresh) {
-    m_skipNextSilentRefresh = false;
-    return;
-  }
-
-  
-  
-  
-  m_pendingDeferredFetchId.clear();
-
-  if (!m_currentItemId.isEmpty() && m_core && m_core->mediaService()) {
-    executeSilentRefresh(QPointer<DetailView>(this), m_core, m_currentItemId);
-  }
-}
-
-void DetailView::clearLayout(QLayout *layout) {
-  if (!layout)
-    return;
-  QLayoutItem *child;
-  while ((child = layout->takeAt(0)) != nullptr) {
-    if (child->widget()) {
-      child->widget()->hide();
-      child->widget()->setParent(nullptr);
-      child->widget()->deleteLater();
-    } else if (child->layout()) {
-      clearLayout(child->layout());
-    }
-    delete child;
-  }
-}
-
-QString DetailView::formatRunTime(long long ticks) {
-  long long totalSeconds = ticks / 10000000;
-  long long hours = totalSeconds / 3600;
-  long long minutes = (totalSeconds % 3600) / 60;
-  if (hours > 0)
-    return QString(tr("%1 hr %2 min")).arg(hours).arg(minutes);
-  return QString(tr("%1 min")).arg(minutes);
-}
-
-bool DetailView::shouldShowDisplayNumber(const MediaItem &item) const {
-  if (item.type.compare("Movie", Qt::CaseInsensitive) != 0) {
-    return false;
-  }
-
-  static const QList<QRegularExpression> adultMarkers = {
-      QRegularExpression(R"((^|[^0-9])18\+?([^0-9]|$))",
-                         QRegularExpression::CaseInsensitiveOption),
-      QRegularExpression(R"(\b(?:R[-\s]?18\+?|NC[-\s]?17|JAV|AV)\b)",
-                         QRegularExpression::CaseInsensitiveOption),
-      QRegularExpression(QStringLiteral("(成人|无码|有码|無碼|有碼)"))};
-
-  const auto containsAdultMarker = [](const QString &value) -> bool {
-    const QString trimmedValue = value.trimmed();
-    if (trimmedValue.isEmpty()) {
-      return false;
-    }
-
-    for (const QRegularExpression &pattern : adultMarkers) {
-      if (pattern.match(trimmedValue).hasMatch()) {
-        return true;
-      }
-    }
-
-    return false;
-  };
-
-  if (containsAdultMarker(item.officialRating)) {
-    return true;
-  }
-
-  for (const QString &genre : item.genres) {
-    if (containsAdultMarker(genre)) {
-      return true;
-    }
-  }
-
-  for (const QString &tag : item.tags) {
-    if (containsAdultMarker(tag)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-bool DetailView::isCurrentActionItem(const QString &itemId) const {
-  if (itemId.isEmpty())
-    return false;
-  if (itemId == m_currentMediaItem.id)
-    return true;
-  return m_currentMediaItem.type == "Series" &&
-         itemId == m_currentPlayableItem.id;
-}
-
-QStringList DetailView::buildNumberCandidates(const MediaItem &item) const {
-  QStringList candidates;
-  const auto appendCandidate = [&candidates](const QString &value) {
-    const QString trimmedValue = value.trimmed();
-    if (!trimmedValue.isEmpty() && !candidates.contains(trimmedValue)) {
-      candidates.append(trimmedValue);
-    }
-  };
-
-  for (const MediaSourceInfo &source : item.mediaSources) {
-    appendCandidate(source.path);
-  }
-
-  appendCandidate(item.path);
-  appendCandidate(item.name);
-  appendCandidate(item.originalTitle);
-  appendCandidate(item.sortName);
-
-  for (const QString &tagline : item.taglines) {
-    appendCandidate(tagline);
-  }
-
-  for (const QString &tag : item.tags) {
-    appendCandidate(tag);
-  }
-
-  return candidates;
-}
-
-QString DetailView::extractDisplayNumber(const MediaItem &item) const {
-  static const NumberExtractor extractor(true);
-  const QStringList candidates = buildNumberCandidates(item);
-  const QString displayNumber = extractor.extractBestNumber(candidates);
-
-  qDebug() << "[DetailView] adult number extraction itemId=" << item.id
-           << "officialRating=" << item.officialRating
-           << "candidateCount=" << candidates.size()
-           << "selected=" << displayNumber;
-
-  return displayNumber;
-}
-
-void DetailView::updateDisplayNumber(const QString &number) {
-  if (!m_numberButton || !m_metaRowWidget) {
-    return;
-  }
-
-  const QString trimmedNumber = number.trimmed();
-  const bool hasNumber = !trimmedNumber.isEmpty();
-  m_numberButton->setVisible(hasNumber);
-  m_numberButton->setText(trimmedNumber);
-  m_numberButton->setToolTip(hasNumber ? tr("Click to copy number")
-                                       : QString());
-  m_metaRowWidget->setVisible(!m_metaLabel->text().isEmpty() || hasNumber);
-}
-
-void DetailView::copyDisplayedNumber() {
-  if (!m_numberButton) {
-    return;
-  }
-
-  const QString displayNumber = m_numberButton->text().trimmed();
-  if (displayNumber.isEmpty()) {
-    return;
-  }
-
-  if (QClipboard *clipboard = QGuiApplication::clipboard()) {
-    clipboard->setText(displayNumber);
-  }
-
-  qDebug() << "[DetailView] copied display number" << displayNumber
-           << "for itemId" << m_currentItemId;
-  ModernToast::showMessage(tr("Number copied: %1").arg(displayNumber), 2000);
-}
-
-void DetailView::markManualSeriesSelection(const QString &reason) {
-  if (m_currentMediaItem.type != "Series")
-    return;
-
-  if (!m_hasManualSeriesSelection) {
-    qDebug() << "[DetailView] Manual series selection locked server auto-sync"
-             << "seriesId=" << m_currentItemId << "reason=" << reason;
-  }
-  m_hasManualSeriesSelection = true;
-}
-
-void DetailView::rememberSeriesSelection(const MediaItem &episode,
-                                         const QString &reason,
-                                         bool persist) {
-  if (m_currentMediaItem.type != "Series")
-    return;
-
-  int selectedSeasonIndex = -1;
-  QString selectedSeasonId;
-  bool hasSelectedSeason = false;
-  if (episode.type == "Episode" && episode.parentIndexNumber >= 0) {
-    for (int i = 0; i < m_seriesSeasons.size(); ++i) {
-      if (m_seriesSeasons[i].indexNumber == episode.parentIndexNumber) {
-        selectedSeasonIndex = i;
-        selectedSeasonId = m_seriesSeasons[i].id;
-        hasSelectedSeason = true;
-        break;
-      }
-    }
-  } else {
-    selectedSeasonIndex = m_currentSeasonIndex;
-    if (selectedSeasonIndex >= 0 &&
-        selectedSeasonIndex < m_seriesSeasons.size()) {
-      selectedSeasonId = m_seriesSeasons[selectedSeasonIndex].id;
-      hasSelectedSeason = true;
-    }
-  }
-
-  if (hasSelectedSeason) {
-    if (persist) {
-      m_cachedSeasonIndex = selectedSeasonIndex;
-      m_cachedSeasonId = selectedSeasonId;
-    } else {
-      m_manualSelectedSeasonIndex = selectedSeasonIndex;
-      m_manualSelectedSeasonId = selectedSeasonId;
-    }
-  }
-  if (episode.type == "Episode" && !episode.id.isEmpty()) {
-    if (persist) {
-      m_cachedSeriesPlayableItem = episode;
-      m_hasCachedSeriesPlayableItem = true;
-    } else {
-      m_manualSelectedEpisodeId = episode.id;
-    }
-  }
-
-  qDebug() << "[DetailView] Remember series selection"
-           << "seriesId=" << m_currentItemId
-           << "seasonIndex="
-           << (persist ? m_cachedSeasonIndex : m_manualSelectedSeasonIndex)
-           << "seasonId="
-           << (persist ? m_cachedSeasonId : m_manualSelectedSeasonId)
-           << "episodeId="
-           << (persist ? m_cachedSeriesPlayableItem.id
-                       : m_manualSelectedEpisodeId)
-           << "persist=" << persist << "reason=" << reason;
-
-  if (persist)
-    persistDetailCacheSnapshot(reason);
-}
-
-void DetailView::updateOverviewElidedText() {
-  if (m_cleanOverviewText.isEmpty() || !m_overviewLabel)
-    return;
-
-  const int generation = ++m_overviewElideGeneration;
-  QPointer<DetailView> safeThis(this);
-  QTimer::singleShot(0, this, [safeThis, generation]() {
-    if (!safeThis || generation != safeThis->m_overviewElideGeneration)
-      return;
-
-    int labelWidth = safeThis->m_overviewLabel->contentsRect().width();
-    if (labelWidth <= 10 && safeThis->m_textContainer)
-      labelWidth = safeThis->m_textContainer->contentsRect().width();
-    if (labelWidth <= 10)
-      return;
-
-    QFontMetrics fm(safeThis->m_overviewLabel->font());
-    int maxHeight = fm.lineSpacing() * 5 + 10;
-    QTextDocument doc;
-    doc.setDefaultFont(safeThis->m_overviewLabel->font());
-    doc.setTextWidth(labelWidth);
-
-    QString fullHtml = safeThis->m_cleanOverviewText.toHtmlEscaped();
-    fullHtml.replace("\n", "<br>");
-    doc.setHtml(fullHtml);
-
-    if (doc.size().height() <= maxHeight) {
-      if (safeThis->m_overviewLabel->text() != fullHtml)
-        safeThis->m_overviewLabel->setText(fullHtml);
-      return;
-    }
-
-    int low = 0, high = safeThis->m_cleanOverviewText.length(), best = 0;
-    QString moreLink =
-        safeThis->tr("... <a href='more' style='color:#3B82F6; "
-                     "text-decoration:none; font-weight:bold;'>More</a>");
-    while (low <= high) {
-      int mid = low + (high - low) / 2;
-      QString testHtml =
-          safeThis->m_cleanOverviewText.left(mid).toHtmlEscaped();
-      testHtml.replace("\n", "<br>");
-      doc.setHtml(testHtml + moreLink);
-      if (doc.size().height() <= maxHeight) {
-        best = mid;
-        low = mid + 1;
-      } else {
-        high = mid - 1;
-      }
-    }
-
-    QString finalHtml =
-        safeThis->m_cleanOverviewText.left(best).toHtmlEscaped();
-    finalHtml.replace("\n", "<br>");
-    const QString overviewHtml = finalHtml + moreLink;
-    if (safeThis->m_overviewLabel->text() != overviewHtml)
-      safeThis->m_overviewLabel->setText(overviewHtml);
-  });
-}
-
-QCoro::Task<void> DetailView::updateUi(MediaItem item, bool isSilentRefresh) {
-  m_currentMediaItem = item;
-  if (!isSilentRefresh && item.type == "Series")
-    m_deferBottomInfoReveal = true;
-  m_titleLabel->setText(item.name);
-
-  const QString metaEpisodeTag =
-      item.type == "Series" && m_currentPlayableItem.type == "Episode"
-          ? formatEpisodeTag(m_currentPlayableItem)
-          : formatEpisodeTag(item);
-  updateMetaRow(item, metaEpisodeTag);
-
-  const bool shouldShowNumber = shouldShowDisplayNumber(item);
-  const QString displayNumber =
-      shouldShowNumber ? extractDisplayNumber(item) : QString();
-  updateDisplayNumber(displayNumber);
-
-  qDebug() << "[DetailView] updateUi itemId=" << item.id
-           << "adultMovie=" << shouldShowNumber
-           << "displayNumber=" << displayNumber;
-
-  QString text = item.overview;
-  text.replace(QRegularExpression("<br\\s*/?>",
-                                  QRegularExpression::CaseInsensitiveOption),
-               "\n");
-  text.replace("</p>", "\n\n");
-  text.remove(QRegularExpression("<[^>]*>"));
-  QTextDocument doc;
-  doc.setHtml(text);
-  QString cleanText = doc.toPlainText();
-  cleanText.replace(QChar::LineSeparator, '\n');
-  cleanText.remove(QRegularExpression("<[^>]*>"));
-  m_cleanOverviewText = cleanText;
-  m_lastOverviewWidth = -1;
-  updateOverviewElidedText();
-
-  if (item.type == "Series") {
-    const bool hasCurrentEpisode =
-        m_currentPlayableItem.type == "Episode" &&
-        !m_currentPlayableItem.id.isEmpty();
-    if (!isSilentRefresh && !hasCurrentEpisode)
-      m_actionWidget->setSeriesLoadingMode();
-  } else {
-    
-    
-    m_currentPlayableItem = item;
-    m_actionWidget->setupNormalMode(item);
-  }
-
-  
-  
-  const QString newSourcesFingerprint =
-      computeSourcesFingerprint(item.mediaSources);
-  const bool sourcesUnchanged =
-      !m_appliedSourcesFingerprint.isEmpty() &&
-      newSourcesFingerprint == m_appliedSourcesFingerprint;
-  const bool sourcesOwnedBySeriesEpisode =
-      item.type == "Series" && m_currentPlayableItem.type == "Episode" &&
-      !m_currentPlayableItem.id.isEmpty();
-  if (!sourcesOwnedBySeriesEpisode && !sourcesUnchanged) {
-    m_actionWidget->setSources(item.mediaSources, 0);
-    m_appliedSourcesFingerprint = newSourcesFingerprint;
-    if (item.mediaSources.isEmpty() ||
-        item.mediaSources.first().mediaStreams.isEmpty()) {
-      m_actionWidget->setStreams(MediaSourceInfo{});
-    }
-  }
-  m_actionWidget->refreshExtPlayerButton();
-
-  if (!item.taglines.isEmpty()) {
-    m_taglineLabel->setText(item.taglines.first());
-    m_taglineLabel->show();
-  } else {
-    m_taglineLabel->hide();
-  }
-
-  m_isFavorite = item.isFavorite();
-  m_actionWidget->setFavoriteState(m_isFavorite);
-  m_actionWidget->setPlayedState(item.userData.played);
-
-  
-  
-  buildTagButtons(item.genres);
-
-  QCoro::connect(executeLoadImages(QPointer<DetailView>(this), m_core, item,
-                                   true),
-                 this, []() {});
-
-  QPointer<DetailView> safeThis(this);
-
-  
-  
-  auto applyBottomInfo = [this, &item](const QList<MediaSourceInfo> &srcs) {
-    const QString fp = computeBottomInfoFingerprint(item, srcs);
-    if (fp == m_appliedBottomInfoFingerprint)
-      return;
-    m_bottomInfoWidget->setInfo(item, srcs);
-    m_appliedBottomInfoFingerprint = fp;
-    if (m_deferBottomInfoReveal) {
-      showReserveWidget(m_bottomInfoReserveWidget,
-                        reserveHeightFor(m_bottomInfoWidget, 220));
-    }
-  };
-
-  if (sourcesOwnedBySeriesEpisode) {
-    applySeriesPlayableItemToUi(m_currentPlayableItem);
-  } else if (!item.mediaSources.isEmpty() &&
-             !item.mediaSources.first().mediaStreams.isEmpty()) {
-    int defaultIndex = m_actionWidget->currentSourceIndex();
-    QList<MediaSourceInfo> defaultSource;
-    if (defaultIndex < item.mediaSources.size()) {
-      const MediaSourceInfo &dSrc = item.mediaSources[defaultIndex];
-      
-      
-      if (!sourcesUnchanged)
-        m_actionWidget->setStreams(dSrc);
-      defaultSource.append(dSrc);
-    }
-    applyBottomInfo(defaultSource);
-  } else {
-    
-    
-    applyBottomInfo({});
-    if (item.mediaType == "Video" || item.mediaType == "Audio" ||
-        item.type == "Movie" || item.type == "Episode") {
-      try {
-        PlaybackInfo info =
-            co_await m_core->mediaService()->getPlaybackInfo(item.id);
-        if (!safeThis)
-          co_return;
-        if (item.id == safeThis->m_currentItemId &&
-            !info.mediaSources.isEmpty()) {
-          safeThis->m_currentMediaItem.mediaSources = info.mediaSources;
-
-          const QString refreshedNumber =
-              safeThis->shouldShowDisplayNumber(safeThis->m_currentMediaItem)
-                  ? safeThis->extractDisplayNumber(safeThis->m_currentMediaItem)
-                  : QString();
-          safeThis->updateDisplayNumber(refreshedNumber);
-
-          
-          
-          if (item.type != "Series") {
-            safeThis->m_currentPlayableItem.mediaSources = info.mediaSources;
-          }
-
-          int idx = safeThis->m_actionWidget->currentSourceIndex();
-          if (idx >= info.mediaSources.size())
-            idx = 0;
-          safeThis->m_actionWidget->setSources(info.mediaSources, idx);
-          safeThis->m_appliedSourcesFingerprint =
-              computeSourcesFingerprint(info.mediaSources);
-          idx = safeThis->m_actionWidget->currentSourceIndex();
-          if (idx >= safeThis->m_currentMediaItem.mediaSources.size())
-            idx = 0;
-          if (idx < safeThis->m_currentMediaItem.mediaSources.size()) {
-            const MediaSourceInfo &singleSource =
-                safeThis->m_currentMediaItem.mediaSources[idx];
-            safeThis->m_actionWidget->setStreams(singleSource);
-            QList<MediaSourceInfo> sList;
-            sList.append(singleSource);
-            
-            const QString fp = computeBottomInfoFingerprint(
-                safeThis->m_currentMediaItem, sList);
-            if (fp != safeThis->m_appliedBottomInfoFingerprint) {
-              safeThis->m_bottomInfoWidget->setInfo(
-                  safeThis->m_currentMediaItem, sList);
-              safeThis->m_appliedBottomInfoFingerprint = fp;
-              if (safeThis->m_deferBottomInfoReveal) {
-                showReserveWidget(
-                    safeThis->m_bottomInfoReserveWidget,
-                    reserveHeightFor(safeThis->m_bottomInfoWidget, 220));
-              }
+        if (cachedEntry.has_value())
+        {
+            MediaItem cachedItem = withSeedContext(cachedEntry->item, seed);
+            cachedFingerprint = cachedEntry->fingerprint;
+
+            safeThis->m_cachedDetailFingerprint = cachedEntry->fingerprint;
+            safeThis->m_cachedSectionsFingerprint = cachedEntry->sectionsFingerprint;
+            safeThis->m_cachedSeriesPlayableItem = withSeedContext(cachedEntry->playableItem, MediaItem{});
+            safeThis->m_cachedSeriesSeasons = cachedEntry->seasons;
+            safeThis->m_cachedSeasonEpisodes = cachedEntry->seasonEpisodes;
+            safeThis->m_cachedSimilarItems = cachedEntry->similarItems;
+            safeThis->m_cachedCollections = cachedEntry->collections;
+            safeThis->m_cachedAdditionalParts = cachedEntry->additionalParts;
+            safeThis->m_cachedSeasonId = cachedEntry->seasonId;
+            safeThis->m_cachedSeasonIndex = cachedEntry->seasonIndex;
+            safeThis->m_manualSelectedSeasonId.clear();
+            safeThis->m_manualSelectedSeasonIndex = -1;
+            safeThis->m_manualSelectedEpisodeId.clear();
+            safeThis->m_hasCachedSeriesPlayableItem =
+                cachedEntry->hasPlayableItem && cachedEntry->playableItemFromServer;
+            if (!safeThis->m_hasCachedSeriesPlayableItem)
+                safeThis->m_cachedSeriesPlayableItem = MediaItem{};
+            safeThis->m_hasCachedSeriesSeasons = cachedEntry->hasSeasons;
+            safeThis->m_hasCachedSeasonEpisodes = cachedEntry->hasSeasonEpisodes;
+            safeThis->m_hasCachedSimilarItems = cachedEntry->hasSimilarItems;
+            safeThis->m_hasCachedCollections = cachedEntry->hasCollections;
+            safeThis->m_hasCachedAdditionalParts = cachedEntry->hasAdditionalParts;
+            safeThis->m_hasCachedCastData = !cachedItem.people.isEmpty();
+            const bool hasCachedSecondaryData = cacheEntryHasAnySecondaryData(*cachedEntry);
+
+            if (!cachedItem.name.trimmed().isEmpty())
+            {
+                safeThis->m_pendingFetchedItem = cachedItem;
+                safeThis->m_pendingFetchReady = true;
+                safeThis->m_pendingFetchedItemFromCache = true;
+
+                
+                
+                const bool hasSeedUi = safeThis->m_currentMediaItem.id == targetId &&
+                                       !safeThis->m_currentMediaItem.name.trimmed().isEmpty();
+                if (!hasSeedUi)
+                {
+                    safeThis->applySeedToUi(cachedItem);
+                }
+                safeThis->maybeFlushDeferredUpdate(targetId);
+
+                qDebug() << "[DetailView] Detail cache hit"
+                         << "itemId=" << targetId << "fingerprint=" << cachedFingerprint.left(12)
+                         << "hasSecondaryCache=" << hasCachedSecondaryData << "deferredSeedApply=" << hasSeedUi;
             }
-          }
+            else
+            {
+                cachedFingerprint.clear();
+                safeThis->m_cachedDetailFingerprint.clear();
+                safeThis->m_cachedSectionsFingerprint.clear();
+                safeThis->m_cachedSeriesPlayableItem = MediaItem{};
+                safeThis->m_cachedSeriesSeasons.clear();
+                safeThis->m_cachedSeasonEpisodes.clear();
+                safeThis->m_cachedSimilarItems.clear();
+                safeThis->m_cachedCollections.clear();
+                safeThis->m_cachedAdditionalParts.clear();
+                safeThis->m_cachedSeasonId.clear();
+                safeThis->m_manualSelectedSeasonId.clear();
+                safeThis->m_manualSelectedEpisodeId.clear();
+                safeThis->m_cachedSeasonIndex = -1;
+                safeThis->m_manualSelectedSeasonIndex = -1;
+                safeThis->m_hasCachedSeriesPlayableItem = false;
+                safeThis->m_hasCachedSeriesSeasons = false;
+                safeThis->m_hasCachedSeasonEpisodes = false;
+                safeThis->m_hasCachedSimilarItems = false;
+                safeThis->m_hasCachedCollections = false;
+                safeThis->m_hasCachedAdditionalParts = false;
+                safeThis->m_hasCachedCastData = false;
+                qWarning() << "[DetailView] Ignore incomplete detail cache"
+                           << "itemId=" << targetId << "file=" << cachedEntry->filePath;
+            }
         }
-      } catch (...) {
-      }
+        else
+        {
+            qDebug() << "[DetailView] Detail cache miss"
+                     << "itemId=" << targetId;
+        }
     }
-  }
 
-  if (!safeThis)
-    co_return;
-  safeThis->m_bottomInfoWidget->setVisible(
-      !safeThis->m_deferBottomInfoReveal);
-  if (safeThis->m_deferBottomInfoReveal) {
-    showReserveWidget(safeThis->m_bottomInfoReserveWidget,
-                      reserveHeightFor(safeThis->m_bottomInfoWidget, 220));
-  } else {
-    hideReserveWidget(safeThis->m_bottomInfoReserveWidget);
-  }
-  if (!isSilentRefresh && safeThis)
-    QMetaObject::invokeMethod(safeThis.data(), "scrollToTop",
-                              Qt::QueuedConnection);
+    if (!safeThis || safeThis->m_currentItemId != targetId)
+        co_return;
+
+    if (safeThis->m_core && safeThis->m_core->mediaService())
+    {
+        QCoro::connect(safeThis->prefetchItemDetail(targetId, serverId, userId, cachedFingerprint), safeThis.data(),
+                       []() {});
+    }
 }
 
-void DetailView::onOverviewMoreClicked(const QString &link) {
-  if (link == "more") {
-    OverviewDialog dialog(this);
-    dialog.setMediaItem(m_currentMediaItem, m_currentPosterPix);
-    dialog.exec();
-  }
+QCoro::Task<void> DetailView::prefetchItemDetail(QString itemId, QString cacheServerId, QString cacheUserId,
+                                                 QString cachedFingerprint)
+{
+    QPointer<DetailView> safeThis(this);
+    QPointer<MediaService> mediaService(
+        m_core ? m_core->mediaService() : nullptr);
+    QString targetId = std::move(itemId);
+    QString serverId = std::move(cacheServerId);
+    QString userId = std::move(cacheUserId);
+    QString previousFingerprint = std::move(cachedFingerprint);
+
+    try
+    {
+        if (!mediaService)
+            co_return;
+        MediaItem item = co_await mediaService->getItemDetail(targetId);
+        auto fingerprintFuture = QtConcurrent::run(
+            [item]() mutable { return DetailCacheUtils::fingerprint(item); });
+        const QString fetchedFingerprint = co_await fingerprintFuture;
+        const bool differsFromCache = previousFingerprint.isEmpty() || fetchedFingerprint != previousFingerprint;
+
+        if (differsFromCache)
+        {
+            saveDetailCacheAsync(serverId, userId, item, fetchedFingerprint);
+        }
+        else
+        {
+            qDebug() << "[DetailView] Detail cache unchanged"
+                     << "itemId=" << targetId << "fingerprint=" << fetchedFingerprint.left(12);
+        }
+
+        if (!safeThis || (safeThis->m_pendingDeferredFetchId != targetId && safeThis->m_currentItemId != targetId))
+        {
+            
+            co_return;
+        }
+
+        safeThis->m_cachedDetailFingerprint = fetchedFingerprint;
+
+        if (safeThis->m_pendingDeferredFetchId == targetId)
+        {
+            if (!differsFromCache && safeThis->m_pendingFetchReady && safeThis->m_pendingFetchedItemFromCache)
+            {
+                safeThis->maybeFlushDeferredUpdate(targetId);
+                co_return;
+            }
+
+            
+            
+            safeThis->m_pendingFetchedItem = std::move(item);
+            safeThis->m_pendingFetchReady = true;
+            safeThis->m_pendingFetchedItemFromCache = false;
+            safeThis->maybeFlushDeferredUpdate(targetId);
+            co_return;
+        }
+
+        
+        if (safeThis->m_currentItemId == targetId && differsFromCache)
+        {
+            qDebug() << "[DetailView] Applying refreshed detail after cache"
+                     << "itemId=" << targetId;
+            QCoro::connect(safeThis->executeDeferredUpdate(std::move(item), true), safeThis.data(), []() {});
+        }
+    }
+    catch (...)
+    {
+        if (safeThis && safeThis->m_pendingDeferredFetchId == targetId)
+        {
+            if (!safeThis->m_pendingFetchReady && safeThis->m_currentMediaItem.id != targetId)
+            {
+                safeThis->m_pendingDeferredFetchId.clear();
+                const QString errorText = DetailView::tr("Error Loading Item");
+                QMetaObject::invokeMethod(
+                    safeThis.data(),
+                    [safeThis, targetId, errorText]()
+                    {
+                        if (safeThis && safeThis->m_currentItemId == targetId)
+                            safeThis->m_titleLabel->setText(errorText);
+                    },
+                    Qt::QueuedConnection);
+            }
+            else
+            {
+                qDebug() << "[DetailView] Detail refresh failed; using existing data"
+                         << "itemId=" << targetId;
+            }
+        }
+    }
 }
 
-QCoro::Task<void>
-DetailView::executeSilentRefresh(QPointer<DetailView> safeThis, QEmbyCore *core,
-                                 QString itemId) {
-  QString cacheServerId;
-  QString cacheUserId;
-  if (core && core->serverManager()) {
-    const ServerProfile profile = core->serverManager()->activeProfile();
-    cacheServerId = profile.id;
-    cacheUserId = profile.userId;
-  }
+void DetailView::maybeFlushDeferredUpdate(const QString &itemId)
+{
+    if (m_pendingDeferredFetchId != itemId)
+        return;
+    if (!m_pendingFetchReady || !m_pendingAnimationGuardDone)
+        return;
 
-  try {
-    MediaItem item = co_await core->mediaService()->getItemDetail(itemId);
-    if (!cacheServerId.isEmpty() && !cacheUserId.isEmpty()) {
-      const QString fp = co_await QtConcurrent::run(
-          [item]() mutable { return DetailCacheUtils::fingerprint(item); });
-      saveDetailCacheAsync(cacheServerId, cacheUserId, item, fp);
-      if (safeThis && item.id == safeThis->m_currentItemId)
-        safeThis->m_cachedDetailFingerprint = fp;
+    
+    m_pendingDeferredFetchId.clear();
+
+    MediaItem item = m_pendingFetchedItem;
+    const bool fromCache = m_pendingFetchedItemFromCache;
+    m_pendingFetchedItem = MediaItem{};
+    m_pendingFetchReady = false;
+    m_pendingAnimationGuardDone = false;
+    m_pendingFetchedItemFromCache = false;
+
+    if (item.type != "Series" || m_currentPlayableItem.type != "Episode" || m_currentPlayableItem.id.isEmpty())
+    {
+        m_currentPlayableItem = item;
     }
-    if (safeThis && item.id == safeThis->m_currentItemId) {
-      co_await safeThis->updateUi(item, true);
+    qDebug() << "[DetailView] Deferred detail update"
+             << "itemId=" << itemId << "fromCache=" << fromCache;
+    QCoro::connect(executeDeferredUpdate(std::move(item)), this, []() {});
+}
 
-      
-      if (item.type == "Series") {
-        co_await safeThis->fetchSeriesNextUp(
-            itemId, !safeThis->m_hasManualSeriesSelection);
-        if (!safeThis || safeThis->m_currentItemId != itemId)
-          co_return;
+QCoro::Task<void> DetailView::executeDeferredUpdate(MediaItem item, bool isSilentRefresh)
+{
+    QPointer<DetailView> safeThis(this);
+    const QString targetId = item.id;
+    const QString detectedType = item.type;
+    const bool batchPresentation = isVisible();
 
-        auto seasons = co_await core->mediaService()->getSeasons(itemId);
-        if (!safeThis || safeThis->m_currentItemId != itemId)
-          co_return;
+    if (batchPresentation)
+    {
+        
+        
+        
+        setDeferredPresentationBatchActive(true);
+        QTimer::singleShot(160, this,
+                           [safeThis]()
+                           {
+                               if (safeThis && safeThis->m_deferredPresentationBatchActive)
+                                   safeThis->setDeferredPresentationBatchActive(false);
+                           });
+    }
 
+    
+    
+    
+    co_await updateUi(item, isSilentRefresh);
+    if (!safeThis)
+        co_return;
+    safeThis->persistDetailCacheSnapshot(QStringLiteral("detail-ui"));
+
+    if (isSilentRefresh)
+    {
+        safeThis->setDeferredPresentationBatchActive(false);
+        co_return;
+    }
+
+    if (batchPresentation)
+    {
+        QTimer::singleShot(0, safeThis.data(),
+                           [safeThis, targetId, detectedType]()
+                           {
+                               if (!safeThis)
+                                   return;
+                               safeThis->finishDeferredPresentationBatch(targetId, detectedType);
+                           });
+    }
+    else
+    {
+        safeThis->startSecondaryFetches(targetId, detectedType);
+    }
+}
+
+void DetailView::setDeferredPresentationBatchActive(bool active)
+{
+    m_deferredPresentationBatchActive = active;
+}
+
+void DetailView::finishDeferredPresentationBatch(const QString &targetId, const QString &detectedType)
+{
+    if (m_currentItemId != targetId)
+    {
+        setDeferredPresentationBatchActive(false);
+        return;
+    }
+
+    updateTagLayoutHeight();
+    updateEpisodeJumpControl(m_currentSeasonEpisodes.size());
+
+    if (m_contentWidget && m_contentWidget->layout())
+        m_contentWidget->layout()->activate();
+    if (layout())
+        layout()->activate();
+
+    setDeferredPresentationBatchActive(false);
+
+    startSecondaryFetches(targetId, detectedType);
+}
+
+void DetailView::startSecondaryFetches(const QString &targetId, const QString &detectedType)
+{
+    if (targetId.isEmpty() || !m_core || !m_core->mediaService())
+        return;
+
+    const auto startNetworkFetches = [this, targetId, detectedType]()
+    {
+        qDebug() << "[DetailView][network] Start secondary fetches"
+                 << "itemId=" << targetId << "type=" << detectedType;
+        QCoro::connect(executeFetchSecondaries(QPointer<DetailView>(this), m_core, targetId, detectedType), this,
+                       []() {});
+    };
+
+    if (detectedType == "Series")
+    {
+        const bool hasCachedSeriesSecondaryUi = m_hasCachedCastData || m_hasCachedSeriesPlayableItem ||
+                                                m_hasCachedSeriesSeasons || m_hasCachedSeasonEpisodes ||
+                                                m_hasCachedSimilarItems || m_hasCachedCollections ||
+                                                m_hasCachedAdditionalParts;
+        startNetworkFetches();
+        if (hasCachedSeriesSecondaryUi)
+        {
+            applyCachedSecondaryData(targetId, detectedType);
+        }
+        else
+        {
+            qDebug() << "[DetailView][cache-ui] Skip cached secondary data"
+                     << "itemId=" << targetId << "type=" << detectedType
+                     << "reason=" << "no-cached-series-secondary-data";
+        }
+        return;
+    }
+
+    applyCachedSecondaryData(targetId, detectedType);
+    startNetworkFetches();
+}
+
+void DetailView::applyCachedSecondaryData(const QString &targetId, const QString &detectedType, bool revealBottomInfo)
+{
+    if (targetId != m_currentItemId)
+        return;
+
+    qDebug() << "[DetailView][cache-ui] Applying cached secondary data"
+             << "itemId=" << targetId << "type=" << detectedType << "sections=" << m_cachedSectionsFingerprint.left(12);
+
+    if (detectedType == "Series")
+    {
+        if (!m_hasManualSeriesSelection && m_hasCachedSeriesPlayableItem &&
+            m_cachedSeriesPlayableItem.type == "Episode" && !m_cachedSeriesPlayableItem.id.isEmpty())
+        {
+            if (m_currentPlayableItem.id != m_cachedSeriesPlayableItem.id)
+                applySeriesPlayableItemToUi(m_cachedSeriesPlayableItem);
+        }
+
+        if (m_hasCachedSeriesSeasons && !m_appliedCachedSeriesSeasonsToUi)
+        {
+            m_seriesSeasons = m_cachedSeriesSeasons;
+            int targetSeasonIdx = 0;
+            const int cachedEpisodeSeasonIndex = m_cachedSeasonIndex;
+            const QString cachedEpisodeSeasonId = m_cachedSeasonId;
+            bool selectedSeasonResolved = false;
+            if (m_hasManualSeriesSelection && m_currentSeasonIndex >= 0 &&
+                m_currentSeasonIndex < m_seriesSeasons.size())
+            {
+                targetSeasonIdx = m_currentSeasonIndex;
+                selectedSeasonResolved = true;
+            }
+            const int playableParentIdx = m_currentPlayableItem.parentIndexNumber;
+            if (!selectedSeasonResolved && !m_hasManualSeriesSelection && playableParentIdx >= 0)
+            {
+                for (int i = 0; i < m_seriesSeasons.size(); ++i)
+                {
+                    if (m_seriesSeasons[i].indexNumber == playableParentIdx)
+                    {
+                        targetSeasonIdx = i;
+                        break;
+                    }
+                }
+            }
+            if (!m_seriesSeasons.isEmpty())
+            {
+                targetSeasonIdx = qBound(0, targetSeasonIdx, m_seriesSeasons.size() - 1);
+                m_currentSeasonIndex = targetSeasonIdx;
+                updateSeasonSwitcher(targetSeasonIdx);
+            }
+
+            if (m_hasCachedSeasonEpisodes && cachedEpisodeSeasonIndex == targetSeasonIdx &&
+                cachedEpisodeSeasonId ==
+                    (m_seriesSeasons.isEmpty() ? QString() : m_seriesSeasons[targetSeasonIdx].id) &&
+                !m_seriesSeasons.isEmpty() &&
+                episodesBelongToSeason(m_cachedSeasonEpisodes, m_seriesSeasons[targetSeasonIdx]))
+            {
+                m_currentSeasonEpisodes = m_cachedSeasonEpisodes;
+                if (!m_appliedCachedSeasonEpisodesToUi && m_episodeWidget)
+                {
+                    applyReservedSectionItems(m_episodeSectionReserveWidget, m_episodeWidget, m_currentSeasonEpisodes);
+                    updateEpisodeJumpControl(m_currentSeasonEpisodes.size());
+                    const QString highlightedEpisodeId = m_currentPlayableItem.id;
+                    if (!highlightedEpisodeId.isEmpty())
+                    {
+                        m_episodeWidget->gallery()->setHighlightedItemId(highlightedEpisodeId);
+                        m_episodeWidget->gallery()->scrollToItemId(highlightedEpisodeId);
+                    }
+                }
+                m_appliedCachedSeasonEpisodesToUi = true;
+            }
+
+            if (m_seasonWidget)
+            {
+                m_seasonWidget->setTitle(tr("Seasons"));
+                m_seasonWidget->setCardStyle(MediaCardDelegate::Poster);
+                m_seasonWidget->setGalleryHeight(300);
+                applyReservedSectionItems(m_seasonSectionReserveWidget, m_seasonWidget, m_seriesSeasons);
+                m_appliedCachedSeriesSeasonsToUi = true;
+            }
+        }
+    }
+
+    
+    if (m_hasCachedCastData && !m_appliedCachedCastToUi)
+    {
+        applyCastSection(m_currentMediaItem);
+        m_appliedCachedCastToUi = true;
+    }
+    if (revealBottomInfo && m_deferBottomInfoReveal)
+    {
+        m_deferBottomInfoReveal = false;
+        hideReserveWidget(m_bottomInfoReserveWidget);
+        if (m_bottomInfoWidget)
+            m_bottomInfoWidget->show();
+    }
+
+    
+    
+    
+    if (m_hasCachedAdditionalParts && !m_appliedCachedAdditionalPartsToUi)
+    {
+        applyReservedSectionItems(m_additionalPartsSectionReserveWidget, m_additionalPartsWidget,
+                                  m_cachedAdditionalParts);
+        m_appliedCachedAdditionalPartsToUi = true;
+    }
+    else if (!m_hasCachedAdditionalParts && (m_hasCachedCollections || m_hasCachedSimilarItems))
+    {
+        applyReservedSectionItems(m_additionalPartsSectionReserveWidget, m_additionalPartsWidget, {});
+    }
+
+    if (m_hasCachedCollections && !m_appliedCachedCollectionsToUi)
+    {
+        applyCollectionGalleryLayout(m_cachedCollections);
+        applyReservedSectionItems(m_collectionSectionReserveWidget, m_collectionWidget, m_cachedCollections);
+        m_appliedCachedCollectionsToUi = true;
+    }
+    else if (!m_hasCachedCollections && m_hasCachedSimilarItems)
+    {
+        applyReservedSectionItems(m_collectionSectionReserveWidget, m_collectionWidget, {});
+    }
+
+    if (m_hasCachedSimilarItems && !m_appliedCachedSimilarItemsToUi)
+    {
+        applyReservedSectionItems(m_similarSectionReserveWidget, m_similarWidget, m_cachedSimilarItems);
+        m_appliedCachedSimilarItemsToUi = true;
+    }
+}
+
+void DetailView::persistDetailCacheSnapshot(const QString &reason)
+{
+    if (m_detailCacheServerId.isEmpty() || m_detailCacheUserId.isEmpty() || m_currentMediaItem.id.isEmpty())
+        return;
+
+    DetailCacheUtils::DetailCacheEntry entry;
+    entry.item = m_currentMediaItem;
+    const bool isSeries = m_currentMediaItem.type == "Series";
+    entry.hasPlayableItem = isSeries && m_currentPlayableItem.type == "Episode" && !m_currentPlayableItem.id.isEmpty();
+    if (entry.hasPlayableItem)
+        entry.playableItem = m_currentPlayableItem;
+    entry.hasSeasons = isSeries && m_hasCachedSeriesSeasons;
+    entry.seasons = m_cachedSeriesSeasons;
+    entry.hasSeasonEpisodes = isSeries && m_hasCachedSeasonEpisodes;
+    entry.seasonEpisodes = m_cachedSeasonEpisodes;
+    entry.seasonIndex = isSeries ? m_cachedSeasonIndex : -1;
+    entry.seasonId = isSeries ? m_cachedSeasonId : QString();
+    entry.playableItemFromServer = entry.hasPlayableItem;
+    entry.hasSimilarItems = m_hasCachedSimilarItems;
+    entry.similarItems = m_cachedSimilarItems;
+    entry.hasCollections = m_hasCachedCollections;
+    entry.collections = m_cachedCollections;
+    entry.hasAdditionalParts = m_hasCachedAdditionalParts;
+    entry.additionalParts = m_cachedAdditionalParts;
+
+    saveDetailCacheEntryAsync(m_detailCacheServerId, m_detailCacheUserId, entry, reason);
+}
+
+void DetailView::updateMetaRow(const MediaItem &item, const QString &leadingMeta)
+{
+    QStringList metas;
+    if (item.communityRating > 0)
+    {
+        m_ratingStarLabel->show();
+        metas << QString::number(item.communityRating, 'f', 1);
+    }
+    else
+    {
+        m_ratingStarLabel->hide();
+    }
+    if (!leadingMeta.isEmpty())
+        metas << leadingMeta;
+    const QString releaseDate = formatDetailReleaseDate(item);
+    if (!releaseDate.isEmpty())
+        metas << releaseDate;
+    if (item.runTimeTicks > 0)
+        metas << formatRunTime(item.runTimeTicks);
+    if (!item.officialRating.isEmpty())
+        metas << item.officialRating;
+
+    m_metaLabel->setText(metas.join("  \u2022  "));
+    m_metaRowWidget->show();
+}
+
+
+
+
+
+
+void DetailView::applySeedToUi(const MediaItem &seed)
+{
+    m_currentMediaItem = seed;
+    m_titleLabel->setText(seed.name);
+
+    
+    updateMetaRow(seed, formatEpisodeTag(seed));
+
+    
+    const bool shouldShowNumber = shouldShowDisplayNumber(seed);
+    const QString displayNumber = shouldShowNumber ? extractDisplayNumber(seed) : QString();
+    updateDisplayNumber(displayNumber);
+
+    
+    QString text = seed.overview;
+    text.replace(QRegularExpression("<br\\s*/?>", QRegularExpression::CaseInsensitiveOption), "\n");
+    text.replace("</p>", "\n\n");
+    text.remove(QRegularExpression("<[^>]*>"));
+    QTextDocument doc;
+    doc.setHtml(text);
+    QString cleanText = doc.toPlainText();
+    cleanText.replace(QChar::LineSeparator, '\n');
+    cleanText.remove(QRegularExpression("<[^>]*>"));
+    m_cleanOverviewText = cleanText;
+    m_lastOverviewWidth = -1;
+    updateOverviewElidedText();
+
+    
+    if (!seed.taglines.isEmpty())
+    {
+        m_taglineLabel->setText(seed.taglines.first());
+        m_taglineLabel->show();
+    }
+    else
+    {
+        m_taglineLabel->hide();
+    }
+
+    
+    m_isFavorite = seed.isFavorite();
+    m_actionWidget->setFavoriteState(m_isFavorite);
+    m_actionWidget->setPlayedState(seed.userData.played);
+
+    
+    
+    
+    
+    if (seed.type == "Series")
+    {
+        m_actionWidget->setSeriesLoadingMode();
+    }
+    else
+    {
+        m_actionWidget->setupNormalMode(seed);
+    }
+
+    
+    
+    
+    
+    
+    if (!seed.mediaSources.isEmpty())
+    {
+        const int selectedSourceIndex = preferredSourceIndex(m_core, seed);
+        m_actionWidget->setSources(seed.mediaSources, selectedSourceIndex);
+        if (selectedSourceIndex < seed.mediaSources.size() &&
+            !seed.mediaSources[selectedSourceIndex].mediaStreams.isEmpty())
+        {
+            applyRememberedStreams(seed, seed.mediaSources[selectedSourceIndex]);
+        }
+        m_appliedSourcesFingerprint = computeSourcesFingerprint(seed.mediaSources);
+    }
+    else
+    {
+        m_actionWidget->setSources(QList<MediaSourceInfo>{}, 0);
+        m_actionWidget->setStreams(MediaSourceInfo{});
+        m_appliedSourcesFingerprint = computeSourcesFingerprint(QList<MediaSourceInfo>{});
+    }
+    m_actionWidget->refreshExtPlayerButton();
+
+    
+    
+    
+    buildTagButtons(seed.genres);
+
+    
+    
+    
+    
+    
+    
+    QList<MediaSourceInfo> seedDefaultSource;
+    if (!seed.mediaSources.isEmpty())
+    {
+        const int selectedSourceIndex = m_actionWidget->currentSourceIndex();
+        if (selectedSourceIndex < seed.mediaSources.size())
+            seedDefaultSource.append(seed.mediaSources[selectedSourceIndex]);
+    }
+    m_bottomInfoWidget->setInfo(seed, seedDefaultSource);
+    m_bottomInfoWidget->setVisible(!m_deferBottomInfoReveal);
+    if (m_deferBottomInfoReveal)
+    {
+        showReserveWidget(m_bottomInfoReserveWidget, reserveHeightFor(m_bottomInfoWidget, 220));
+    }
+    else
+    {
+        hideReserveWidget(m_bottomInfoReserveWidget);
+    }
+    m_appliedBottomInfoFingerprint = computeBottomInfoFingerprint(seed, seedDefaultSource);
+
+    
+    
+    m_currentBackdropPix = QPixmap();
+    updateBackdrop();
+
+    
+    
+    
+    
+    
+    QCoro::connect(executeLoadImages(QPointer<DetailView>(this), m_core, seed, false), this, []() {});
+}
+
+
+
+
+
+void DetailView::buildTagButtons(const QStringList &genres)
+{
+    if (!m_tagsWidget || !m_tagsLayout)
+        return;
+
+    
+    if (m_tagsLayout->count() == genres.size())
+    {
+        bool same = true;
+        for (int i = 0; i < genres.size(); ++i)
+        {
+            QLayoutItem *layoutItem = m_tagsLayout->itemAt(i);
+            QWidget *w = layoutItem ? layoutItem->widget() : nullptr;
+            auto *btn = qobject_cast<QPushButton *>(w);
+            if (!btn || btn->text() != genres[i])
+            {
+                same = false;
+                break;
+            }
+        }
+        if (same)
+            return;
+    }
+
+    m_tagsWidget->setUpdatesEnabled(false);
+    clearLayout(m_tagsLayout);
+    for (const QString &genre : genres)
+    {
+        auto *tagBtn = new DetailTagButton(genre, m_tagsWidget);
+        connect(tagBtn, &QPushButton::clicked, this,
+                [this, genre]() { Q_EMIT navigateToFilteredView("Genre", genre); });
+        m_tagsLayout->addWidget(tagBtn);
+    }
+    m_tagsWidget->setUpdatesEnabled(true);
+    updateTagLayoutHeight();
+    QTimer::singleShot(0, this, [this]() { updateTagLayoutHeight(); });
+}
+
+void DetailView::applyCastSection(const MediaItem &item)
+{
+    if (!m_castWidget)
+        return;
+
+    const QString fp = castFingerprint(item);
+    if (!fp.isEmpty() && fp == m_appliedCastFingerprint)
+        return;
+
+    if (item.people.isEmpty())
+    {
+        applyReservedSectionItems(m_castSectionReserveWidget, m_castWidget, {});
+        m_appliedCastFingerprint = fp;
+        return;
+    }
+
+    QList<MediaItem> castItems;
+    castItems.reserve(item.people.size());
+    for (const auto &person : item.people)
+    {
+        MediaItem fakeItem;
+        fakeItem.id = person.id;
+        fakeItem.name = person.name;
+        fakeItem.images.primaryTag = person.primaryImageTag;
+        
+        QStringList personParts;
+        if (!person.type.isEmpty())
+        {
+            
+            static const QHash<QString, const char *> typeMap = {
+                {"Actor", QT_TR_NOOP("Actor")},         {"Director", QT_TR_NOOP("Director")},
+                {"Writer", QT_TR_NOOP("Writer")},       {"Producer", QT_TR_NOOP("Producer")},
+                {"Composer", QT_TR_NOOP("Composer")},   {"Conductor", QT_TR_NOOP("Conductor")},
+                {"GuestStar", QT_TR_NOOP("GuestStar")}, {"Editor", QT_TR_NOOP("Editor")},
+                {"Lyricist", QT_TR_NOOP("Lyricist")},
+            };
+            auto it = typeMap.constFind(person.type);
+            personParts << (it != typeMap.constEnd() ? tr(it.value()) : person.type);
+        }
+        if (!person.role.isEmpty())
+            personParts << person.role;
+        fakeItem.overview = personParts.join(" · ");
+        fakeItem.type = "Person";
+        castItems.append(fakeItem);
+    }
+
+    applyReservedSectionItems(m_castSectionReserveWidget, m_castWidget, castItems);
+    m_appliedCastFingerprint = fp;
+}
+
+void DetailView::applyCollectionGalleryLayout(const QList<MediaItem> &collections)
+{
+    int landscapeSignals = 0;
+    int portraitSignals = 0;
+
+    const auto hasLandscapeArtwork = [](const MediaItem &item)
+    {
+        const double primaryAspectRatio = item.images.primaryImageAspectRatio;
+        if (primaryAspectRatio > 1.05)
+            return true;
+        if (primaryAspectRatio > 0.0)
+            return false;
+
+        if (!item.images.primaryTag.isEmpty())
+            return false;
+
+        return !item.images.thumbTag.isEmpty() || !item.images.backdropTag.isEmpty() ||
+               !item.images.parentThumbTag.isEmpty() || !item.images.parentBackdropTag.isEmpty();
+    };
+
+    for (const MediaItem &collection : collections)
+    {
+        if (hasLandscapeArtwork(collection))
+        {
+            ++landscapeSignals;
+        }
+        else if (!collection.images.primaryTag.isEmpty() || collection.images.primaryImageAspectRatio > 0.0)
+        {
+            ++portraitSignals;
+        }
+    }
+
+    const bool useLandscapeCards = landscapeSignals > 0 && landscapeSignals > portraitSignals;
+
+    if (useLandscapeCards)
+    {
+        m_collectionWidget->setCardStyle(MediaCardDelegate::LibraryTile);
+        m_collectionWidget->setGalleryHeight(230);
+    }
+    else
+    {
+        m_collectionWidget->setCardStyle(MediaCardDelegate::Poster);
+        m_collectionWidget->setGalleryHeight(300);
+    }
+
+    qDebug() << "[DetailView] Collection gallery layout"
+             << "itemCount=" << collections.size() << "landscapeSignals=" << landscapeSignals
+             << "portraitSignals=" << portraitSignals << "style=" << (useLandscapeCards ? "LibraryTile" : "Poster");
+}
+
+
+
+
+
+
+
+QCoro::Task<void> DetailView::executeFetchSecondaries(QPointer<DetailView> safeThis, QEmbyCore *core, QString targetId,
+                                                      QString itemType)
+{
+    if (!safeThis)
+        co_return;
+
+    
+    
+    if (itemType == "Series")
+    {
+        if (!safeThis->m_hasManualSeriesSelection && safeThis->m_hasCachedSeriesPlayableItem &&
+            safeThis->m_cachedSeriesPlayableItem.type == "Episode" &&
+            !safeThis->m_cachedSeriesPlayableItem.id.isEmpty())
+        {
+            safeThis->applySeriesPlayableItemToUi(safeThis->m_cachedSeriesPlayableItem);
+            qDebug() << "[DetailView][cache-ui] Applied cached series playable item"
+                     << "seriesId=" << targetId << "episodeId=" << safeThis->m_cachedSeriesPlayableItem.id;
+        }
+        qDebug() << "[DetailView][network] Fetch series next-up"
+                 << "seriesId=" << targetId << "applyToUi=" << !safeThis->m_hasManualSeriesSelection;
+        co_await safeThis->fetchSeriesNextUp(targetId, !safeThis->m_hasManualSeriesSelection);
+        if (!safeThis || safeThis->m_currentItemId != targetId)
+            co_return;
+
+        
+        qDebug() << "[DetailView][network] Fetch series seasons"
+                 << "seriesId=" << targetId;
+        auto seasons = co_await core->mediaService()->getSeasons(targetId);
+        if (!safeThis || safeThis->m_currentItemId != targetId)
+            co_return;
+
+        bool seasonsUnchanged = false;
+        if (safeThis->m_appliedCachedSeriesSeasonsToUi)
+        {
+            seasonsUnchanged = co_await mediaItemListsEqualAsync(safeThis->m_cachedSeriesSeasons, seasons);
+            if (!safeThis || safeThis->m_currentItemId != targetId)
+                co_return;
+        }
         safeThis->m_seriesSeasons = seasons;
         safeThis->m_cachedSeriesSeasons = seasons;
         safeThis->m_hasCachedSeriesSeasons = true;
 
         
         
+        int targetSeasonIdx = 0;
         bool selectedSeasonResolved = false;
-        if (safeThis->m_hasManualSeriesSelection &&
-            !safeThis->m_manualSelectedSeasonId.isEmpty()) {
-          for (int i = 0; i < seasons.size(); ++i) {
-            if (seasons[i].id == safeThis->m_manualSelectedSeasonId) {
-              safeThis->m_currentSeasonIndex = i;
-              selectedSeasonResolved = true;
-              break;
+        if (safeThis->m_hasManualSeriesSelection && !safeThis->m_manualSelectedSeasonId.isEmpty())
+        {
+            for (int i = 0; i < seasons.size(); ++i)
+            {
+                if (seasons[i].id == safeThis->m_manualSelectedSeasonId)
+                {
+                    targetSeasonIdx = i;
+                    selectedSeasonResolved = true;
+                    break;
+                }
             }
-          }
         }
-        if (!selectedSeasonResolved &&
-            safeThis->m_hasManualSeriesSelection &&
-            safeThis->m_manualSelectedSeasonIndex >= 0 &&
-            safeThis->m_manualSelectedSeasonIndex < seasons.size()) {
-          safeThis->m_currentSeasonIndex =
-              safeThis->m_manualSelectedSeasonIndex;
-          selectedSeasonResolved = true;
+        if (!selectedSeasonResolved && safeThis->m_hasManualSeriesSelection &&
+            safeThis->m_manualSelectedSeasonIndex >= 0 && safeThis->m_manualSelectedSeasonIndex < seasons.size())
+        {
+            targetSeasonIdx = safeThis->m_manualSelectedSeasonIndex;
+            selectedSeasonResolved = true;
         }
-        if (!selectedSeasonResolved &&
-            safeThis->m_hasManualSeriesSelection &&
-            safeThis->m_currentSeasonIndex >= 0 &&
-            safeThis->m_currentSeasonIndex < seasons.size()) {
-          selectedSeasonResolved = true;
+        if (!selectedSeasonResolved && safeThis->m_hasManualSeriesSelection && safeThis->m_currentSeasonIndex >= 0 &&
+            safeThis->m_currentSeasonIndex < seasons.size())
+        {
+            targetSeasonIdx = safeThis->m_currentSeasonIndex;
+            selectedSeasonResolved = true;
         }
-        int playableParentIdx =
-            safeThis->m_currentPlayableItem.parentIndexNumber;
-        if (!selectedSeasonResolved &&
-            !safeThis->m_hasManualSeriesSelection && playableParentIdx >= 0) {
-          for (int i = 0; i < seasons.size(); ++i) {
-            if (seasons[i].indexNumber == playableParentIdx) {
-              safeThis->m_currentSeasonIndex = i;
-              break;
+        int playableParentIdx = safeThis->m_currentPlayableItem.parentIndexNumber;
+        if (!selectedSeasonResolved && !safeThis->m_hasManualSeriesSelection && playableParentIdx >= 0)
+        {
+            for (int i = 0; i < seasons.size(); ++i)
+            {
+                if (seasons[i].indexNumber == playableParentIdx)
+                {
+                    targetSeasonIdx = i;
+                    break;
+                }
             }
-          }
         }
+        if (!seasons.isEmpty())
+            targetSeasonIdx = qBound(0, targetSeasonIdx, seasons.size() - 1);
+        safeThis->m_currentSeasonIndex = targetSeasonIdx;
 
-        if (!seasons.isEmpty() && safeThis->m_episodeWidget) {
-          const int idx =
-              qBound(0, safeThis->m_currentSeasonIndex, seasons.size() - 1);
-          safeThis->updateSeasonSwitcher(idx);
+        
+        if (!seasons.isEmpty() && safeThis->m_episodeWidget)
+        {
+            safeThis->updateSeasonSwitcher(targetSeasonIdx);
 
-          const QString playableItemId =
-              safeThis->m_hasManualSeriesSelection &&
-                      !safeThis->m_manualSelectedEpisodeId.isEmpty()
-                  ? safeThis->m_manualSelectedEpisodeId
-                  : safeThis->m_currentPlayableItem.id;
-          co_await safeThis->loadEpisodesForSeason(
-              idx, playableItemId, !playableItemId.isEmpty(),
-              safeThis->m_hasManualSeriesSelection);
-        } else if (safeThis->m_episodeWidget) {
-          applyReservedSectionItems(safeThis->m_episodeSectionReserveWidget,
-                                    safeThis->m_episodeWidget, {});
+            const QString playableItemId =
+                safeThis->m_hasManualSeriesSelection && !safeThis->m_manualSelectedEpisodeId.isEmpty()
+                    ? safeThis->m_manualSelectedEpisodeId
+                    : safeThis->m_currentPlayableItem.id;
+            co_await safeThis->loadEpisodesForSeason(targetSeasonIdx, playableItemId, !playableItemId.isEmpty(),
+                                                     safeThis->m_hasManualSeriesSelection);
         }
-        if (!safeThis || safeThis->m_currentItemId != itemId)
-          co_return;
-
-        if (safeThis->m_seasonWidget) {
-          safeThis->m_seasonWidget->setTitle(tr("Seasons"));
-          safeThis->m_seasonWidget->setCardStyle(MediaCardDelegate::Poster);
-          safeThis->m_seasonWidget->setGalleryHeight(300);
-          applyReservedSectionItems(safeThis->m_seasonSectionReserveWidget,
-                                    safeThis->m_seasonWidget, seasons);
+        else if (safeThis->m_episodeWidget)
+        {
+            applyReservedSectionItems(safeThis->m_episodeSectionReserveWidget, safeThis->m_episodeWidget, {});
         }
-      }
+        if (!safeThis || safeThis->m_currentItemId != targetId)
+            co_return;
 
-      safeThis->applyCastSection(item);
-      if (safeThis->m_deferBottomInfoReveal) {
+        
+        if (safeThis->m_seasonWidget && !seasonsUnchanged)
+        {
+            safeThis->m_seasonWidget->setTitle(tr("Seasons"));
+            safeThis->m_seasonWidget->setCardStyle(MediaCardDelegate::Poster);
+            safeThis->m_seasonWidget->setGalleryHeight(300);
+            applyReservedSectionItems(safeThis->m_seasonSectionReserveWidget, safeThis->m_seasonWidget, seasons);
+        }
+    }
+
+    
+    if (safeThis->m_currentItemId != targetId)
+        co_return;
+    qDebug() << "[DetailView][ui] Apply cast section"
+             << "itemId=" << targetId << "afterSeriesSections=" << (itemType == "Series");
+    safeThis->applyCastSection(safeThis->m_currentMediaItem);
+    if (safeThis->m_deferBottomInfoReveal)
+    {
         safeThis->m_deferBottomInfoReveal = false;
         hideReserveWidget(safeThis->m_bottomInfoReserveWidget);
         if (safeThis->m_bottomInfoWidget)
-          safeThis->m_bottomInfoWidget->show();
-      }
-      safeThis->persistDetailCacheSnapshot(QStringLiteral("silent-refresh"));
+            safeThis->m_bottomInfoWidget->show();
     }
-  } catch (...) {
-  }
-}
-
-QCoro::Task<void> DetailView::executeLoadImages(QPointer<DetailView> safeThis,
-                                                QEmbyCore *core,
-                                                MediaItem item,
-                                                bool allowPrimaryBackdropFallback) {
-  bool adaptive =
-      ConfigStore::instance()->get<bool>(ConfigKeys::AdaptiveImages, true);
-  QString cacheServerId;
-  QString cacheUserId;
-  if (safeThis) {
-    cacheServerId = safeThis->m_detailCacheServerId;
-    cacheUserId = safeThis->m_detailCacheUserId;
-  } else if (core && core->serverManager()) {
-    const ServerProfile profile = core->serverManager()->activeProfile();
-    cacheServerId = profile.id;
-    cacheUserId = profile.userId;
-  }
-
-  
-  
-  QString posterType = QStringLiteral("Primary");
-  QString posterTag = item.images.primaryTag;
-  QString posterId = item.id;
-  if (posterTag.isEmpty() && adaptive) {
-    auto best = item.images.bestPoster();
-    posterTag = best.first;
-    posterType = best.second;
-    if (item.images.isParentTag(posterTag)) {
-      posterId = item.images.parentImageItemId.isEmpty()
-                     ? item.seriesId
-                     : item.images.parentImageItemId;
-    }
-  }
-  const int posterMaxWidth =
-      posterType == QStringLiteral("Primary") ? 400 : 800;
-
-  QString backdropType = QStringLiteral("Backdrop");
-  QString backdropTag = item.images.backdropTag;
-  QString backdropId = item.id;
-  if (backdropTag.isEmpty() && adaptive) {
-    if (allowPrimaryBackdropFallback) {
-      auto best = item.images.bestBackdrop();
-      backdropTag = best.first;
-      backdropType = best.second;
-    } else {
-      if (!item.images.thumbTag.isEmpty()) {
-        backdropTag = item.images.thumbTag;
-        backdropType = QStringLiteral("Thumb");
-      } else if (!item.images.parentBackdropTag.isEmpty()) {
-        backdropTag = item.images.parentBackdropTag;
-        backdropType = QStringLiteral("Backdrop");
-      } else if (!item.images.parentThumbTag.isEmpty()) {
-        backdropTag = item.images.parentThumbTag;
-        backdropType = QStringLiteral("Thumb");
-      }
-    }
-    if (item.images.isParentTag(backdropTag)) {
-      backdropId = item.images.parentImageItemId.isEmpty()
-                       ? item.seriesId
-                       : item.images.parentImageItemId;
-    }
-  }
-
-  const QString logoId = item.id;
-  const QString logoType = QStringLiteral("Logo");
-  const QString logoTag = item.images.logoTag;
-  constexpr int logoMaxWidth = 400;
-
-  const CachedDetailImages cachedImages = co_await QtConcurrent::run(
-      [cacheServerId, cacheUserId, ownerItemId = item.id, posterId,
-       posterType, posterTag, posterMaxWidth, backdropId, backdropType,
-       backdropTag, logoId, logoType, logoTag, logoMaxWidth]() mutable {
-        CachedDetailImages result;
-        if (!posterTag.isEmpty()) {
-          result.poster = DetailCacheUtils::loadImage(
-              cacheServerId, cacheUserId, ownerItemId,
-              QStringLiteral("poster"), posterId, posterType, posterTag,
-              posterMaxWidth);
-        }
-        if (!backdropTag.isEmpty()) {
-          result.backdrop = DetailCacheUtils::loadImage(
-              cacheServerId, cacheUserId, ownerItemId,
-              QStringLiteral("backdrop"), backdropId, backdropType,
-              backdropTag, 1920);
-        }
-        if (!logoTag.isEmpty()) {
-          result.logo = DetailCacheUtils::loadImage(
-              cacheServerId, cacheUserId, ownerItemId, QStringLiteral("logo"),
-              logoId, logoType, logoTag, logoMaxWidth);
-        }
-        return result;
-      });
-  if (!safeThis || safeThis->m_currentItemId != item.id)
-    co_return;
-
-  if (cachedImages.poster.has_value()) {
-    safeThis->m_currentPosterPix =
-        QPixmap::fromImage(cachedImages.poster.value());
-    safeThis->m_posterLabel->setPixmap(safeThis->m_currentPosterPix);
-    qDebug() << "[DetailView] Detail poster image cache hit"
-             << "itemId=" << item.id << "imageId=" << posterId
-             << "type=" << posterType;
-  }
-
-  if (cachedImages.backdrop.has_value()) {
-    safeThis->m_currentBackdropPix =
-        QPixmap::fromImage(cachedImages.backdrop.value());
-    safeThis->updateBackdrop();
-    qDebug() << "[DetailView] Detail backdrop image cache hit"
-             << "itemId=" << item.id << "imageId=" << backdropId
-             << "type=" << backdropType;
-  }
-
-  if (cachedImages.logo.has_value()) {
-    safeThis->m_logoLabel->setPixmap(
-        QPixmap::fromImage(cachedImages.logo.value()));
-    safeThis->m_logoLabel->show();
-    qDebug() << "[DetailView] Detail logo image cache hit"
-             << "itemId=" << item.id;
-  }
-
-  
-  if (!posterTag.isEmpty()) {
-    try {
-      QPixmap pix = co_await core->mediaService()->fetchImage(
-          posterId, posterType, posterTag, posterMaxWidth);
-      if (safeThis && safeThis->m_currentItemId == item.id && !pix.isNull()) {
-        safeThis->m_currentPosterPix = pix;
-
-        
-        
-        
-        const QSize posterSize(250, 375);
-        const QString currentItemId = item.id;
-        QImage src = pix.toImage();
-
-        auto *watcher = new QFutureWatcher<QImage>(safeThis.data());
-        QObject::connect(
-            watcher, &QFutureWatcher<QImage>::finished, safeThis.data(),
-            [safeThis, watcher, currentItemId, cacheServerId, cacheUserId,
-             posterId, posterType, posterTag, posterMaxWidth]() {
-              if (safeThis && safeThis->m_currentItemId == currentItemId) {
-                const QImage result = watcher->result();
-                if (!result.isNull()) {
-                  safeThis->m_posterLabel->setPixmap(
-                      QPixmap::fromImage(result));
-                  saveDetailImageAsync(cacheServerId, cacheUserId,
-                                       currentItemId,
-                                       QStringLiteral("poster"), posterId,
-                                       posterType, posterTag, posterMaxWidth,
-                                       result);
-                }
-              }
-              watcher->deleteLater();
-            });
-        watcher->setFuture(QtConcurrent::run([src, posterSize]() -> QImage {
-          QImage scaled =
-              src.scaled(posterSize, Qt::KeepAspectRatioByExpanding,
-                         Qt::SmoothTransformation);
-          const int cropX = (scaled.width() - posterSize.width()) / 2;
-          const int cropY = (scaled.height() - posterSize.height()) / 2;
-          QImage cropped =
-              scaled.copy(cropX, cropY, posterSize.width(), posterSize.height());
-
-          
-          QImage rounded(posterSize, QImage::Format_ARGB32_Premultiplied);
-          rounded.fill(Qt::transparent);
-          QPainter p(&rounded);
-          p.setRenderHint(QPainter::Antialiasing);
-          QPainterPath path;
-          path.addRoundedRect(
-              QRectF(0, 0, posterSize.width(), posterSize.height()), 12, 12);
-          p.setClipPath(path);
-          p.drawImage(0, 0, cropped);
-          p.end();
-          return rounded;
-        }));
-      }
-    } catch (...) {
-    }
-  }
-
-  
-  if (!backdropTag.isEmpty()) {
-    try {
-      QPixmap pix = co_await core->mediaService()->fetchImage(
-          backdropId, backdropType, backdropTag, 1920);
-      if (safeThis && safeThis->m_currentItemId == item.id && !pix.isNull()) {
-        safeThis->m_currentBackdropPix = pix;
-        safeThis->updateBackdrop();
-        saveDetailImageAsync(cacheServerId, cacheUserId, item.id,
-                             QStringLiteral("backdrop"), backdropId,
-                             backdropType, backdropTag, 1920, pix.toImage());
-      }
-    } catch (...) {
-    }
-  }
-
-  
-  
-  if (!logoTag.isEmpty()) {
-    try {
-      QPixmap pix =
-          co_await core->mediaService()->fetchImage(logoId, logoType, logoTag,
-                                                    logoMaxWidth);
-      if (safeThis && safeThis->m_currentItemId == item.id && !pix.isNull()) {
-        const QString currentItemId = item.id;
-        QImage src = pix.toImage();
-
-        auto *watcher = new QFutureWatcher<QImage>(safeThis.data());
-        QObject::connect(
-            watcher, &QFutureWatcher<QImage>::finished, safeThis.data(),
-            [safeThis, watcher, currentItemId, cacheServerId, cacheUserId,
-             logoId, logoType, logoTag, logoMaxWidth]() {
-              if (safeThis &&
-                  safeThis->m_currentItemId == currentItemId) {
-                const QImage result = watcher->result();
-                if (!result.isNull()) {
-                  safeThis->m_logoLabel->setPixmap(
-                      QPixmap::fromImage(result));
-                  safeThis->m_logoLabel->show();
-                  saveDetailImageAsync(
-                      cacheServerId, cacheUserId, currentItemId,
-                      QStringLiteral("logo"), logoId, logoType, logoTag,
-                      logoMaxWidth, result);
-                }
-              }
-              watcher->deleteLater();
-            });
-        watcher->setFuture(QtConcurrent::run([src]() -> QImage {
-          return src.scaled(250, 100, Qt::KeepAspectRatio,
-                            Qt::SmoothTransformation);
-        }));
-      }
-    } catch (...) {
-    }
-  }
-}
-
-void DetailView::onMediaItemUpdated(const MediaItem &item) {
-  
-  if (m_currentItemId == item.id && m_core && !m_skipSilentRefresh) {
-    QCoro::connect(
-        executeSilentRefresh(QPointer<DetailView>(this), m_core, item.id), this,
-        []() {});
-  }
-
-  
-  if (item.type == "Season" && !m_currentSeasonEpisodes.isEmpty()) {
-    bool belongsToSeries = false;
-    for (const MediaItem &season : m_seriesSeasons) {
-      if (season.id == item.id) {
-        belongsToSeries = true;
-        break;
-      }
-    }
-    if (belongsToSeries) {
-      for (MediaItem &ep : m_currentSeasonEpisodes) {
-        if (ep.parentIndexNumber == item.indexNumber)
-          ep.userData.played = item.userData.played;
-      }
-      m_episodeWidget->setItems(m_currentSeasonEpisodes);
-    }
-  }
-
-  
-  if (item.type == "Episode" && !m_currentSeasonEpisodes.isEmpty() &&
-      !m_seriesSeasons.isEmpty()) {
-    
-    for (MediaItem &ep : m_currentSeasonEpisodes) {
-      if (ep.id == item.id) {
-        ep.userData.played = item.userData.played;
-        break;
-      }
-    }
-    
-    const int seasonIndex = item.parentIndexNumber;
-    if (seasonIndex >= 0) {
-      for (MediaItem &season : m_seriesSeasons) {
-        if (season.indexNumber == seasonIndex) {
-          int total = 0, played = 0;
-          for (const MediaItem &ep : m_currentSeasonEpisodes) {
-            if (ep.parentIndexNumber == seasonIndex) {
-              total++;
-              if (ep.userData.played)
-                played++;
-            }
-          }
-          const bool allPlayed = (total > 0 && played == total);
-          if (season.userData.played != allPlayed) {
-            season.userData.played = allPlayed;
-            m_seasonWidget->updateItem(season);
-          }
-          break;
-        }
-      }
-    }
-  }
-
-  
-  if (m_currentPlayableItem.id == item.id) {
-    m_currentPlayableItem.userData.played = item.userData.played;
-    m_actionWidget->setPlayedState(item.userData.played);
-  }
-  if (m_currentMediaItem.id == item.id) {
-    m_currentMediaItem.userData.played = item.userData.played;
-    m_actionWidget->setPlayedState(item.userData.played);
-  }
-
-  if (m_seasonWidget)
-    m_seasonWidget->updateItem(item);
-  if (m_episodeWidget)
-    m_episodeWidget->updateItem(item);
-  if (m_castWidget)
-    m_castWidget->updateItem(item);
-  if (m_additionalPartsWidget)
-    m_additionalPartsWidget->updateItem(item);
-  if (m_collectionWidget)
-    m_collectionWidget->updateItem(item);
-  if (m_similarWidget)
-    m_similarWidget->updateItem(item);
-}
-
-void DetailView::beginOptimisticPlayedUpdate() { m_skipSilentRefresh = true; }
-
-void DetailView::endOptimisticPlayedUpdate() { m_skipSilentRefresh = false; }
-
-void DetailView::updateSeasonSwitcher(int currentIndex) {
-  if (!m_seasonSwitcher)
-    return;
-
-  QSignalBlocker blocker(m_seasonSwitcher);
-  m_seasonSwitcher->clear();
-
-  for (const MediaItem &season : m_seriesSeasons)
-    m_seasonSwitcher->addItem(season.name, "");
-
-  if (!m_seriesSeasons.isEmpty()) {
-    const int idx = qBound(0, currentIndex, m_seriesSeasons.size() - 1);
-    m_seasonSwitcher->setCurrentIndex(idx);
-  }
-
-  m_seasonSwitcher->setVisible(m_seriesSeasons.size() > 1);
-  m_seasonSwitcher->adjustSize();
-  if (m_episodeJumpEdit) {
-    const int switcherHeight =
-        qMax(m_seasonSwitcher->height(), m_seasonSwitcher->sizeHint().height());
-    m_episodeJumpEdit->setFixedHeight(switcherHeight);
-  }
-  updateEpisodeHeaderControlsVisibility();
-}
-
-void DetailView::updateEpisodeHeaderControlsVisibility() {
-  if (!m_episodeHeaderControls)
-    return;
-
-  const bool showSeasonSwitcher =
-      m_seasonSwitcher && !m_seasonSwitcher->isHidden();
-  const bool showEpisodeJump =
-      m_episodeJumpEdit && !m_episodeJumpEdit->isHidden();
-  m_episodeHeaderControls->setVisible(showSeasonSwitcher || showEpisodeJump);
-  m_episodeHeaderControls->adjustSize();
-  m_episodeHeaderControls->updateGeometry();
-}
-
-void DetailView::updateEpisodeJumpControl(int episodeCount) {
-  if (!m_episodeJumpEdit) {
-    return;
-  }
-
-  const int visibleCardCapacity = episodeGalleryVisibleCardCapacity();
-  const bool showJump =
-      episodeCount > 0 && visibleCardCapacity > 0 &&
-      episodeCount > visibleCardCapacity;
-  if (showJump) {
-    int explicitMaxEpisodeNumber = 0;
-    for (const MediaItem &episode : m_currentSeasonEpisodes)
-      explicitMaxEpisodeNumber = qMax(explicitMaxEpisodeNumber,
-                                      episode.indexNumber);
-
-    const int maxEpisodeNumber =
-        explicitMaxEpisodeNumber > 0 ? explicitMaxEpisodeNumber : episodeCount;
-    const QString rangeText = tr("1-%1").arg(maxEpisodeNumber);
-    m_episodeJumpEdit->setPlaceholderText(rangeText);
-    m_episodeJumpEdit->setToolTip(
-        tr("Jump to episode number (1-%1)").arg(maxEpisodeNumber));
-    if (m_episodeJumpValidator)
-      m_episodeJumpValidator->setTop(maxEpisodeNumber);
-    m_episodeJumpEdit->setMaxLength(
-        qMax(1, QString::number(maxEpisodeNumber).length()));
-
-    const int textWidth =
-        m_episodeJumpEdit->fontMetrics().horizontalAdvance(rangeText);
-    m_episodeJumpEdit->setFixedWidth(qBound(64, textWidth + 22, 92));
-  } else {
-    m_episodeJumpEdit->clear();
-    m_episodeJumpEdit->setPlaceholderText(tr("Ep #"));
-    m_episodeJumpEdit->setToolTip(tr("Jump to episode number"));
-    if (m_episodeJumpValidator)
-      m_episodeJumpValidator->setTop(9999);
-    m_episodeJumpEdit->setMaxLength(4);
-    m_episodeJumpEdit->setFixedWidth(64);
-  }
-
-  m_episodeJumpEdit->setVisible(showJump);
-  updateEpisodeHeaderControlsVisibility();
-}
-
-int DetailView::episodeGalleryVisibleCardCapacity() const {
-  if (!m_episodeWidget || !m_episodeWidget->gallery())
-    return 0;
-
-  QListView *listView = m_episodeWidget->gallery()->listView();
-  if (!listView || !listView->viewport())
-    return 0;
-
-  int cardWidth = m_episodeTileWidth;
-  if (cardWidth <= 0 && listView->model() && listView->model()->rowCount() > 0) {
-    const QSize itemSize =
-        listView->sizeHintForIndex(listView->model()->index(0, 0));
-    cardWidth = itemSize.width();
-  }
-  if (cardWidth <= 0)
-    return 0;
-
-  const int viewportWidth = listView->viewport()->width();
-  if (viewportWidth <= 0)
-    return 0;
-
-  return qMax(1, viewportWidth / cardWidth);
-}
-
-MediaItem DetailView::episodeForJumpNumber(int episodeNumber) const {
-  if (episodeNumber <= 0)
-    return MediaItem{};
-
-  bool hasExplicitEpisodeNumbers = false;
-  for (const MediaItem &episode : m_currentSeasonEpisodes) {
-    if (episode.indexNumber > 0)
-      hasExplicitEpisodeNumbers = true;
-    if (episode.indexNumber == episodeNumber)
-      return episode;
-  }
-
-  if (hasExplicitEpisodeNumbers)
-    return MediaItem{};
-
-  const int row = episodeNumber - 1;
-  if (row >= 0 && row < m_currentSeasonEpisodes.size())
-    return m_currentSeasonEpisodes.at(row);
-
-  return MediaItem{};
-}
-
-void DetailView::submitEpisodeJump() {
-  if (!m_episodeJumpEdit || m_episodeJumpEdit->isHidden() ||
-      m_currentSeasonEpisodes.isEmpty()) {
-    return;
-  }
-
-  const QString text = m_episodeJumpEdit->text().trimmed();
-  if (text.isEmpty())
-    return;
-
-  bool ok = false;
-  const int episodeNumber = text.toInt(&ok);
-  if (!ok)
-    return;
-
-  const MediaItem targetEpisode = episodeForJumpNumber(episodeNumber);
-  if (targetEpisode.id.isEmpty()) {
-    qDebug() << "[DetailView] Episode jump target not found"
-             << "seriesId=" << m_currentItemId
-             << "seasonIndex=" << m_currentSeasonIndex
-             << "episodeNumber=" << episodeNumber
-             << "episodeCount=" << m_currentSeasonEpisodes.size();
-    ModernToast::showMessage(tr("Episode %1 not found").arg(episodeNumber),
-                             1600);
-    m_episodeJumpEdit->selectAll();
-    return;
-  }
-
-  qDebug() << "[DetailView] Episode jump"
-           << "seriesId=" << m_currentItemId
-           << "seasonIndex=" << m_currentSeasonIndex
-           << "episodeNumber=" << episodeNumber
-           << "episodeId=" << targetEpisode.id;
-
-  m_episodeJumpEdit->clear();
-  markManualSeriesSelection(QStringLiteral("episode-jump"));
-  QCoro::connect(applySeriesPlayableItem(targetEpisode, true), this, []() {});
-}
-
-QCoro::Task<void> DetailView::loadEpisodesForSeason(int idx,
-                                                    QString highlightEpisodeId,
-                                                    bool scrollToHighlight,
-                                                    bool manualSelection) {
-  if (idx < 0 || idx >= m_seriesSeasons.size() || !m_episodeWidget)
-    co_return;
-
-  m_currentSeasonIndex = idx;
-  const QString seasonId = m_seriesSeasons[idx].id;
-  if (seasonId.isEmpty())
-    co_return;
-  if (manualSelection)
-    markManualSeriesSelection(QStringLiteral("season-selection"));
-  rememberSeriesSelection(MediaItem{}, QStringLiteral("season-selection"),
-                          !manualSelection);
-
-  bool showedCachedEpisodes = false;
-  QList<MediaItem> shownCachedEpisodes;
-  if (m_hasCachedSeasonEpisodes && m_cachedSeasonIndex == idx &&
-      m_cachedSeasonId == seasonId &&
-      episodesBelongToSeason(m_cachedSeasonEpisodes, m_seriesSeasons[idx])) {
-    shownCachedEpisodes = m_cachedSeasonEpisodes;
-    if (!m_appliedCachedSeasonEpisodesToUi) {
-      m_currentSeasonEpisodes = shownCachedEpisodes;
-      applyReservedSectionItems(m_episodeSectionReserveWidget, m_episodeWidget,
-                                shownCachedEpisodes);
-      updateEpisodeJumpControl(shownCachedEpisodes.size());
-      if (!highlightEpisodeId.isEmpty()) {
-        m_episodeWidget->gallery()->setHighlightedItemId(highlightEpisodeId);
-        if (scrollToHighlight) {
-          m_episodeWidget->gallery()->scrollToItemId(highlightEpisodeId);
-        }
-      }
-      m_appliedCachedSeasonEpisodesToUi = true;
-    }
-    showedCachedEpisodes = true;
-    qDebug() << "[DetailView][cache-ui] Applied cached season episodes"
-             << "seriesId=" << m_currentItemId << "seasonId=" << seasonId
-             << "seasonIndex=" << idx
-             << "episodeCount=" << shownCachedEpisodes.size();
-  } else {
-    m_currentSeasonEpisodes.clear();
-    updateEpisodeJumpControl(0);
-  }
-
-  if (!m_core || !m_core->mediaService())
-    co_return;
-
-  QPointer<DetailView> safeThis(this);
-  const QString seriesId = m_currentItemId;
-  QEmbyCore *core = m_core;
-
-  try {
-    qDebug() << "[DetailView][network] Fetch season episodes"
-             << "seriesId=" << seriesId << "seasonId=" << seasonId
-             << "seasonIndex=" << idx;
-    QList<MediaItem> episodes =
-        co_await core->mediaService()->getEpisodes(seriesId, seasonId);
-
-    if (!safeThis || safeThis->m_currentItemId != seriesId ||
-        safeThis->m_currentSeasonIndex != idx)
-      co_return;
-
-    bool episodesUnchanged = false;
-    if (showedCachedEpisodes) {
-      episodesUnchanged =
-          co_await mediaItemListsEqualAsync(shownCachedEpisodes, episodes);
-      if (!safeThis || safeThis->m_currentItemId != seriesId ||
-          safeThis->m_currentSeasonIndex != idx)
+    if (!safeThis)
         co_return;
-    }
 
-    safeThis->m_currentSeasonEpisodes = episodes;
-    if (!safeThis->m_hasManualSeriesSelection) {
-      safeThis->m_cachedSeasonEpisodes = episodes;
-      safeThis->m_cachedSeasonIndex = idx;
-      safeThis->m_cachedSeasonId = seasonId;
-      safeThis->m_hasCachedSeasonEpisodes = true;
-    } else {
-      qDebug() << "[DetailView] Skip persisting manually selected season "
-                  "episodes"
-               << "seriesId=" << seriesId << "seasonId=" << seasonId
-               << "seasonIndex=" << idx;
-    }
-    if (!manualSelection && !highlightEpisodeId.isEmpty() &&
-        safeThis->m_currentPlayableItem.id != highlightEpisodeId) {
-      for (const MediaItem &episode : episodes) {
-        if (episode.id == highlightEpisodeId) {
-          safeThis->applySeriesPlayableItemToUi(episode);
-          break;
+    
+    
+    
+    try
+    {
+        qDebug() << "[DetailView][network] Fetch similar items"
+                 << "itemId=" << targetId;
+        QList<MediaItem> similar = co_await core->mediaService()->getSimilarItems(targetId, 15);
+        if (!safeThis || safeThis->m_currentItemId != targetId)
+            co_return;
+
+        bool similarUnchanged = false;
+        if (safeThis->m_appliedCachedSimilarItemsToUi)
+        {
+            similarUnchanged = co_await mediaItemListsEqualAsync(safeThis->m_cachedSimilarItems, similar);
+            if (!safeThis || safeThis->m_currentItemId != targetId)
+                co_return;
         }
-      }
+        safeThis->m_cachedSimilarItems = similar;
+        safeThis->m_hasCachedSimilarItems = true;
+        if (!similarUnchanged)
+        {
+            applyReservedSectionItems(safeThis->m_similarSectionReserveWidget, safeThis->m_similarWidget, similar);
+        }
     }
-    if (!episodesUnchanged) {
-      applyReservedSectionItems(safeThis->m_episodeSectionReserveWidget,
-                                safeThis->m_episodeWidget, episodes);
+    catch (...)
+    {
+        if (safeThis && safeThis->m_currentItemId == targetId && !safeThis->m_appliedCachedSimilarItemsToUi)
+        {
+            applyReservedSectionItems(safeThis->m_similarSectionReserveWidget, safeThis->m_similarWidget, {});
+        }
     }
-    safeThis->updateEpisodeJumpControl(episodes.size());
+    if (!safeThis)
+        co_return;
 
-    qDebug() << "[DetailView][network] Loaded season episodes"
-             << "seriesId=" << seriesId << "seasonId=" << seasonId
-             << "seasonIndex=" << idx << "episodeCount=" << episodes.size()
-             << "fromCache=" << showedCachedEpisodes
-             << "unchanged=" << episodesUnchanged
-             << "visibleCardCapacity="
-             << safeThis->episodeGalleryVisibleCardCapacity()
-             << "jumpVisible="
-             << (safeThis->m_episodeJumpEdit &&
-                 !safeThis->m_episodeJumpEdit->isHidden());
+    
+    
+    try
+    {
+        qDebug() << "[DetailView][network] Fetch item collections"
+                 << "itemId=" << targetId;
+        QList<MediaItem> collections = co_await core->mediaService()->getItemCollections(targetId);
+        if (!safeThis || safeThis->m_currentItemId != targetId)
+            co_return;
 
-    if (!highlightEpisodeId.isEmpty()) {
-      safeThis->m_episodeWidget->gallery()->setHighlightedItemId(
-          highlightEpisodeId);
-      if (scrollToHighlight) {
-        safeThis->m_episodeWidget->gallery()->scrollToItemId(
-            highlightEpisodeId);
-      }
+        bool collectionsUnchanged = false;
+        if (safeThis->m_appliedCachedCollectionsToUi)
+        {
+            collectionsUnchanged = co_await mediaItemListsEqualAsync(safeThis->m_cachedCollections, collections);
+            if (!safeThis || safeThis->m_currentItemId != targetId)
+                co_return;
+        }
+        safeThis->m_cachedCollections = collections;
+        safeThis->m_hasCachedCollections = true;
+        if (!collectionsUnchanged)
+        {
+            safeThis->applyCollectionGalleryLayout(collections);
+            applyReservedSectionItems(safeThis->m_collectionSectionReserveWidget, safeThis->m_collectionWidget,
+                                      collections);
+        }
     }
-    safeThis->persistDetailCacheSnapshot(QStringLiteral("episodes"));
-  } catch (...) {
-    if (safeThis && safeThis->m_currentItemId == seriesId &&
-        safeThis->m_currentSeasonIndex == idx) {
-      if (!showedCachedEpisodes) {
-        safeThis->m_currentSeasonEpisodes.clear();
-        safeThis->updateEpisodeJumpControl(0);
-        applyReservedSectionItems(safeThis->m_episodeSectionReserveWidget,
-                                  safeThis->m_episodeWidget, {});
-      }
-      qDebug() << "[DetailView] Failed to load season episodes"
-               << "seriesId=" << seriesId << "seasonId=" << seasonId
-               << "seasonIndex=" << idx
-               << "keptCache=" << showedCachedEpisodes;
+    catch (...)
+    {
+        if (safeThis && safeThis->m_currentItemId == targetId && !safeThis->m_appliedCachedCollectionsToUi)
+        {
+            applyReservedSectionItems(safeThis->m_collectionSectionReserveWidget, safeThis->m_collectionWidget, {});
+        }
     }
-  }
+    if (!safeThis)
+        co_return;
+
+    
+    try
+    {
+        qDebug() << "[DetailView][network] Fetch additional parts"
+                 << "itemId=" << targetId;
+        QList<MediaItem> additionalParts = co_await core->mediaService()->getAdditionalParts(targetId);
+        if (!safeThis || safeThis->m_currentItemId != targetId)
+            co_return;
+
+        bool additionalPartsUnchanged = false;
+        if (safeThis->m_appliedCachedAdditionalPartsToUi)
+        {
+            additionalPartsUnchanged =
+                co_await mediaItemListsEqualAsync(safeThis->m_cachedAdditionalParts, additionalParts);
+            if (!safeThis || safeThis->m_currentItemId != targetId)
+                co_return;
+        }
+        safeThis->m_cachedAdditionalParts = additionalParts;
+        safeThis->m_hasCachedAdditionalParts = true;
+        if (!additionalPartsUnchanged)
+        {
+            applyReservedSectionItems(safeThis->m_additionalPartsSectionReserveWidget,
+                                      safeThis->m_additionalPartsWidget, additionalParts);
+        }
+    }
+    catch (...)
+    {
+        if (safeThis && safeThis->m_currentItemId == targetId && !safeThis->m_appliedCachedAdditionalPartsToUi)
+        {
+            applyReservedSectionItems(safeThis->m_additionalPartsSectionReserveWidget,
+                                      safeThis->m_additionalPartsWidget, {});
+        }
+    }
+
+    if (safeThis && safeThis->m_currentItemId == targetId)
+        safeThis->persistDetailCacheSnapshot(QStringLiteral("secondaries"));
+}
+
+QCoro::Task<void> DetailView::fetchSeriesNextUp(QString targetId, bool applyToUi)
+{
+    QPointer<DetailView> safeThis(this);
+    QPointer<MediaService> mediaService(
+        m_core ? m_core->mediaService() : nullptr);
+    try
+    {
+        if (!mediaService)
+            co_return;
+        MediaItem playableItem;
+        qDebug() << "[DetailView][network] Fetch next-up"
+                 << "seriesId=" << targetId;
+        auto nextUp = co_await mediaService->getNextUp(targetId);
+
+        if (!safeThis || !mediaService || safeThis->m_currentItemId != targetId)
+            co_return;
+
+        if (!nextUp.isEmpty())
+            playableItem = nextUp.first();
+        else
+        {
+            qDebug() << "[DetailView][network] Fetch seasons for next-up fallback"
+                     << "seriesId=" << targetId;
+            auto seasons = co_await mediaService->getSeasons(targetId);
+            if (!safeThis || !mediaService ||
+                safeThis->m_currentItemId != targetId)
+                co_return;
+            if (!seasons.isEmpty())
+            {
+                qDebug() << "[DetailView][network] Fetch episodes for next-up fallback"
+                         << "seriesId=" << targetId << "seasonId=" << seasons.first().id;
+                auto episodes = co_await mediaService->getEpisodes(
+                    targetId, seasons.first().id);
+                if (!safeThis || safeThis->m_currentItemId != targetId)
+                    co_return;
+                if (!episodes.isEmpty())
+                    playableItem = episodes.first();
+            }
+        }
+
+        if (safeThis && safeThis->m_currentItemId == targetId && !playableItem.id.isEmpty())
+        {
+            safeThis->m_cachedSeriesPlayableItem = playableItem;
+            safeThis->m_hasCachedSeriesPlayableItem = true;
+
+            if (!applyToUi || safeThis->m_hasManualSeriesSelection)
+            {
+                qDebug() << "[DetailView][network] Updated server next-up cache without "
+                            "changing manual selection"
+                         << "seriesId=" << targetId << "episodeId=" << playableItem.id << "applyToUi=" << applyToUi
+                         << "manualSelection=" << safeThis->m_hasManualSeriesSelection;
+                safeThis->persistDetailCacheSnapshot(QStringLiteral("series-server-next-up"));
+                co_return;
+            }
+
+            co_await safeThis->applySeriesPlayableItem(playableItem);
+        }
+    }
+    catch (...)
+    {
+    }
+}
+
+void DetailView::applySeriesPlayableItemToUi(const MediaItem &playableItem, bool scrollToEpisode)
+{
+    if (playableItem.id.isEmpty() || m_currentMediaItem.type != "Series")
+        return;
+
+    const QString playableFingerprint = DetailCacheUtils::fingerprint(playableItem);
+    const bool playableUnchanged =
+        !m_appliedSeriesPlayableFingerprint.isEmpty() && playableFingerprint == m_appliedSeriesPlayableFingerprint;
+    m_currentPlayableItem = playableItem;
+    const QString episodeTag = formatEpisodeTag(playableItem);
+
+    if (!playableUnchanged)
+    {
+        const QString actionTag = episodeTag.isEmpty() ? playableItem.name : episodeTag;
+        m_actionWidget->setupSeriesMode(playableItem, actionTag);
+        updateMetaRow(m_currentMediaItem, episodeTag);
+
+        m_actionWidget->setSources(playableItem.mediaSources,
+                                   preferredSourceIndex(m_core, playableItem));
+        m_appliedSourcesFingerprint = computeSourcesFingerprint(playableItem.mediaSources);
+
+        QList<MediaSourceInfo> selectedSources;
+        if (!playableItem.mediaSources.isEmpty())
+        {
+            int sourceIndex = m_actionWidget->currentSourceIndex();
+            if (sourceIndex >= playableItem.mediaSources.size())
+                sourceIndex = 0;
+
+            const MediaSourceInfo &selectedSource = playableItem.mediaSources[sourceIndex];
+            applyRememberedStreams(playableItem, selectedSource);
+            selectedSources.append(selectedSource);
+        }
+        else
+        {
+            m_actionWidget->setStreams(MediaSourceInfo{});
+        }
+
+        if (!selectedSources.isEmpty())
+        {
+            const QString bottomInfoFingerprint = computeBottomInfoFingerprint(playableItem, selectedSources);
+            if (bottomInfoFingerprint != m_appliedBottomInfoFingerprint)
+            {
+                m_bottomInfoWidget->setInfo(playableItem, selectedSources);
+                m_appliedBottomInfoFingerprint = bottomInfoFingerprint;
+                m_bottomInfoWidget->setVisible(!m_deferBottomInfoReveal);
+                if (m_deferBottomInfoReveal)
+                {
+                    showReserveWidget(m_bottomInfoReserveWidget, reserveHeightFor(m_bottomInfoWidget, 220));
+                }
+                else
+                {
+                    hideReserveWidget(m_bottomInfoReserveWidget);
+                }
+            }
+            else
+            {
+                m_bottomInfoWidget->setVisible(!m_deferBottomInfoReveal);
+            }
+        }
+
+        m_appliedSeriesPlayableFingerprint = playableFingerprint;
+    }
+
+    m_actionWidget->refreshExtPlayerButton();
+    m_actionWidget->setPlayedState(playableItem.userData.played);
+    if (m_episodeWidget)
+    {
+        m_episodeWidget->gallery()->setHighlightedItemId(playableItem.id);
+        if (scrollToEpisode)
+            m_episodeWidget->gallery()->scrollToItemId(playableItem.id);
+    }
+
+    qDebug() << "[DetailView] Apply series playable item"
+             << "seriesId=" << m_currentItemId << "episodeId=" << playableItem.id << "episodeTag=" << episodeTag
+             << "sourceCount=" << playableItem.mediaSources.size();
+}
+
+QCoro::Task<void> DetailView::applySeriesPlayableItem(MediaItem playableItem, bool scrollToEpisode)
+{
+    if (playableItem.id.isEmpty() || m_currentMediaItem.type != "Series")
+        co_return;
+
+    QPointer<DetailView> safeThis(this);
+    const QString seriesId = m_currentItemId;
+    const QString playableItemId = playableItem.id;
+
+    applySeriesPlayableItemToUi(playableItem, scrollToEpisode);
+    const bool persistServerSelection = !m_hasManualSeriesSelection;
+    rememberSeriesSelection(playableItem, QStringLiteral("series-selection"), persistServerSelection);
+
+    const bool needsPlaybackInfo =
+        playableItem.mediaSources.isEmpty() || playableItem.mediaSources.first().mediaStreams.isEmpty();
+    if (!needsPlaybackInfo)
+        co_return;
+
+    try
+    {
+        PlaybackInfo info = co_await m_core->mediaService()->getPlaybackInfo(playableItemId);
+        if (!safeThis || safeThis->m_currentItemId != seriesId || safeThis->m_currentMediaItem.type != "Series" ||
+            safeThis->m_currentPlayableItem.id != playableItemId)
+            co_return;
+        if (!info.mediaSources.isEmpty())
+        {
+            playableItem.mediaSources = info.mediaSources;
+            safeThis->applySeriesPlayableItemToUi(playableItem, false);
+            const bool persistPlaybackInfoSelection = !safeThis->m_hasManualSeriesSelection;
+            safeThis->rememberSeriesSelection(playableItem, QStringLiteral("series-selection-playback-info"),
+                                              persistPlaybackInfoSelection);
+        }
+    }
+    catch (...)
+    {
+    }
+}
+
+void DetailView::applyRememberedStreams(const MediaItem &item,
+                                        const MediaSourceInfo &source)
+{
+    const PlayerPreferenceUtils::RememberedStreamSelection remembered =
+        PlayerPreferenceUtils::validatedRememberedStreamSelection(
+            activeServerId(m_core), item.id, source);
+    m_actionWidget->setStreams(source, remembered.audioIndex,
+                               remembered.subtitleIndex);
+}
+
+QCoro::Task<void> DetailView::onVersionChanged(int index)
+{
+    const bool usePlayableItem = m_currentMediaItem.type == "Series" && !m_currentPlayableItem.id.isEmpty();
+    MediaItem actionItem = usePlayableItem ? m_currentPlayableItem : m_currentMediaItem;
+    if (index < 0 || index >= actionItem.mediaSources.size())
+        co_return;
+    MediaSourceInfo source = actionItem.mediaSources[index];
+    QPointer<DetailView> safeThis(this);
+    const QString expectedPageId = m_currentItemId;
+    const QString actionItemId = actionItem.id;
+
+    MediaSourcePreferenceUtils::rememberMediaSourceId(
+        activeServerId(m_core), actionItemId, source.id);
+
+    if (source.mediaStreams.isEmpty())
+    {
+        try
+        {
+            PlaybackInfo info = co_await m_core->mediaService()->getPlaybackInfo(actionItemId);
+            if (!safeThis || safeThis->m_currentItemId != expectedPageId)
+                co_return;
+            if (!info.mediaSources.isEmpty())
+            {
+                if (usePlayableItem)
+                {
+                    if (safeThis->m_currentPlayableItem.id != actionItemId)
+                        co_return;
+                    safeThis->m_currentPlayableItem.mediaSources = info.mediaSources;
+                    actionItem = safeThis->m_currentPlayableItem;
+                }
+                else
+                {
+                    safeThis->m_currentMediaItem.mediaSources = info.mediaSources;
+
+                    
+                    
+                    safeThis->m_currentPlayableItem.mediaSources = info.mediaSources;
+                    actionItem = safeThis->m_currentMediaItem;
+                }
+
+                int selectedIndex = MediaSourcePreferenceUtils::resolvePreferredMediaSourceIndex(
+                    actionItem.mediaSources, QString(), source.id);
+                if (selectedIndex < actionItem.mediaSources.size())
+                {
+                    source = actionItem.mediaSources[selectedIndex];
+                }
+            }
+        }
+        catch (...)
+        {
+            co_return;
+        }
+    }
+    if (!safeThis || source.mediaStreams.isEmpty())
+        co_return;
+
+    safeThis->applyRememberedStreams(actionItem, source);
+    QList<MediaSourceInfo> singleSource;
+    singleSource.append(source);
+    const MediaItem infoItem = usePlayableItem ? safeThis->m_currentPlayableItem : safeThis->m_currentMediaItem;
+    safeThis->m_bottomInfoWidget->setInfo(infoItem, singleSource);
+    hideReserveWidget(safeThis->m_bottomInfoReserveWidget);
+}
+
+QCoro::Task<void> DetailView::executePlay(MediaItem targetItem, long long startTicks)
+{
+    if (targetItem.id.isEmpty())
+        co_return;
+    try
+    {
+        MediaItem actualItem = targetItem;
+        if (actualItem.mediaSources.isEmpty())
+        {
+            PlaybackInfo info = co_await m_core->mediaService()->getPlaybackInfo(actualItem.id);
+            actualItem.mediaSources = info.mediaSources;
+        }
+        if (actualItem.mediaSources.isEmpty())
+            co_return;
+
+        int sourceIdx = 0;
+        int selectedAudioIdx = -1;
+        int selectedSubIdx = -1;
+        const bool useUiSelection = isCurrentActionItem(actualItem.id);
+
+        if (useUiSelection)
+        {
+            
+            sourceIdx = m_actionWidget->currentSourceIndex();
+            selectedAudioIdx = m_actionWidget->currentAudioIndex();
+            selectedSubIdx = m_actionWidget->currentSubtitleIndex();
+        }
+        else
+        {
+            sourceIdx = MediaSourcePreferenceUtils::resolvePreferredMediaSourceIndex(
+                actualItem.mediaSources,
+                ConfigStore::instance()->get<QString>(ConfigKeys::PlayerPreferredVersion).trimmed(),
+                MediaSourcePreferenceUtils::rememberedMediaSourceId(
+                    activeServerId(m_core), actualItem.id));
+        }
+
+        if (sourceIdx >= actualItem.mediaSources.size())
+            sourceIdx = 0;
+        MediaSourceInfo modifiedSource = actualItem.mediaSources[sourceIdx];
+
+        if (useUiSelection)
+        {
+            
+            
+            
+            for (auto &stream : modifiedSource.mediaStreams)
+            {
+                if (stream.type == "Audio" && selectedAudioIdx >= 0)
+                    stream.isDefault = (stream.index == selectedAudioIdx);
+                else if (stream.type == "Subtitle" && selectedSubIdx >= 0)
+                    stream.isDefault = (stream.index == selectedSubIdx);
+            }
+        }
+        else
+        {
+            PlayerPreferenceUtils::applyRememberedOrPreferredStreamRules(
+                modifiedSource, activeServerId(m_core), actualItem.id,
+                ConfigStore::instance()->get<QString>(ConfigKeys::PlayerAudioLang, "auto"),
+                ConfigStore::instance()->get<QString>(ConfigKeys::PlayerSubLang, "auto"));
+        }
+
+        QString streamUrl = m_core->mediaService()->getStreamUrl(actualItem.id, modifiedSource.id);
+
+        const QString playTitle = MediaItemUtils::playbackTitle(actualItem, m_currentMediaItem.name);
+
+        
+        PlaybackManager::instance()->startInternalPlayback(actualItem.id, playTitle, streamUrl, startTicks,
+                                                           QVariant::fromValue(modifiedSource));
+    }
+    catch (...)
+    {
+    }
+}
+
+QCoro::Task<void> DetailView::executePlaySeason(MediaItem seasonItem)
+{
+    if (seasonItem.id.isEmpty() || m_currentItemId.isEmpty() || !m_core || !m_core->mediaService())
+        co_return;
+
+    QPointer<DetailView> safeThis(this);
+    const QString seriesId = m_currentItemId;
+    const QString seasonId = seasonItem.id;
+
+    try
+    {
+        QList<MediaItem> episodes = co_await m_core->mediaService()->getEpisodes(seriesId, seasonId);
+        if (!safeThis || safeThis->m_currentItemId != seriesId)
+            co_return;
+
+        MediaItem targetEpisode = resolveSeasonPlaybackEpisode(episodes);
+        if (targetEpisode.id.isEmpty())
+            co_return;
+
+        qDebug() << "[DetailView] Play season"
+                 << "seriesId=" << seriesId << "seasonId=" << seasonId << "episodeId=" << targetEpisode.id
+                 << "episodeTag=" << formatEpisodeTag(targetEpisode) << "episodeCount=" << episodes.size()
+                 << "startTicks=" << targetEpisode.userData.playbackPositionTicks;
+
+        co_await safeThis->applySeriesPlayableItem(targetEpisode, false);
+        if (!safeThis || safeThis->m_currentItemId != seriesId)
+            co_return;
+
+        const MediaItem playbackItem =
+            safeThis->m_currentPlayableItem.id == targetEpisode.id ? safeThis->m_currentPlayableItem : targetEpisode;
+        co_await safeThis->executePlay(playbackItem, playbackItem.userData.playbackPositionTicks);
+    }
+    catch (...)
+    {
+    }
+}
+
+QCoro::Task<void> DetailView::executeExternalPlay(MediaItem targetItem, QString playerPath)
+{
+    if (targetItem.id.isEmpty() || playerPath.isEmpty())
+        co_return;
+    try
+    {
+        MediaItem actualItem = targetItem;
+        if (actualItem.mediaSources.isEmpty())
+        {
+            PlaybackInfo info = co_await m_core->mediaService()->getPlaybackInfo(actualItem.id);
+            actualItem.mediaSources = info.mediaSources;
+        }
+        if (actualItem.mediaSources.isEmpty())
+            co_return;
+
+        
+        int sourceIdx = 0;
+        const bool useUiSelection = isCurrentActionItem(actualItem.id);
+        if (useUiSelection)
+        {
+            sourceIdx = m_actionWidget->currentSourceIndex();
+        }
+        else
+        {
+            sourceIdx = preferredSourceIndex(m_core, actualItem);
+        }
+        if (sourceIdx >= actualItem.mediaSources.size())
+            sourceIdx = 0;
+        MediaSourceInfo modifiedSource = actualItem.mediaSources[sourceIdx];
+
+        if (useUiSelection)
+        {
+            int selectedAudioIdx = m_actionWidget->currentAudioIndex();
+            int selectedSubIdx = m_actionWidget->currentSubtitleIndex();
+            for (auto &stream : modifiedSource.mediaStreams)
+            {
+                if (stream.type == "Audio" && selectedAudioIdx >= 0)
+                    stream.isDefault = (stream.index == selectedAudioIdx);
+                else if (stream.type == "Subtitle" && selectedSubIdx >= 0)
+                    stream.isDefault = (stream.index == selectedSubIdx);
+            }
+        }
+        else
+        {
+            PlayerPreferenceUtils::applyRememberedOrPreferredStreamRules(
+                modifiedSource, activeServerId(m_core), actualItem.id,
+                ConfigStore::instance()->get<QString>(ConfigKeys::PlayerAudioLang, "auto"),
+                ConfigStore::instance()->get<QString>(ConfigKeys::PlayerSubLang, "auto"));
+        }
+
+        QString streamUrl = m_core->mediaService()->getStreamUrl(actualItem.id, modifiedSource.id);
+
+        const QString playTitle = MediaItemUtils::playbackTitle(actualItem, m_currentMediaItem.name);
+
+        long long startTicks = actualItem.userData.playbackPositionTicks;
+        PlaybackManager::instance()->startExternalPlayback(playerPath, actualItem.id, playTitle, streamUrl, startTicks,
+                                                           QVariant::fromValue(modifiedSource));
+    }
+    catch (...)
+    {
+    }
+}
+
+void DetailView::updateBackdrop()
+{
+    if (m_contentWidget)
+        static_cast<DetailContentWidget *>(m_contentWidget)->setBackdrop(m_currentBackdropPix);
+}
+
+void DetailView::updateTagLayoutHeight()
+{
+    if (!m_tagsWidget || !m_tagsLayout)
+        return;
+
+    int targetWidth = m_tagsWidget->width();
+    if (targetWidth <= 0 && m_textContainer)
+    {
+        targetWidth = m_textContainer->contentsRect().width();
+    }
+
+    if (targetWidth <= 0)
+    {
+        m_tagsWidget->updateGeometry();
+        QTimer::singleShot(50, this, [this]() { updateTagLayoutHeight(); });
+        return;
+    }
+
+    m_tagsLayout->invalidate();
+    const int targetHeight = m_tagsLayout->heightForWidth(targetWidth);
+    if (m_tagsWidget->minimumHeight() != targetHeight)
+    {
+        m_tagsWidget->setMinimumHeight(targetHeight);
+    }
+    m_tagsWidget->updateGeometry();
+
+    if (m_textContainer)
+    {
+        m_textContainer->updateGeometry();
+    }
+}
+
+void DetailView::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+    if (m_overviewLabel && m_overviewLabel->width() > 10 && qAbs(m_overviewLabel->width() - m_lastOverviewWidth) > 5)
+    {
+        m_lastOverviewWidth = m_overviewLabel->width();
+        updateOverviewElidedText();
+    }
+    updateTagLayoutHeight();
+    updateEpisodeJumpControl(m_currentSeasonEpisodes.size());
+}
+
+bool DetailView::eventFilter(QObject *obj, QEvent *event)
+{
+    if (m_mainScrollArea && obj == m_mainScrollArea->viewport() && event->type() == QEvent::Resize)
+    {
+        QResizeEvent *re = static_cast<QResizeEvent *>(event);
+        int newWidth = re->size().width();
+        if (m_contentWidget && newWidth > 100 && m_contentWidget->maximumWidth() != newWidth)
+        {
+            m_contentWidget->setMaximumWidth(newWidth);
+            QTimer::singleShot(0, this,
+                               [this]()
+                               {
+                                   updateTagLayoutHeight();
+                                   updateEpisodeJumpControl(m_currentSeasonEpisodes.size());
+                               });
+        }
+    }
+    if (m_episodeWidget && m_episodeWidget->gallery() && obj == m_episodeWidget->gallery()->listView()->viewport() &&
+        event->type() == QEvent::Resize)
+    {
+        QTimer::singleShot(0, this, [this]() { updateEpisodeJumpControl(m_currentSeasonEpisodes.size()); });
+    }
+    if (event->type() == QEvent::Wheel)
+    {
+        bool isHorizontalViewport = obj->parent() && obj->parent()->property("isHorizontalListView").toBool();
+        bool isMainViewport = (m_mainScrollArea && obj == m_mainScrollArea->viewport());
+        if (isHorizontalViewport || isMainViewport)
+        {
+            QWheelEvent *we = static_cast<QWheelEvent *>(event);
+            if (m_vScrollController)
+            {
+                m_vScrollController->scrollByWheelEvent(we, Qt::Vertical);
+            }
+            return true;
+        }
+    }
+    return QWidget::eventFilter(obj, event);
+}
+
+void DetailView::showEvent(QShowEvent *event)
+{
+    BaseView::showEvent(event);
+
+    
+    
+    if (m_skipNextSilentRefresh)
+    {
+        m_skipNextSilentRefresh = false;
+        return;
+    }
+
+    
+    
+    
+    m_pendingDeferredFetchId.clear();
+
+    if (!m_currentItemId.isEmpty() && m_core && m_core->mediaService())
+    {
+        executeSilentRefresh(QPointer<DetailView>(this), m_core, m_currentItemId);
+    }
+}
+
+void DetailView::clearLayout(QLayout *layout)
+{
+    if (!layout)
+        return;
+    QLayoutItem *child;
+    while ((child = layout->takeAt(0)) != nullptr)
+    {
+        if (child->widget())
+        {
+            child->widget()->hide();
+            child->widget()->setParent(nullptr);
+            child->widget()->deleteLater();
+        }
+        else if (child->layout())
+        {
+            clearLayout(child->layout());
+        }
+        delete child;
+    }
+}
+
+QString DetailView::formatRunTime(long long ticks)
+{
+    long long totalSeconds = ticks / 10000000;
+    long long hours = totalSeconds / 3600;
+    long long minutes = (totalSeconds % 3600) / 60;
+    if (hours > 0)
+        return QString(tr("%1 hr %2 min")).arg(hours).arg(minutes);
+    return QString(tr("%1 min")).arg(minutes);
+}
+
+bool DetailView::shouldShowDisplayNumber(const MediaItem &item) const
+{
+    if (item.type.compare("Movie", Qt::CaseInsensitive) != 0)
+    {
+        return false;
+    }
+
+    static const QList<QRegularExpression> adultMarkers = {
+        QRegularExpression(R"((^|[^0-9])18\+?([^0-9]|$))", QRegularExpression::CaseInsensitiveOption),
+        QRegularExpression(R"(\b(?:R[-\s]?18\+?|NC[-\s]?17|JAV|AV)\b)", QRegularExpression::CaseInsensitiveOption),
+        QRegularExpression(QStringLiteral("(成人|无码|有码|無碼|有碼)"))};
+
+    const auto containsAdultMarker = [](const QString &value) -> bool
+    {
+        const QString trimmedValue = value.trimmed();
+        if (trimmedValue.isEmpty())
+        {
+            return false;
+        }
+
+        for (const QRegularExpression &pattern : adultMarkers)
+        {
+            if (pattern.match(trimmedValue).hasMatch())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    if (containsAdultMarker(item.officialRating))
+    {
+        return true;
+    }
+
+    for (const QString &genre : item.genres)
+    {
+        if (containsAdultMarker(genre))
+        {
+            return true;
+        }
+    }
+
+    for (const QString &tag : item.tags)
+    {
+        if (containsAdultMarker(tag))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool DetailView::isCurrentActionItem(const QString &itemId) const
+{
+    if (itemId.isEmpty())
+        return false;
+    if (itemId == m_currentMediaItem.id)
+        return true;
+    return m_currentMediaItem.type == "Series" && itemId == m_currentPlayableItem.id;
+}
+
+QStringList DetailView::buildNumberCandidates(const MediaItem &item) const
+{
+    QStringList candidates;
+    const auto appendCandidate = [&candidates](const QString &value)
+    {
+        const QString trimmedValue = value.trimmed();
+        if (!trimmedValue.isEmpty() && !candidates.contains(trimmedValue))
+        {
+            candidates.append(trimmedValue);
+        }
+    };
+
+    for (const MediaSourceInfo &source : item.mediaSources)
+    {
+        appendCandidate(source.path);
+    }
+
+    appendCandidate(item.path);
+    appendCandidate(item.name);
+    appendCandidate(item.originalTitle);
+    appendCandidate(item.sortName);
+
+    for (const QString &tagline : item.taglines)
+    {
+        appendCandidate(tagline);
+    }
+
+    for (const QString &tag : item.tags)
+    {
+        appendCandidate(tag);
+    }
+
+    return candidates;
+}
+
+QString DetailView::extractDisplayNumber(const MediaItem &item) const
+{
+    static const NumberExtractor extractor(true);
+    const QStringList candidates = buildNumberCandidates(item);
+    const QString displayNumber = extractor.extractBestNumber(candidates);
+
+    qDebug() << "[DetailView] adult number extraction itemId=" << item.id << "officialRating=" << item.officialRating
+             << "candidateCount=" << candidates.size() << "selected=" << displayNumber;
+
+    return displayNumber;
+}
+
+void DetailView::updateDisplayNumber(const QString &number)
+{
+    if (!m_numberButton || !m_metaRowWidget)
+    {
+        return;
+    }
+
+    const QString trimmedNumber = number.trimmed();
+    const bool hasNumber = !trimmedNumber.isEmpty();
+    m_numberButton->setVisible(hasNumber);
+    m_numberButton->setText(trimmedNumber);
+    m_numberButton->setToolTip(hasNumber ? tr("Click to copy number") : QString());
+    m_metaRowWidget->setVisible(!m_metaLabel->text().isEmpty() || hasNumber);
+}
+
+void DetailView::copyDisplayedNumber()
+{
+    if (!m_numberButton)
+    {
+        return;
+    }
+
+    const QString displayNumber = m_numberButton->text().trimmed();
+    if (displayNumber.isEmpty())
+    {
+        return;
+    }
+
+    if (QClipboard *clipboard = QGuiApplication::clipboard())
+    {
+        clipboard->setText(displayNumber);
+    }
+
+    qDebug() << "[DetailView] copied display number" << displayNumber << "for itemId" << m_currentItemId;
+    ModernToast::showMessage(tr("Number copied: %1").arg(displayNumber), 2000);
+}
+
+void DetailView::markManualSeriesSelection(const QString &reason)
+{
+    if (m_currentMediaItem.type != "Series")
+        return;
+
+    if (!m_hasManualSeriesSelection)
+    {
+        qDebug() << "[DetailView] Manual series selection locked server auto-sync"
+                 << "seriesId=" << m_currentItemId << "reason=" << reason;
+    }
+    m_hasManualSeriesSelection = true;
+}
+
+void DetailView::rememberSeriesSelection(const MediaItem &episode, const QString &reason, bool persist)
+{
+    if (m_currentMediaItem.type != "Series")
+        return;
+
+    int selectedSeasonIndex = -1;
+    QString selectedSeasonId;
+    bool hasSelectedSeason = false;
+    if (episode.type == "Episode" && episode.parentIndexNumber >= 0)
+    {
+        for (int i = 0; i < m_seriesSeasons.size(); ++i)
+        {
+            if (m_seriesSeasons[i].indexNumber == episode.parentIndexNumber)
+            {
+                selectedSeasonIndex = i;
+                selectedSeasonId = m_seriesSeasons[i].id;
+                hasSelectedSeason = true;
+                break;
+            }
+        }
+    }
+    else
+    {
+        selectedSeasonIndex = m_currentSeasonIndex;
+        if (selectedSeasonIndex >= 0 && selectedSeasonIndex < m_seriesSeasons.size())
+        {
+            selectedSeasonId = m_seriesSeasons[selectedSeasonIndex].id;
+            hasSelectedSeason = true;
+        }
+    }
+
+    if (hasSelectedSeason)
+    {
+        if (persist)
+        {
+            m_cachedSeasonIndex = selectedSeasonIndex;
+            m_cachedSeasonId = selectedSeasonId;
+        }
+        else
+        {
+            m_manualSelectedSeasonIndex = selectedSeasonIndex;
+            m_manualSelectedSeasonId = selectedSeasonId;
+        }
+    }
+    if (episode.type == "Episode" && !episode.id.isEmpty())
+    {
+        if (persist)
+        {
+            m_cachedSeriesPlayableItem = episode;
+            m_hasCachedSeriesPlayableItem = true;
+        }
+        else
+        {
+            m_manualSelectedEpisodeId = episode.id;
+        }
+    }
+
+    qDebug() << "[DetailView] Remember series selection"
+             << "seriesId=" << m_currentItemId
+             << "seasonIndex=" << (persist ? m_cachedSeasonIndex : m_manualSelectedSeasonIndex)
+             << "seasonId=" << (persist ? m_cachedSeasonId : m_manualSelectedSeasonId)
+             << "episodeId=" << (persist ? m_cachedSeriesPlayableItem.id : m_manualSelectedEpisodeId)
+             << "persist=" << persist << "reason=" << reason;
+
+    if (persist)
+        persistDetailCacheSnapshot(reason);
+}
+
+void DetailView::updateOverviewElidedText()
+{
+    if (m_cleanOverviewText.isEmpty() || !m_overviewLabel)
+        return;
+
+    const int generation = ++m_overviewElideGeneration;
+    QPointer<DetailView> safeThis(this);
+    QTimer::singleShot(0, this,
+                       [safeThis, generation]()
+                       {
+                           if (!safeThis || generation != safeThis->m_overviewElideGeneration)
+                               return;
+
+                           int labelWidth = safeThis->m_overviewLabel->contentsRect().width();
+                           if (labelWidth <= 10 && safeThis->m_textContainer)
+                               labelWidth = safeThis->m_textContainer->contentsRect().width();
+                           if (labelWidth <= 10)
+                               return;
+
+                           QFontMetrics fm(safeThis->m_overviewLabel->font());
+                           int maxHeight = fm.lineSpacing() * 5 + 10;
+                           QTextDocument doc;
+                           doc.setDefaultFont(safeThis->m_overviewLabel->font());
+                           doc.setTextWidth(labelWidth);
+
+                           QString fullHtml = safeThis->m_cleanOverviewText.toHtmlEscaped();
+                           fullHtml.replace("\n", "<br>");
+                           doc.setHtml(fullHtml);
+
+                           if (doc.size().height() <= maxHeight)
+                           {
+                               if (safeThis->m_overviewLabel->text() != fullHtml)
+                                   safeThis->m_overviewLabel->setText(fullHtml);
+                               return;
+                           }
+
+                           int low = 0, high = safeThis->m_cleanOverviewText.length(), best = 0;
+                           QString moreLink = safeThis->tr("... <a href='more' style='color:#3B82F6; "
+                                                           "text-decoration:none; font-weight:bold;'>More</a>");
+                           while (low <= high)
+                           {
+                               int mid = low + (high - low) / 2;
+                               QString testHtml = safeThis->m_cleanOverviewText.left(mid).toHtmlEscaped();
+                               testHtml.replace("\n", "<br>");
+                               doc.setHtml(testHtml + moreLink);
+                               if (doc.size().height() <= maxHeight)
+                               {
+                                   best = mid;
+                                   low = mid + 1;
+                               }
+                               else
+                               {
+                                   high = mid - 1;
+                               }
+                           }
+
+                           QString finalHtml = safeThis->m_cleanOverviewText.left(best).toHtmlEscaped();
+                           finalHtml.replace("\n", "<br>");
+                           const QString overviewHtml = finalHtml + moreLink;
+                           if (safeThis->m_overviewLabel->text() != overviewHtml)
+                               safeThis->m_overviewLabel->setText(overviewHtml);
+                       });
+}
+
+QCoro::Task<void> DetailView::updateUi(MediaItem item, bool isSilentRefresh)
+{
+    m_currentMediaItem = item;
+    if (!isSilentRefresh && item.type == "Series")
+        m_deferBottomInfoReveal = true;
+    m_titleLabel->setText(item.name);
+
+    const QString metaEpisodeTag = item.type == "Series" && m_currentPlayableItem.type == "Episode"
+                                       ? formatEpisodeTag(m_currentPlayableItem)
+                                       : formatEpisodeTag(item);
+    updateMetaRow(item, metaEpisodeTag);
+
+    const bool shouldShowNumber = shouldShowDisplayNumber(item);
+    const QString displayNumber = shouldShowNumber ? extractDisplayNumber(item) : QString();
+    updateDisplayNumber(displayNumber);
+
+    qDebug() << "[DetailView] updateUi itemId=" << item.id << "adultMovie=" << shouldShowNumber
+             << "displayNumber=" << displayNumber;
+
+    QString text = item.overview;
+    text.replace(QRegularExpression("<br\\s*/?>", QRegularExpression::CaseInsensitiveOption), "\n");
+    text.replace("</p>", "\n\n");
+    text.remove(QRegularExpression("<[^>]*>"));
+    QTextDocument doc;
+    doc.setHtml(text);
+    QString cleanText = doc.toPlainText();
+    cleanText.replace(QChar::LineSeparator, '\n');
+    cleanText.remove(QRegularExpression("<[^>]*>"));
+    m_cleanOverviewText = cleanText;
+    m_lastOverviewWidth = -1;
+    updateOverviewElidedText();
+
+    if (item.type == "Series")
+    {
+        const bool hasCurrentEpisode = m_currentPlayableItem.type == "Episode" && !m_currentPlayableItem.id.isEmpty();
+        if (!isSilentRefresh && !hasCurrentEpisode)
+            m_actionWidget->setSeriesLoadingMode();
+    }
+    else
+    {
+        
+        
+        m_currentPlayableItem = item;
+        m_actionWidget->setupNormalMode(item);
+    }
+
+    
+    
+    const QString newSourcesFingerprint = computeSourcesFingerprint(item.mediaSources);
+    const bool sourcesUnchanged =
+        !m_appliedSourcesFingerprint.isEmpty() && newSourcesFingerprint == m_appliedSourcesFingerprint;
+    const bool sourcesOwnedBySeriesEpisode =
+        item.type == "Series" && m_currentPlayableItem.type == "Episode" && !m_currentPlayableItem.id.isEmpty();
+    if (!sourcesOwnedBySeriesEpisode && !sourcesUnchanged)
+    {
+        m_actionWidget->setSources(item.mediaSources,
+                                   preferredSourceIndex(m_core, item));
+        m_appliedSourcesFingerprint = newSourcesFingerprint;
+        if (item.mediaSources.isEmpty() || item.mediaSources.first().mediaStreams.isEmpty())
+        {
+            m_actionWidget->setStreams(MediaSourceInfo{});
+        }
+    }
+    m_actionWidget->refreshExtPlayerButton();
+
+    if (!item.taglines.isEmpty())
+    {
+        m_taglineLabel->setText(item.taglines.first());
+        m_taglineLabel->show();
+    }
+    else
+    {
+        m_taglineLabel->hide();
+    }
+
+    m_isFavorite = item.isFavorite();
+    m_actionWidget->setFavoriteState(m_isFavorite);
+    m_actionWidget->setPlayedState(item.userData.played);
+
+    
+    
+    buildTagButtons(item.genres);
+
+    QCoro::connect(executeLoadImages(QPointer<DetailView>(this), m_core, item, true), this, []() {});
+
+    QPointer<DetailView> safeThis(this);
+
+    
+    
+    auto applyBottomInfo = [this, &item](const QList<MediaSourceInfo> &srcs)
+    {
+        const QString fp = computeBottomInfoFingerprint(item, srcs);
+        if (fp == m_appliedBottomInfoFingerprint)
+            return;
+        m_bottomInfoWidget->setInfo(item, srcs);
+        m_appliedBottomInfoFingerprint = fp;
+        if (m_deferBottomInfoReveal)
+        {
+            showReserveWidget(m_bottomInfoReserveWidget, reserveHeightFor(m_bottomInfoWidget, 220));
+        }
+    };
+
+    if (sourcesOwnedBySeriesEpisode)
+    {
+        applySeriesPlayableItemToUi(m_currentPlayableItem);
+    }
+    else if (!item.mediaSources.isEmpty() && !item.mediaSources.first().mediaStreams.isEmpty())
+    {
+        int defaultIndex = m_actionWidget->currentSourceIndex();
+        QList<MediaSourceInfo> defaultSource;
+        if (defaultIndex < item.mediaSources.size())
+        {
+            const MediaSourceInfo &dSrc = item.mediaSources[defaultIndex];
+            
+            
+            if (!sourcesUnchanged)
+                applyRememberedStreams(item, dSrc);
+            defaultSource.append(dSrc);
+        }
+        applyBottomInfo(defaultSource);
+    }
+    else
+    {
+        
+        
+        applyBottomInfo({});
+        if (item.mediaType == "Video" || item.mediaType == "Audio" || item.type == "Movie" || item.type == "Episode")
+        {
+            
+            
+            QCoro::connect(fetchAndApplyPlaybackInfo(item.id), this, []() {});
+        }
+    }
+
+    if (!safeThis)
+        co_return;
+    safeThis->m_bottomInfoWidget->setVisible(!safeThis->m_deferBottomInfoReveal);
+    if (safeThis->m_deferBottomInfoReveal)
+    {
+        showReserveWidget(safeThis->m_bottomInfoReserveWidget, reserveHeightFor(safeThis->m_bottomInfoWidget, 220));
+    }
+    else
+    {
+        hideReserveWidget(safeThis->m_bottomInfoReserveWidget);
+    }
+    if (!isSilentRefresh && safeThis)
+        QMetaObject::invokeMethod(safeThis.data(), "scrollToTop", Qt::QueuedConnection);
 }
 
 
-QCoro::Task<void> DetailView::switchToSeason(int idx, bool manualSelection) {
-  co_await loadEpisodesForSeason(idx, QString(), false, manualSelection);
+
+
+
+QCoro::Task<void> DetailView::fetchAndApplyPlaybackInfo(QString itemId)
+{
+    QPointer<DetailView> safeThis(this);
+    QPointer<MediaService> mediaService(
+        m_core ? m_core->mediaService() : nullptr);
+    try
+    {
+        if (!mediaService)
+            co_return;
+        PlaybackInfo info = co_await mediaService->getPlaybackInfo(itemId);
+        if (!safeThis || safeThis->m_currentItemId != itemId)
+            co_return;
+        if (info.mediaSources.isEmpty())
+            co_return;
+
+        safeThis->m_currentMediaItem.mediaSources = info.mediaSources;
+
+        const QString refreshedNumber = safeThis->shouldShowDisplayNumber(safeThis->m_currentMediaItem)
+                                            ? safeThis->extractDisplayNumber(safeThis->m_currentMediaItem)
+                                            : QString();
+        safeThis->updateDisplayNumber(refreshedNumber);
+
+        
+        if (safeThis->m_currentMediaItem.type != "Series")
+        {
+            safeThis->m_currentPlayableItem.mediaSources = info.mediaSources;
+        }
+
+        int idx = MediaSourcePreferenceUtils::resolvePreferredMediaSourceIndex(
+            info.mediaSources,
+            ConfigStore::instance()->get<QString>(ConfigKeys::PlayerPreferredVersion).trimmed(),
+            MediaSourcePreferenceUtils::rememberedMediaSourceId(
+                activeServerId(safeThis->m_core), itemId));
+        safeThis->m_actionWidget->setSources(info.mediaSources, idx);
+        safeThis->m_appliedSourcesFingerprint = computeSourcesFingerprint(info.mediaSources);
+
+        idx = safeThis->m_actionWidget->currentSourceIndex();
+        if (idx >= safeThis->m_currentMediaItem.mediaSources.size())
+            idx = 0;
+        if (idx < safeThis->m_currentMediaItem.mediaSources.size())
+        {
+            const MediaSourceInfo &singleSource = safeThis->m_currentMediaItem.mediaSources[idx];
+            safeThis->applyRememberedStreams(safeThis->m_currentMediaItem,
+                                             singleSource);
+            QList<MediaSourceInfo> sList;
+            sList.append(singleSource);
+            const QString fp = computeBottomInfoFingerprint(safeThis->m_currentMediaItem, sList);
+            if (fp != safeThis->m_appliedBottomInfoFingerprint)
+            {
+                safeThis->m_bottomInfoWidget->setInfo(safeThis->m_currentMediaItem, sList);
+                safeThis->m_appliedBottomInfoFingerprint = fp;
+                if (safeThis->m_deferBottomInfoReveal)
+                {
+                    showReserveWidget(safeThis->m_bottomInfoReserveWidget,
+                                      reserveHeightFor(safeThis->m_bottomInfoWidget, 220));
+                }
+            }
+        }
+    }
+    catch (...)
+    {
+    }
+}
+
+void DetailView::onOverviewMoreClicked(const QString &link)
+{
+    if (link == "more")
+    {
+        OverviewDialog dialog(this);
+        dialog.setMediaItem(m_currentMediaItem, m_currentPosterPix);
+        dialog.exec();
+    }
+}
+
+QCoro::Task<void> DetailView::executeSilentRefresh(QPointer<DetailView> safeThis, QEmbyCore *core, QString itemId)
+{
+    QString cacheServerId;
+    QString cacheUserId;
+    if (core && core->serverManager())
+    {
+        const ServerProfile profile = core->serverManager()->activeProfile();
+        cacheServerId = profile.id;
+        cacheUserId = profile.userId;
+    }
+
+    try
+    {
+        MediaItem item = co_await core->mediaService()->getItemDetail(itemId);
+        if (!cacheServerId.isEmpty() && !cacheUserId.isEmpty())
+        {
+            auto fingerprintFuture = QtConcurrent::run(
+                [item]() mutable { return DetailCacheUtils::fingerprint(item); });
+            const QString fp = co_await fingerprintFuture;
+            saveDetailCacheAsync(cacheServerId, cacheUserId, item, fp);
+            if (safeThis && item.id == safeThis->m_currentItemId)
+                safeThis->m_cachedDetailFingerprint = fp;
+        }
+        if (safeThis && item.id == safeThis->m_currentItemId)
+        {
+            co_await safeThis->updateUi(item, true);
+
+            
+            if (item.type == "Series")
+            {
+                co_await safeThis->fetchSeriesNextUp(itemId, !safeThis->m_hasManualSeriesSelection);
+                if (!safeThis || safeThis->m_currentItemId != itemId)
+                    co_return;
+
+                auto seasons = co_await core->mediaService()->getSeasons(itemId);
+                if (!safeThis || safeThis->m_currentItemId != itemId)
+                    co_return;
+
+                safeThis->m_seriesSeasons = seasons;
+                safeThis->m_cachedSeriesSeasons = seasons;
+                safeThis->m_hasCachedSeriesSeasons = true;
+
+                
+                
+                bool selectedSeasonResolved = false;
+                if (safeThis->m_hasManualSeriesSelection && !safeThis->m_manualSelectedSeasonId.isEmpty())
+                {
+                    for (int i = 0; i < seasons.size(); ++i)
+                    {
+                        if (seasons[i].id == safeThis->m_manualSelectedSeasonId)
+                        {
+                            safeThis->m_currentSeasonIndex = i;
+                            selectedSeasonResolved = true;
+                            break;
+                        }
+                    }
+                }
+                if (!selectedSeasonResolved && safeThis->m_hasManualSeriesSelection &&
+                    safeThis->m_manualSelectedSeasonIndex >= 0 &&
+                    safeThis->m_manualSelectedSeasonIndex < seasons.size())
+                {
+                    safeThis->m_currentSeasonIndex = safeThis->m_manualSelectedSeasonIndex;
+                    selectedSeasonResolved = true;
+                }
+                if (!selectedSeasonResolved && safeThis->m_hasManualSeriesSelection &&
+                    safeThis->m_currentSeasonIndex >= 0 && safeThis->m_currentSeasonIndex < seasons.size())
+                {
+                    selectedSeasonResolved = true;
+                }
+                int playableParentIdx = safeThis->m_currentPlayableItem.parentIndexNumber;
+                if (!selectedSeasonResolved && !safeThis->m_hasManualSeriesSelection && playableParentIdx >= 0)
+                {
+                    for (int i = 0; i < seasons.size(); ++i)
+                    {
+                        if (seasons[i].indexNumber == playableParentIdx)
+                        {
+                            safeThis->m_currentSeasonIndex = i;
+                            break;
+                        }
+                    }
+                }
+
+                if (!seasons.isEmpty() && safeThis->m_episodeWidget)
+                {
+                    const int idx = qBound(0, safeThis->m_currentSeasonIndex, seasons.size() - 1);
+                    safeThis->updateSeasonSwitcher(idx);
+
+                    const QString playableItemId =
+                        safeThis->m_hasManualSeriesSelection && !safeThis->m_manualSelectedEpisodeId.isEmpty()
+                            ? safeThis->m_manualSelectedEpisodeId
+                            : safeThis->m_currentPlayableItem.id;
+                    co_await safeThis->loadEpisodesForSeason(idx, playableItemId, !playableItemId.isEmpty(),
+                                                             safeThis->m_hasManualSeriesSelection);
+                }
+                else if (safeThis->m_episodeWidget)
+                {
+                    applyReservedSectionItems(safeThis->m_episodeSectionReserveWidget, safeThis->m_episodeWidget, {});
+                }
+                if (!safeThis || safeThis->m_currentItemId != itemId)
+                    co_return;
+
+                if (safeThis->m_seasonWidget)
+                {
+                    safeThis->m_seasonWidget->setTitle(tr("Seasons"));
+                    safeThis->m_seasonWidget->setCardStyle(MediaCardDelegate::Poster);
+                    safeThis->m_seasonWidget->setGalleryHeight(300);
+                    applyReservedSectionItems(safeThis->m_seasonSectionReserveWidget, safeThis->m_seasonWidget,
+                                              seasons);
+                }
+            }
+
+            safeThis->applyCastSection(item);
+            if (safeThis->m_deferBottomInfoReveal)
+            {
+                safeThis->m_deferBottomInfoReveal = false;
+                hideReserveWidget(safeThis->m_bottomInfoReserveWidget);
+                if (safeThis->m_bottomInfoWidget)
+                    safeThis->m_bottomInfoWidget->show();
+            }
+            safeThis->persistDetailCacheSnapshot(QStringLiteral("silent-refresh"));
+        }
+    }
+    catch (...)
+    {
+    }
+}
+
+QCoro::Task<void> DetailView::executeLoadImages(QPointer<DetailView> safeThis, QEmbyCore *core, MediaItem item,
+                                                bool allowPrimaryBackdropFallback)
+{
+    bool adaptive = ConfigStore::instance()->get<bool>(ConfigKeys::AdaptiveImages, true);
+    QString cacheServerId;
+    QString cacheUserId;
+    if (safeThis)
+    {
+        cacheServerId = safeThis->m_detailCacheServerId;
+        cacheUserId = safeThis->m_detailCacheUserId;
+    }
+    else if (core && core->serverManager())
+    {
+        const ServerProfile profile = core->serverManager()->activeProfile();
+        cacheServerId = profile.id;
+        cacheUserId = profile.userId;
+    }
+
+    
+    
+    QString posterType = QStringLiteral("Primary");
+    QString posterTag = item.images.primaryTag;
+    QString posterId = item.id;
+    if (posterTag.isEmpty() && adaptive)
+    {
+        auto best = item.images.bestPoster();
+        posterTag = best.first;
+        posterType = best.second;
+        if (item.images.isParentTag(posterTag))
+        {
+            posterId = item.images.parentImageItemId.isEmpty() ? item.seriesId : item.images.parentImageItemId;
+        }
+    }
+    const int posterMaxWidth = posterType == QStringLiteral("Primary") ? 400 : 800;
+
+    QString backdropType = QStringLiteral("Backdrop");
+    QString backdropTag = item.images.backdropTag;
+    QString backdropId = item.id;
+    if (backdropTag.isEmpty() && adaptive)
+    {
+        if (allowPrimaryBackdropFallback)
+        {
+            auto best = item.images.bestBackdrop();
+            backdropTag = best.first;
+            backdropType = best.second;
+        }
+        else
+        {
+            if (!item.images.thumbTag.isEmpty())
+            {
+                backdropTag = item.images.thumbTag;
+                backdropType = QStringLiteral("Thumb");
+            }
+            else if (!item.images.parentBackdropTag.isEmpty())
+            {
+                backdropTag = item.images.parentBackdropTag;
+                backdropType = QStringLiteral("Backdrop");
+            }
+            else if (!item.images.parentThumbTag.isEmpty())
+            {
+                backdropTag = item.images.parentThumbTag;
+                backdropType = QStringLiteral("Thumb");
+            }
+        }
+        if (item.images.isParentTag(backdropTag))
+        {
+            backdropId = item.images.parentImageItemId.isEmpty() ? item.seriesId : item.images.parentImageItemId;
+        }
+    }
+
+    const QString logoId = item.id;
+    const QString logoType = QStringLiteral("Logo");
+    const QString logoTag = item.images.logoTag;
+    constexpr int logoMaxWidth = 400;
+
+    auto cachedImagesFuture = QtConcurrent::run(
+        [cacheServerId, cacheUserId, ownerItemId = item.id, posterId, posterType, posterTag, posterMaxWidth, backdropId,
+         backdropType, backdropTag, logoId, logoType, logoTag, logoMaxWidth]() mutable
+        {
+            CachedDetailImages result;
+            if (!posterTag.isEmpty())
+            {
+                result.poster =
+                    DetailCacheUtils::loadImage(cacheServerId, cacheUserId, ownerItemId, QStringLiteral("poster"),
+                                                posterId, posterType, posterTag, posterMaxWidth);
+            }
+            if (!backdropTag.isEmpty())
+            {
+                result.backdrop =
+                    DetailCacheUtils::loadImage(cacheServerId, cacheUserId, ownerItemId, QStringLiteral("backdrop"),
+                                                backdropId, backdropType, backdropTag, 1920);
+            }
+            if (!logoTag.isEmpty())
+            {
+                result.logo =
+                    DetailCacheUtils::loadImage(cacheServerId, cacheUserId, ownerItemId, QStringLiteral("logo"), logoId,
+                                                logoType, logoTag, logoMaxWidth);
+            }
+            return result;
+        });
+    const CachedDetailImages cachedImages = co_await cachedImagesFuture;
+    if (!safeThis || safeThis->m_currentItemId != item.id)
+        co_return;
+
+    if (cachedImages.poster.has_value())
+    {
+        safeThis->m_currentPosterPix = QPixmap::fromImage(cachedImages.poster.value());
+        safeThis->m_posterLabel->setPixmap(safeThis->m_currentPosterPix);
+        qDebug() << "[DetailView] Detail poster image cache hit"
+                 << "itemId=" << item.id << "imageId=" << posterId << "type=" << posterType;
+    }
+
+    if (cachedImages.backdrop.has_value())
+    {
+        safeThis->m_currentBackdropPix = QPixmap::fromImage(cachedImages.backdrop.value());
+        safeThis->updateBackdrop();
+        qDebug() << "[DetailView] Detail backdrop image cache hit"
+                 << "itemId=" << item.id << "imageId=" << backdropId << "type=" << backdropType;
+    }
+
+    if (cachedImages.logo.has_value())
+    {
+        safeThis->m_logoLabel->setPixmap(QPixmap::fromImage(cachedImages.logo.value()));
+        safeThis->m_logoLabel->show();
+        qDebug() << "[DetailView] Detail logo image cache hit"
+                 << "itemId=" << item.id;
+    }
+
+    
+    if (!posterTag.isEmpty())
+    {
+        try
+        {
+            QPixmap pix = co_await core->mediaService()->fetchImage(posterId, posterType, posterTag, posterMaxWidth);
+            if (safeThis && safeThis->m_currentItemId == item.id && !pix.isNull())
+            {
+                safeThis->m_currentPosterPix = pix;
+
+                
+                
+                
+                const QSize posterSize(250, 375);
+                const QString currentItemId = item.id;
+                QImage src = pix.toImage();
+
+                auto *watcher = new QFutureWatcher<QImage>(safeThis.data());
+                QObject::connect(watcher, &QFutureWatcher<QImage>::finished, safeThis.data(),
+                                 [safeThis, watcher, currentItemId, cacheServerId, cacheUserId, posterId, posterType,
+                                  posterTag, posterMaxWidth]()
+                                 {
+                                     if (safeThis && safeThis->m_currentItemId == currentItemId)
+                                     {
+                                         const QImage result = watcher->result();
+                                         if (!result.isNull())
+                                         {
+                                             safeThis->m_posterLabel->setPixmap(QPixmap::fromImage(result));
+                                             saveDetailImageAsync(cacheServerId, cacheUserId, currentItemId,
+                                                                  QStringLiteral("poster"), posterId, posterType,
+                                                                  posterTag, posterMaxWidth, result);
+                                         }
+                                     }
+                                     watcher->deleteLater();
+                                 });
+                watcher->setFuture(QtConcurrent::run(
+                    [src, posterSize]() -> QImage
+                    {
+                        QImage scaled =
+                            src.scaled(posterSize, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
+                        const int cropX = (scaled.width() - posterSize.width()) / 2;
+                        const int cropY = (scaled.height() - posterSize.height()) / 2;
+                        QImage cropped = scaled.copy(cropX, cropY, posterSize.width(), posterSize.height());
+
+                        
+                        QImage rounded(posterSize, QImage::Format_ARGB32_Premultiplied);
+                        rounded.fill(Qt::transparent);
+                        QPainter p(&rounded);
+                        p.setRenderHint(QPainter::Antialiasing);
+                        QPainterPath path;
+                        path.addRoundedRect(QRectF(0, 0, posterSize.width(), posterSize.height()), 12, 12);
+                        p.setClipPath(path);
+                        p.drawImage(0, 0, cropped);
+                        p.end();
+                        return rounded;
+                    }));
+            }
+        }
+        catch (...)
+        {
+        }
+    }
+
+    
+    if (!backdropTag.isEmpty())
+    {
+        try
+        {
+            QPixmap pix = co_await core->mediaService()->fetchImage(backdropId, backdropType, backdropTag, 1920);
+            if (safeThis && safeThis->m_currentItemId == item.id && !pix.isNull())
+            {
+                safeThis->m_currentBackdropPix = pix;
+                safeThis->updateBackdrop();
+                saveDetailImageAsync(cacheServerId, cacheUserId, item.id, QStringLiteral("backdrop"), backdropId,
+                                     backdropType, backdropTag, 1920, pix.toImage());
+            }
+        }
+        catch (...)
+        {
+        }
+    }
+
+    
+    
+    if (!logoTag.isEmpty())
+    {
+        try
+        {
+            QPixmap pix = co_await core->mediaService()->fetchImage(logoId, logoType, logoTag, logoMaxWidth);
+            if (safeThis && safeThis->m_currentItemId == item.id && !pix.isNull())
+            {
+                const QString currentItemId = item.id;
+                QImage src = pix.toImage();
+
+                auto *watcher = new QFutureWatcher<QImage>(safeThis.data());
+                QObject::connect(watcher, &QFutureWatcher<QImage>::finished, safeThis.data(),
+                                 [safeThis, watcher, currentItemId, cacheServerId, cacheUserId, logoId, logoType,
+                                  logoTag, logoMaxWidth]()
+                                 {
+                                     if (safeThis && safeThis->m_currentItemId == currentItemId)
+                                     {
+                                         const QImage result = watcher->result();
+                                         if (!result.isNull())
+                                         {
+                                             safeThis->m_logoLabel->setPixmap(QPixmap::fromImage(result));
+                                             safeThis->m_logoLabel->show();
+                                             saveDetailImageAsync(cacheServerId, cacheUserId, currentItemId,
+                                                                  QStringLiteral("logo"), logoId, logoType, logoTag,
+                                                                  logoMaxWidth, result);
+                                         }
+                                     }
+                                     watcher->deleteLater();
+                                 });
+                watcher->setFuture(QtConcurrent::run(
+                    [src]() -> QImage { return src.scaled(250, 100, Qt::KeepAspectRatio, Qt::SmoothTransformation); }));
+            }
+        }
+        catch (...)
+        {
+        }
+    }
+}
+
+void DetailView::onMediaItemUpdated(const MediaItem &item)
+{
+    
+    if (m_currentItemId == item.id && m_core && !m_skipSilentRefresh)
+    {
+        QCoro::connect(executeSilentRefresh(QPointer<DetailView>(this), m_core, item.id), this, []() {});
+    }
+
+    
+    if (item.type == "Season" && !m_currentSeasonEpisodes.isEmpty())
+    {
+        bool belongsToSeries = false;
+        for (const MediaItem &season : m_seriesSeasons)
+        {
+            if (season.id == item.id)
+            {
+                belongsToSeries = true;
+                break;
+            }
+        }
+        if (belongsToSeries)
+        {
+            for (MediaItem &ep : m_currentSeasonEpisodes)
+            {
+                if (ep.parentIndexNumber == item.indexNumber)
+                    ep.userData.played = item.userData.played;
+            }
+            m_episodeWidget->setItems(m_currentSeasonEpisodes);
+        }
+    }
+
+    
+    if (item.type == "Episode" && !m_currentSeasonEpisodes.isEmpty() && !m_seriesSeasons.isEmpty())
+    {
+        
+        for (MediaItem &ep : m_currentSeasonEpisodes)
+        {
+            if (ep.id == item.id)
+            {
+                ep.userData.played = item.userData.played;
+                break;
+            }
+        }
+        
+        const int seasonIndex = item.parentIndexNumber;
+        if (seasonIndex >= 0)
+        {
+            for (MediaItem &season : m_seriesSeasons)
+            {
+                if (season.indexNumber == seasonIndex)
+                {
+                    int total = 0, played = 0;
+                    for (const MediaItem &ep : m_currentSeasonEpisodes)
+                    {
+                        if (ep.parentIndexNumber == seasonIndex)
+                        {
+                            total++;
+                            if (ep.userData.played)
+                                played++;
+                        }
+                    }
+                    const bool allPlayed = (total > 0 && played == total);
+                    if (season.userData.played != allPlayed)
+                    {
+                        season.userData.played = allPlayed;
+                        m_seasonWidget->updateItem(season);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    
+    if (m_currentPlayableItem.id == item.id)
+    {
+        m_currentPlayableItem.userData.played = item.userData.played;
+        m_actionWidget->setPlayedState(item.userData.played);
+    }
+    if (m_currentMediaItem.id == item.id)
+    {
+        m_currentMediaItem.userData.played = item.userData.played;
+        m_actionWidget->setPlayedState(item.userData.played);
+    }
+
+    if (m_seasonWidget)
+        m_seasonWidget->updateItem(item);
+    if (m_episodeWidget)
+        m_episodeWidget->updateItem(item);
+    if (m_castWidget)
+        m_castWidget->updateItem(item);
+    if (m_additionalPartsWidget)
+        m_additionalPartsWidget->updateItem(item);
+    if (m_collectionWidget)
+        m_collectionWidget->updateItem(item);
+    if (m_similarWidget)
+        m_similarWidget->updateItem(item);
+}
+
+void DetailView::beginOptimisticPlayedUpdate()
+{
+    m_skipSilentRefresh = true;
+}
+
+void DetailView::endOptimisticPlayedUpdate()
+{
+    m_skipSilentRefresh = false;
+}
+
+void DetailView::updateSeasonSwitcher(int currentIndex)
+{
+    if (!m_seasonSwitcher)
+        return;
+
+    QSignalBlocker blocker(m_seasonSwitcher);
+    m_seasonSwitcher->clear();
+
+    for (const MediaItem &season : m_seriesSeasons)
+        m_seasonSwitcher->addItem(season.name, "");
+
+    if (!m_seriesSeasons.isEmpty())
+    {
+        const int idx = qBound(0, currentIndex, m_seriesSeasons.size() - 1);
+        m_seasonSwitcher->setCurrentIndex(idx);
+    }
+
+    m_seasonSwitcher->setVisible(m_seriesSeasons.size() > 1);
+    m_seasonSwitcher->adjustSize();
+    if (m_episodeJumpEdit)
+    {
+        const int switcherHeight = qMax(m_seasonSwitcher->height(), m_seasonSwitcher->sizeHint().height());
+        m_episodeJumpEdit->setFixedHeight(switcherHeight);
+    }
+    updateEpisodeHeaderControlsVisibility();
+}
+
+void DetailView::updateEpisodeHeaderControlsVisibility()
+{
+    if (!m_episodeHeaderControls)
+        return;
+
+    const bool showSeasonSwitcher = m_seasonSwitcher && !m_seasonSwitcher->isHidden();
+    const bool showEpisodeJump = m_episodeJumpEdit && !m_episodeJumpEdit->isHidden();
+    m_episodeHeaderControls->setVisible(showSeasonSwitcher || showEpisodeJump);
+    m_episodeHeaderControls->adjustSize();
+    m_episodeHeaderControls->updateGeometry();
+}
+
+void DetailView::updateEpisodeJumpControl(int episodeCount)
+{
+    if (!m_episodeJumpEdit)
+    {
+        return;
+    }
+
+    const int visibleCardCapacity = episodeGalleryVisibleCardCapacity();
+    const bool showJump = episodeCount > 0 && visibleCardCapacity > 0 && episodeCount > visibleCardCapacity;
+    if (showJump)
+    {
+        int explicitMaxEpisodeNumber = 0;
+        for (const MediaItem &episode : m_currentSeasonEpisodes)
+            explicitMaxEpisodeNumber = qMax(explicitMaxEpisodeNumber, episode.indexNumber);
+
+        const int maxEpisodeNumber = explicitMaxEpisodeNumber > 0 ? explicitMaxEpisodeNumber : episodeCount;
+        const QString rangeText = tr("1-%1").arg(maxEpisodeNumber);
+        m_episodeJumpEdit->setPlaceholderText(rangeText);
+        m_episodeJumpEdit->setToolTip(tr("Jump to episode number (1-%1)").arg(maxEpisodeNumber));
+        if (m_episodeJumpValidator)
+            m_episodeJumpValidator->setTop(maxEpisodeNumber);
+        m_episodeJumpEdit->setMaxLength(qMax(1, QString::number(maxEpisodeNumber).length()));
+
+        const int textWidth = m_episodeJumpEdit->fontMetrics().horizontalAdvance(rangeText);
+        m_episodeJumpEdit->setFixedWidth(qBound(64, textWidth + 22, 92));
+    }
+    else
+    {
+        m_episodeJumpEdit->clear();
+        m_episodeJumpEdit->setPlaceholderText(tr("Ep #"));
+        m_episodeJumpEdit->setToolTip(tr("Jump to episode number"));
+        if (m_episodeJumpValidator)
+            m_episodeJumpValidator->setTop(9999);
+        m_episodeJumpEdit->setMaxLength(4);
+        m_episodeJumpEdit->setFixedWidth(64);
+    }
+
+    m_episodeJumpEdit->setVisible(showJump);
+    updateEpisodeHeaderControlsVisibility();
+}
+
+int DetailView::episodeGalleryVisibleCardCapacity() const
+{
+    if (!m_episodeWidget || !m_episodeWidget->gallery())
+        return 0;
+
+    QListView *listView = m_episodeWidget->gallery()->listView();
+    if (!listView || !listView->viewport())
+        return 0;
+
+    int cardWidth = m_episodeTileWidth;
+    if (cardWidth <= 0 && listView->model() && listView->model()->rowCount() > 0)
+    {
+        const QSize itemSize = listView->sizeHintForIndex(listView->model()->index(0, 0));
+        cardWidth = itemSize.width();
+    }
+    if (cardWidth <= 0)
+        return 0;
+
+    const int viewportWidth = listView->viewport()->width();
+    if (viewportWidth <= 0)
+        return 0;
+
+    return qMax(1, viewportWidth / cardWidth);
+}
+
+MediaItem DetailView::episodeForJumpNumber(int episodeNumber) const
+{
+    if (episodeNumber <= 0)
+        return MediaItem{};
+
+    bool hasExplicitEpisodeNumbers = false;
+    for (const MediaItem &episode : m_currentSeasonEpisodes)
+    {
+        if (episode.indexNumber > 0)
+            hasExplicitEpisodeNumbers = true;
+        if (episode.indexNumber == episodeNumber)
+            return episode;
+    }
+
+    if (hasExplicitEpisodeNumbers)
+        return MediaItem{};
+
+    const int row = episodeNumber - 1;
+    if (row >= 0 && row < m_currentSeasonEpisodes.size())
+        return m_currentSeasonEpisodes.at(row);
+
+    return MediaItem{};
+}
+
+void DetailView::submitEpisodeJump()
+{
+    if (!m_episodeJumpEdit || m_episodeJumpEdit->isHidden() || m_currentSeasonEpisodes.isEmpty())
+    {
+        return;
+    }
+
+    const QString text = m_episodeJumpEdit->text().trimmed();
+    if (text.isEmpty())
+        return;
+
+    bool ok = false;
+    const int episodeNumber = text.toInt(&ok);
+    if (!ok)
+        return;
+
+    const MediaItem targetEpisode = episodeForJumpNumber(episodeNumber);
+    if (targetEpisode.id.isEmpty())
+    {
+        qDebug() << "[DetailView] Episode jump target not found"
+                 << "seriesId=" << m_currentItemId << "seasonIndex=" << m_currentSeasonIndex
+                 << "episodeNumber=" << episodeNumber << "episodeCount=" << m_currentSeasonEpisodes.size();
+        ModernToast::showMessage(tr("Episode %1 not found").arg(episodeNumber), 1600);
+        m_episodeJumpEdit->selectAll();
+        return;
+    }
+
+    qDebug() << "[DetailView] Episode jump"
+             << "seriesId=" << m_currentItemId << "seasonIndex=" << m_currentSeasonIndex
+             << "episodeNumber=" << episodeNumber << "episodeId=" << targetEpisode.id;
+
+    m_episodeJumpEdit->clear();
+    markManualSeriesSelection(QStringLiteral("episode-jump"));
+    QCoro::connect(applySeriesPlayableItem(targetEpisode, true), this, []() {});
+}
+
+QCoro::Task<void> DetailView::loadEpisodesForSeason(int idx, QString highlightEpisodeId, bool scrollToHighlight,
+                                                    bool manualSelection)
+{
+    if (idx < 0 || idx >= m_seriesSeasons.size() || !m_episodeWidget)
+        co_return;
+
+    m_currentSeasonIndex = idx;
+    const QString seasonId = m_seriesSeasons[idx].id;
+    if (seasonId.isEmpty())
+        co_return;
+    if (manualSelection)
+        markManualSeriesSelection(QStringLiteral("season-selection"));
+    rememberSeriesSelection(MediaItem{}, QStringLiteral("season-selection"), !manualSelection);
+
+    bool showedCachedEpisodes = false;
+    QList<MediaItem> shownCachedEpisodes;
+    if (m_hasCachedSeasonEpisodes && m_cachedSeasonIndex == idx && m_cachedSeasonId == seasonId &&
+        episodesBelongToSeason(m_cachedSeasonEpisodes, m_seriesSeasons[idx]))
+    {
+        shownCachedEpisodes = m_cachedSeasonEpisodes;
+        if (!m_appliedCachedSeasonEpisodesToUi)
+        {
+            m_currentSeasonEpisodes = shownCachedEpisodes;
+            applyReservedSectionItems(m_episodeSectionReserveWidget, m_episodeWidget, shownCachedEpisodes);
+            updateEpisodeJumpControl(shownCachedEpisodes.size());
+            if (!highlightEpisodeId.isEmpty())
+            {
+                m_episodeWidget->gallery()->setHighlightedItemId(highlightEpisodeId);
+                if (scrollToHighlight)
+                {
+                    m_episodeWidget->gallery()->scrollToItemId(highlightEpisodeId);
+                }
+            }
+            m_appliedCachedSeasonEpisodesToUi = true;
+        }
+        showedCachedEpisodes = true;
+        qDebug() << "[DetailView][cache-ui] Applied cached season episodes"
+                 << "seriesId=" << m_currentItemId << "seasonId=" << seasonId << "seasonIndex=" << idx
+                 << "episodeCount=" << shownCachedEpisodes.size();
+    }
+    else
+    {
+        m_currentSeasonEpisodes.clear();
+        updateEpisodeJumpControl(0);
+    }
+
+    if (!m_core || !m_core->mediaService())
+        co_return;
+
+    QPointer<DetailView> safeThis(this);
+    const QString seriesId = m_currentItemId;
+    QEmbyCore *core = m_core;
+
+    try
+    {
+        qDebug() << "[DetailView][network] Fetch season episodes"
+                 << "seriesId=" << seriesId << "seasonId=" << seasonId << "seasonIndex=" << idx;
+        QList<MediaItem> episodes = co_await core->mediaService()->getEpisodes(seriesId, seasonId);
+
+        if (!safeThis || safeThis->m_currentItemId != seriesId || safeThis->m_currentSeasonIndex != idx)
+            co_return;
+
+        bool episodesUnchanged = false;
+        if (showedCachedEpisodes)
+        {
+            episodesUnchanged = co_await mediaItemListsEqualAsync(shownCachedEpisodes, episodes);
+            if (!safeThis || safeThis->m_currentItemId != seriesId || safeThis->m_currentSeasonIndex != idx)
+                co_return;
+        }
+
+        safeThis->m_currentSeasonEpisodes = episodes;
+        if (!safeThis->m_hasManualSeriesSelection)
+        {
+            safeThis->m_cachedSeasonEpisodes = episodes;
+            safeThis->m_cachedSeasonIndex = idx;
+            safeThis->m_cachedSeasonId = seasonId;
+            safeThis->m_hasCachedSeasonEpisodes = true;
+        }
+        else
+        {
+            qDebug() << "[DetailView] Skip persisting manually selected season "
+                        "episodes"
+                     << "seriesId=" << seriesId << "seasonId=" << seasonId << "seasonIndex=" << idx;
+        }
+        if (!manualSelection && !highlightEpisodeId.isEmpty() &&
+            safeThis->m_currentPlayableItem.id != highlightEpisodeId)
+        {
+            for (const MediaItem &episode : episodes)
+            {
+                if (episode.id == highlightEpisodeId)
+                {
+                    safeThis->applySeriesPlayableItemToUi(episode);
+                    break;
+                }
+            }
+        }
+        if (!episodesUnchanged)
+        {
+            applyReservedSectionItems(safeThis->m_episodeSectionReserveWidget, safeThis->m_episodeWidget, episodes);
+        }
+        safeThis->updateEpisodeJumpControl(episodes.size());
+
+        qDebug() << "[DetailView][network] Loaded season episodes"
+                 << "seriesId=" << seriesId << "seasonId=" << seasonId << "seasonIndex=" << idx
+                 << "episodeCount=" << episodes.size() << "fromCache=" << showedCachedEpisodes
+                 << "unchanged=" << episodesUnchanged
+                 << "visibleCardCapacity=" << safeThis->episodeGalleryVisibleCardCapacity()
+                 << "jumpVisible=" << (safeThis->m_episodeJumpEdit && !safeThis->m_episodeJumpEdit->isHidden());
+
+        if (!highlightEpisodeId.isEmpty())
+        {
+            safeThis->m_episodeWidget->gallery()->setHighlightedItemId(highlightEpisodeId);
+            if (scrollToHighlight)
+            {
+                safeThis->m_episodeWidget->gallery()->scrollToItemId(highlightEpisodeId);
+            }
+        }
+        safeThis->persistDetailCacheSnapshot(QStringLiteral("episodes"));
+    }
+    catch (...)
+    {
+        if (safeThis && safeThis->m_currentItemId == seriesId && safeThis->m_currentSeasonIndex == idx)
+        {
+            if (!showedCachedEpisodes)
+            {
+                safeThis->m_currentSeasonEpisodes.clear();
+                safeThis->updateEpisodeJumpControl(0);
+                applyReservedSectionItems(safeThis->m_episodeSectionReserveWidget, safeThis->m_episodeWidget, {});
+            }
+            qDebug() << "[DetailView] Failed to load season episodes"
+                     << "seriesId=" << seriesId << "seasonId=" << seasonId << "seasonIndex=" << idx
+                     << "keptCache=" << showedCachedEpisodes;
+        }
+    }
+}
+
+
+QCoro::Task<void> DetailView::switchToSeason(int idx, bool manualSelection)
+{
+    co_await loadEpisodesForSeason(idx, QString(), false, manualSelection);
 }

--- a/src/qEmbyApp/views/media/detailview.h
+++ b/src/qEmbyApp/views/media/detailview.h
@@ -30,7 +30,7 @@ public:
   
   
   
-  QCoro::Task<void> loadItem(const QString &itemId, const MediaItem &seedItem = {});
+  void loadItem(QString itemId, MediaItem seedItem = {});
 
 public Q_SLOTS:
   void onMediaItemUpdated(const MediaItem &item) override;
@@ -67,12 +67,18 @@ private:
   void rememberSeriesSelection(const MediaItem &episode,
                                const QString &reason = QString(),
                                bool persist = false);
+  void applyRememberedStreams(const MediaItem &item,
+                              const MediaSourceInfo &source);
   void applySeriesPlayableItemToUi(const MediaItem &playableItem,
                                    bool scrollToEpisode = false);
   QCoro::Task<void> applySeriesPlayableItem(MediaItem playableItem,
                                             bool scrollToEpisode = false);
 
   QCoro::Task<void> updateUi(MediaItem item, bool isSilentRefresh = false);
+
+  
+  
+  QCoro::Task<void> fetchAndApplyPlaybackInfo(QString itemId);
 
   
   
@@ -87,7 +93,7 @@ private:
   QCoro::Task<void> executePlay(MediaItem targetItem, long long startTicks);
   QCoro::Task<void> executePlaySeason(MediaItem seasonItem);
   QCoro::Task<void> executeExternalPlay(MediaItem targetItem, QString playerPath);
-  QCoro::Task<void> fetchSeriesNextUp(const QString &targetId,
+  QCoro::Task<void> fetchSeriesNextUp(QString targetId,
                                       bool applyToUi = true);
   void updateSeasonSwitcher(int currentIndex);
   void updateEpisodeHeaderControlsVisibility();

--- a/src/qEmbyApp/views/media/mediacarddelegate.cpp
+++ b/src/qEmbyApp/views/media/mediacarddelegate.cpp
@@ -185,6 +185,29 @@ QPixmap scaledCardPixmap(const MediaItem &item, const QPixmap &source, const QSi
     return scaled;
 }
 
+void drawPlayedBadge(QPainter *painter, const QRect &targetImgRect, bool alignLeft)
+{
+    const int checkSize = 16;
+    const int checkMargin = 4;
+    const int checkX = alignLeft ? targetImgRect.left() + checkMargin
+                                 : targetImgRect.right() - checkSize - checkMargin;
+    const QRect checkRect(checkX, targetImgRect.top() + checkMargin, checkSize, checkSize);
+
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing, true);
+    painter->setPen(Qt::NoPen);
+    painter->setBrush(QColor(16, 185, 129, 140));
+    painter->drawRoundedRect(checkRect, checkSize / 2, checkSize / 2);
+
+    QIcon checkIcon(":/svg/dark/check.svg");
+    if (!checkIcon.isNull())
+    {
+        checkIcon.paint(painter, checkRect.adjusted(3, 3, -3, -3), Qt::AlignCenter);
+    }
+
+    painter->restore();
+}
+
 } 
 
 
@@ -447,6 +470,11 @@ void MediaCardDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opt
             }
         }
 
+        if (item.userData.played)
+        {
+            drawPlayedBadge(painter, baseImgRect, false);
+        }
+
         
         int textX = baseImgRect.right() + 20;
         int favBtnSize = 24;
@@ -652,30 +680,7 @@ void MediaCardDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opt
     
     if ((item.type == "Episode" || item.type == "Season") && item.userData.played)
     {
-        int checkSize = 16;
-        int checkMargin = 4;
-        int checkX = item.type == "Season"
-                         ? targetImgRect.left() + checkMargin
-                         : targetImgRect.right() - checkSize - checkMargin;
-        QRect checkRect(checkX, targetImgRect.top() + checkMargin, checkSize,
-                        checkSize);
-
-        painter->save();
-        painter->setRenderHint(QPainter::Antialiasing, true);
-
-        
-        painter->setPen(Qt::NoPen);
-        painter->setBrush(QColor(16, 185, 129, 140));
-        painter->drawRoundedRect(checkRect, checkSize / 2, checkSize / 2);
-
-        
-        QIcon checkIcon(":/svg/dark/check.svg");
-        if (!checkIcon.isNull()) {
-            checkIcon.paint(painter, checkRect.adjusted(3, 3, -3, -3),
-                           Qt::AlignCenter);
-        }
-
-        painter->restore();
+        drawPlayedBadge(painter, targetImgRect, item.type == "Season");
     }
 
     

--- a/src/qEmbyApp/views/media/medialistmodel.cpp
+++ b/src/qEmbyApp/views/media/medialistmodel.cpp
@@ -6,12 +6,17 @@
 #include <QSet>
 #include <QVector>
 #include <QMutableHashIterator>
+#include <QMutableSetIterator>
 #include <algorithm>
+#include <exception>
 #include <utility>
 
 namespace {
 
-constexpr int kMaxConcurrentImageFetches = 6;
+
+
+
+constexpr int kMaxConcurrentImageFetches = 4;
 
 QString buildImageIdentity(const MediaItem& item)
 {
@@ -84,11 +89,100 @@ MediaItem mergeItemUpdate(const MediaItem& currentItem,
 MediaListModel::MediaListModel(int imageMaxWidth, QEmbyCore* core, QObject *parent)
     : QAbstractListModel(parent), m_imageMaxWidth(imageMaxWidth), m_core(core)
 {
+    m_imageRequestContext = new QObject(this);
     m_imageNotifyTimer = new QTimer(this);
     m_imageNotifyTimer->setSingleShot(true);
     m_imageNotifyTimer->setTimerType(Qt::PreciseTimer);
     connect(m_imageNotifyTimer, &QTimer::timeout, this,
             &MediaListModel::flushPendingImageDataChanges);
+}
+
+MediaListModel::~MediaListModel()
+{
+    ++m_imageRequestGeneration;
+    m_loadingImages.clear();
+    m_pendingImageRequests.clear();
+    m_pendingImageOrder.clear();
+    m_priorityImageIds.clear();
+    m_activeImageFetches = 0;
+    QObject* requestContext = m_imageRequestContext;
+    m_imageRequestContext = nullptr;
+    delete requestContext;
+}
+
+void MediaListModel::suspendImageRequests()
+{
+    const int activeCount = m_activeImageFetches;
+    const int pendingCount = m_pendingImageRequests.size();
+    m_imageRequestsSuspended = true;
+    ++m_imageRequestGeneration;
+
+    
+    
+    
+    QObject* previousRequestContext = m_imageRequestContext;
+    m_imageRequestContext = new QObject(this);
+    delete previousRequestContext;
+
+    m_loadingImages.clear();
+    m_pendingImageRequests.clear();
+    m_pendingImageOrder.clear();
+    m_priorityImageIds.clear();
+    m_pendingImageNotifyIds.clear();
+    m_activeImageFetches = 0;
+    if (m_imageNotifyTimer) {
+        m_imageNotifyTimer->stop();
+    }
+
+    if (activeCount > 0 || pendingCount > 0) {
+        qDebug() << "[MediaListModel] cancelled image request generation"
+                 << "| active=" << activeCount
+                 << "| pending=" << pendingCount
+                 << "| cached=" << m_imageCache.size()
+                 << "| generation=" << m_imageRequestGeneration;
+    }
+}
+
+void MediaListModel::resumeImageRequests()
+{
+    m_imageRequestsSuspended = false;
+}
+
+void MediaListModel::clearImageCache()
+{
+    if (m_imageCache.isEmpty() && m_loadingImages.isEmpty() &&
+        m_pendingImageRequests.isEmpty() && m_failedImageItems.isEmpty() &&
+        m_activeImageFetches == 0) {
+        return;
+    }
+
+    const bool hasRequests = !m_loadingImages.isEmpty() ||
+                             !m_pendingImageRequests.isEmpty() ||
+                             m_activeImageFetches > 0;
+    if (hasRequests) {
+        const bool wasSuspended = m_imageRequestsSuspended;
+        suspendImageRequests();
+        m_imageRequestsSuspended = wasSuspended;
+    }
+    m_imageCache.clear();
+    m_failedImageItems.clear();
+}
+
+void MediaListModel::setPreferThumb(bool prefer)
+{
+    if (m_preferThumb == prefer) {
+        return;
+    }
+
+    m_preferThumb = prefer;
+    if (!m_items.isEmpty()) {
+        clearImageCache();
+    }
+}
+
+void MediaListModel::clearFailedImageItems()
+{
+    m_failedImageItems.clear();
 }
 
 int MediaListModel::rowCount(const QModelIndex &parent) const {
@@ -120,10 +214,42 @@ QVariant MediaListModel::data(const QModelIndex &index, int role) const {
             return m_imageCache.value(item.id);
         }
 
-        const_cast<MediaListModel*>(this)->ensureImageRequested(item);
+        
+        const_cast<MediaListModel*>(this)->ensureImageRequested(item, true);
         return QVariant(); 
     }
     return QVariant();
+}
+
+void MediaListModel::setImageMaxWidth(int maxWidth)
+{
+    const int normalizedWidth = qBound(96, maxWidth, 1024);
+    if (normalizedWidth == m_imageMaxWidth) {
+        return;
+    }
+
+    if (normalizedWidth > m_imageMaxWidth &&
+        normalizedWidth <= m_imageMaxWidth * 6 / 5) {
+        return;
+    }
+
+    const bool requiresHigherResolution = normalizedWidth > m_imageMaxWidth;
+    m_imageMaxWidth = normalizedWidth;
+    if (requiresHigherResolution && !m_items.isEmpty()) {
+        clearImageCache();
+    }
+}
+
+void MediaListModel::setForceNetworkImages(bool forceNetwork)
+{
+    if (m_forceNetworkImages == forceNetwork) {
+        return;
+    }
+
+    m_forceNetworkImages = forceNetwork;
+    if (!m_items.isEmpty()) {
+        clearImageCache();
+    }
 }
 
 QString MediaListModel::buildTooltipText(const MediaItem &item) const {
@@ -229,8 +355,16 @@ void MediaListModel::setItems(const QList<MediaItem>& newItems) {
         } 
         else if (oldIdx == newIdx) {
             
+            const bool imageChanged =
+                buildImageIdentity(m_items[newIdx]) !=
+                buildImageIdentity(newItem);
             m_items[newIdx] = newItem;
-            Q_EMIT dataChanged(index(newIdx, 0), index(newIdx, 0), {ItemDataRole});
+            QVector<int> roles = {ItemDataRole};
+            if (imageChanged) {
+                invalidateItemImageRequest(newItem.id);
+                roles.append(PosterPixmapRole);
+            }
+            Q_EMIT dataChanged(index(newIdx, 0), index(newIdx, 0), roles);
         } 
         else {
             
@@ -240,8 +374,16 @@ void MediaListModel::setItems(const QList<MediaItem>& newItems) {
             endMoveRows();
             
             
+            const bool imageChanged =
+                buildImageIdentity(m_items[newIdx]) !=
+                buildImageIdentity(newItem);
             m_items[newIdx] = newItem;
-            Q_EMIT dataChanged(index(newIdx, 0), index(newIdx, 0), {ItemDataRole});
+            QVector<int> roles = {ItemDataRole};
+            if (imageChanged) {
+                invalidateItemImageRequest(newItem.id);
+                roles.append(PosterPixmapRole);
+            }
+            Q_EMIT dataChanged(index(newIdx, 0), index(newIdx, 0), roles);
         }
     }
 
@@ -251,6 +393,12 @@ void MediaListModel::setItems(const QList<MediaItem>& newItems) {
         it.next();
         if (!newIds.contains(it.key())) {
             it.remove();
+        }
+    }
+    QMutableSetIterator<QString> failedIt(m_failedImageItems);
+    while (failedIt.hasNext()) {
+        if (!newIds.contains(failedIt.next())) {
+            failedIt.remove();
         }
     }
 }
@@ -274,8 +422,7 @@ void MediaListModel::updateItem(const MediaItem& updatedItem) {
             m_items[i] = mergedItem;
 
             if (imageChanged) {
-                m_imageCache.remove(cachedItemId);
-                m_loadingImages.remove(cachedItemId);
+                invalidateItemImageRequest(cachedItemId);
             }
             
             
@@ -340,8 +487,10 @@ void MediaListModel::removeItem(const QString& itemId) {
             
             m_imageCache.remove(cachedItemId);
             m_loadingImages.remove(cachedItemId);
+            m_failedImageItems.remove(cachedItemId);
             m_imageCache.remove(itemId);
             m_loadingImages.remove(itemId);
+            m_failedImageItems.remove(itemId);
             
             break; 
         }
@@ -364,76 +513,165 @@ void MediaListModel::setPriorityRows(const QList<int>& rows)
         }
 
         priorityIds.append(item.id);
-        ensureImageRequested(item);
     }
 
     m_priorityImageIds = priorityIds;
+
+    for (auto it = m_pendingImageRequests.begin();
+         it != m_pendingImageRequests.end(); ++it) {
+        it->highPriority = m_priorityImageIds.contains(it.key());
+    }
+
+    for (const int row : rows) {
+        if (row < 0 || row >= m_items.size()) {
+            continue;
+        }
+        ensureImageRequested(m_items.at(row), true);
+    }
+
     scheduleImageFetches();
 }
 
-void MediaListModel::ensureImageRequested(const MediaItem& item)
+void MediaListModel::ensureImageRequested(const MediaItem& item,
+                                          bool highPriority)
 {
-    if (item.id.isEmpty() || m_imageCache.contains(item.id) ||
-        m_loadingImages.contains(item.id)) {
+    if (m_imageRequestsSuspended) {
         return;
     }
 
-    QString imgType = "Primary";
-    QString imgTag = item.images.primaryTag;
-
-    if (m_preferThumb) {
-        if (ConfigStore::instance()->get<bool>(ConfigKeys::AdaptiveImages, true)) {
-            auto best = item.images.bestThumb();
-            imgTag = best.first;
-            imgType = best.second;
-        } else {
-            if (!item.images.thumbTag.isEmpty()) {
-                imgType = "Thumb";
-                imgTag = item.images.thumbTag;
-            } else if (!item.images.backdropTag.isEmpty()) {
-                imgType = "Backdrop";
-                imgTag = item.images.backdropTag;
-            }
-        }
-    } else if (imgTag.isEmpty() &&
-               ConfigStore::instance()->get<bool>(ConfigKeys::AdaptiveImages,
-                                                  true)) {
-        auto best = item.images.bestPoster();
-        imgTag = best.first;
-        imgType = best.second;
+    if (highPriority && m_pendingImageRequests.contains(item.id)) {
+        m_pendingImageRequests[item.id].highPriority = true;
     }
 
-    QString targetImageId = item.getPrimaryImageId();
-    bool usingParentImage = false;
-    if (!imgTag.isEmpty() && item.images.isParentTag(imgTag) &&
-        !item.images.parentImageItemId.isEmpty()) {
-        targetImageId = item.images.parentImageItemId;
-        usingParentImage = true;
-    }
-
-    if (imgTag.isEmpty()) {
+    if (item.id.isEmpty() || m_imageCache.contains(item.id) ||
+        m_loadingImages.contains(item.id) ||
+        m_failedImageItems.contains(item.id)) {
         return;
     }
 
     PendingImageRequest request;
-    request.targetImageId = targetImageId;
-    request.imageType = imgType;
-    request.imageTag = imgTag;
-    request.maxWidth = usingParentImage ? m_imageMaxWidth * 2 : m_imageMaxWidth;
+    request.highPriority = highPriority;
+    request.imageIdentity = buildImageIdentity(item);
+    QSet<QString> seenCandidates;
+
+    auto appendCandidate = [&](const QString& tag, const QString& type) {
+        const QString trimmedTag = tag.trimmed();
+        const QString trimmedType = type.trimmed();
+        if (trimmedTag.isEmpty() || trimmedType.isEmpty()) {
+            return;
+        }
+
+        QString targetImageId = item.getPrimaryImageId();
+        if (item.images.isParentTag(trimmedTag) &&
+            !item.images.parentImageItemId.isEmpty()) {
+            targetImageId = item.images.parentImageItemId;
+        }
+
+        if (targetImageId.trimmed().isEmpty()) {
+            return;
+        }
+
+        const QString candidateKey =
+            QStringLiteral("%1|%2|%3")
+                .arg(targetImageId, trimmedType, trimmedTag);
+        if (seenCandidates.contains(candidateKey)) {
+            return;
+        }
+        seenCandidates.insert(candidateKey);
+
+        ImageCandidate candidate;
+        candidate.targetImageId = targetImageId;
+        candidate.imageType = trimmedType;
+        candidate.imageTag = trimmedTag;
+        candidate.maxWidth = m_imageMaxWidth;
+        request.candidates.append(candidate);
+    };
+
+    const bool adaptiveImages =
+        ConfigStore::instance()->get<bool>(ConfigKeys::AdaptiveImages, true);
+
+    if (m_preferThumb) {
+        if (adaptiveImages) {
+            appendCandidate(item.images.thumbTag, QStringLiteral("Thumb"));
+            appendCandidate(item.images.backdropTag, QStringLiteral("Backdrop"));
+            appendCandidate(item.images.primaryTag, QStringLiteral("Primary"));
+            appendCandidate(item.images.parentBackdropTag,
+                            QStringLiteral("Backdrop"));
+            appendCandidate(item.images.parentThumbTag, QStringLiteral("Thumb"));
+            appendCandidate(item.images.parentPrimaryTag,
+                            QStringLiteral("Primary"));
+        } else {
+            appendCandidate(item.images.thumbTag, QStringLiteral("Thumb"));
+            appendCandidate(item.images.backdropTag, QStringLiteral("Backdrop"));
+        }
+    } else if (adaptiveImages) {
+        appendCandidate(item.images.primaryTag, QStringLiteral("Primary"));
+        appendCandidate(item.images.thumbTag, QStringLiteral("Thumb"));
+        appendCandidate(item.images.backdropTag, QStringLiteral("Backdrop"));
+        appendCandidate(item.images.parentPrimaryTag, QStringLiteral("Primary"));
+        appendCandidate(item.images.parentBackdropTag,
+                        QStringLiteral("Backdrop"));
+    } else {
+        appendCandidate(item.images.primaryTag, QStringLiteral("Primary"));
+    }
+
+    if (request.candidates.isEmpty()) {
+        
+        
+        
+        m_failedImageItems.insert(item.id);
+        qDebug() << "[MediaListModel] image request skipped: no image metadata"
+                 << "| itemId=" << item.id
+                 << "| itemType=" << item.type
+                 << "| primaryImageItemId="
+                 << item.images.primaryImageItemId
+                 << "| hasPrimary=" << !item.images.primaryTag.isEmpty()
+                 << "| hasThumb=" << !item.images.thumbTag.isEmpty()
+                 << "| hasBackdrop=" << !item.images.backdropTag.isEmpty()
+                 << "| hasParentPrimary="
+                 << !item.images.parentPrimaryTag.isEmpty();
+        return;
+    }
+
+    const ImageCandidate& first = request.candidates.first();
+    qDebug() << "[MediaListModel] image request queued"
+             << "| itemId=" << item.id
+             << "| candidateCount=" << request.candidates.size()
+             << "| firstTargetImageId=" << first.targetImageId
+             << "| firstImageType=" << first.imageType
+             << "| firstHasTag=" << !first.imageTag.isEmpty();
+
     enqueueImageFetch(item.id, request);
 }
 
 void MediaListModel::enqueueImageFetch(const QString& itemId,
                                        const PendingImageRequest& request)
 {
-    if (itemId.isEmpty() || m_imageCache.contains(itemId) ||
-        m_loadingImages.contains(itemId)) {
+    if (itemId.isEmpty() || request.candidates.isEmpty() ||
+        m_imageCache.contains(itemId) || m_loadingImages.contains(itemId)) {
         return;
     }
 
     m_loadingImages.insert(itemId);
     m_pendingImageRequests.insert(itemId, request);
     m_pendingImageOrder.append(itemId);
+    scheduleImageFetches();
+}
+
+void MediaListModel::enqueueImageRetry(const QString& itemId,
+                                       const PendingImageRequest& request)
+{
+    if (itemId.isEmpty() || request.candidates.isEmpty() ||
+        request.candidateIndex < 0 ||
+        request.candidateIndex >= request.candidates.size() ||
+        m_imageCache.contains(itemId)) {
+        return;
+    }
+
+    m_loadingImages.insert(itemId);
+    m_pendingImageRequests.insert(itemId, request);
+    m_pendingImageOrder.removeAll(itemId);
+    m_pendingImageOrder.prepend(itemId);
     scheduleImageFetches();
 }
 
@@ -451,9 +689,10 @@ void MediaListModel::scheduleImageFetches()
         ++m_activeImageFetches;
 
         QPointer<MediaListModel> safeThis(this);
-        executeImageFetch(safeThis, itemId, request.targetImageId,
-                          request.imageType, request.imageTag,
-                          request.maxWidth, m_imageRequestGeneration, m_core);
+        QCoro::connect(
+            executeImageFetch(safeThis, itemId, request,
+                              m_imageRequestGeneration, m_core),
+            this, []() {});
     }
 }
 
@@ -481,12 +720,37 @@ QString MediaListModel::takeNextPendingImageId()
 
 
 QCoro::Task<void> MediaListModel::executeImageFetch(
-    QPointer<MediaListModel> safeThis, QString itemId, QString targetImageId,
-    QString imgType, QString imgTag, int maxWidth, int generation,
-    QEmbyCore* core) {
+    QPointer<MediaListModel> safeThis, QString itemId,
+    PendingImageRequest request, int generation, QEmbyCore* core) {
     try {
+        if (request.candidateIndex < 0 ||
+            request.candidateIndex >= request.candidates.size() || !safeThis ||
+            !core ||
+            !core->mediaService()) {
+            if (safeThis && generation == safeThis->m_imageRequestGeneration) {
+                safeThis->m_loadingImages.remove(itemId);
+                safeThis->m_activeImageFetches =
+                    qMax(0, safeThis->m_activeImageFetches - 1);
+                safeThis->scheduleImageFetches();
+            }
+            co_return;
+        }
+
+        const ImageCandidate candidate =
+            request.candidates.at(request.candidateIndex);
+        QPointer<QObject> requestContext(safeThis->m_imageRequestContext);
+        const ImageFetchPolicy fetchPolicy =
+            safeThis->m_forceNetworkImages
+                ? ImageFetchPolicy::NetworkOnly
+                : ImageFetchPolicy::CachePreferred;
+
         
-        QPixmap pix = co_await core->mediaService()->fetchImage(targetImageId, imgType, imgTag, maxWidth);
+        QPixmap pix = co_await core->mediaService()->fetchImage(
+            candidate.targetImageId, candidate.imageType, candidate.imageTag,
+            candidate.maxWidth, -1,
+            request.highPriority ? ImageRequestPriority::High
+                                 : ImageRequestPriority::Normal,
+            requestContext.data(), fetchPolicy);
         
         
         if (!safeThis) {
@@ -505,6 +769,52 @@ QCoro::Task<void> MediaListModel::executeImageFetch(
         };
 
         if (generation != safeThis->m_imageRequestGeneration) {
+            finishFetch();
+            co_return;
+        }
+
+        if (!safeThis->isImageRequestCurrent(itemId, request)) {
+            qDebug() << "[MediaListModel] discarded stale image result"
+                     << "| itemId=" << itemId
+                     << "| candidateIndex=" << request.candidateIndex;
+            finishFetch();
+            co_return;
+        }
+
+        if (pix.isNull() && request.transientRetryCount == 0) {
+            
+            
+            
+            
+            
+            PendingImageRequest retryRequest = request;
+            ++retryRequest.transientRetryCount;
+            qDebug() << "[MediaListModel] retrying transient empty image result"
+                     << "| itemId=" << itemId
+                     << "| candidateIndex=" << request.candidateIndex
+                     << "| generation=" << generation;
+            QTimer::singleShot(
+                250, safeThis.data(),
+                [safeThis, itemId, retryRequest, generation]() {
+                    if (!safeThis ||
+                        generation != safeThis->m_imageRequestGeneration ||
+                        safeThis->m_imageRequestsSuspended ||
+                        !safeThis->isImageRequestCurrent(itemId,
+                                                         retryRequest)) {
+                        if (safeThis &&
+                            generation == safeThis->m_imageRequestGeneration) {
+                            safeThis->m_loadingImages.remove(itemId);
+                        }
+                        return;
+                    }
+                    safeThis->enqueueImageRetry(itemId, retryRequest);
+                });
+            finishFetch();
+            co_return;
+        }
+
+        if (pix.isNull()) {
+            safeThis->retryNextImageCandidate(itemId, request, generation);
             finishFetch();
             co_return;
         }
@@ -528,17 +838,95 @@ QCoro::Task<void> MediaListModel::executeImageFetch(
             safeThis->queueImageDataChanged(itemId);
         }
         finishFetch();
-    } catch (...) {
-        
+    } catch (const std::exception& e) {
+        qWarning() << "[MediaListModel] image request threw exception"
+                   << "| itemId=" << itemId
+                   << "| candidateIndex=" << request.candidateIndex
+                   << "| error=" << e.what();
         if (safeThis) {
             if (generation == safeThis->m_imageRequestGeneration) {
-                safeThis->m_loadingImages.remove(itemId);
+                if (safeThis->isImageRequestCurrent(itemId, request)) {
+                    safeThis->retryNextImageCandidate(itemId, request,
+                                                      generation);
+                }
+                safeThis->m_activeImageFetches =
+                    qMax(0, safeThis->m_activeImageFetches - 1);
+            }
+            safeThis->scheduleImageFetches();
+        }
+    } catch (...) {
+        qWarning() << "[MediaListModel] image request threw unknown exception"
+                   << "| itemId=" << itemId
+                   << "| candidateIndex=" << request.candidateIndex;
+        if (safeThis) {
+            if (generation == safeThis->m_imageRequestGeneration) {
+                if (safeThis->isImageRequestCurrent(itemId, request)) {
+                    safeThis->retryNextImageCandidate(itemId, request,
+                                                      generation);
+                }
                 safeThis->m_activeImageFetches =
                     qMax(0, safeThis->m_activeImageFetches - 1);
             }
             safeThis->scheduleImageFetches();
         }
     }
+}
+
+void MediaListModel::retryNextImageCandidate(const QString& itemId,
+                                             PendingImageRequest request,
+                                             int generation)
+{
+    if (generation != m_imageRequestGeneration ||
+        !isImageRequestCurrent(itemId, request)) {
+        return;
+    }
+
+    const int previousIndex = request.candidateIndex;
+    ++request.candidateIndex;
+    if (request.candidateIndex >= request.candidates.size()) {
+        
+        
+        
+        
+        m_loadingImages.remove(itemId);
+        m_failedImageItems.insert(itemId);
+        qWarning() << "[MediaListModel] all image candidates exhausted"
+                   << "| itemId=" << itemId
+                   << "| candidateCount=" << request.candidates.size()
+                   << "| retrySuppressedUntilRefresh=" << true;
+        return;
+    }
+
+    const ImageCandidate& next = request.candidates.at(request.candidateIndex);
+    qWarning() << "[MediaListModel] retrying fallback image candidate"
+               << "| itemId=" << itemId
+               << "| failedCandidateIndex=" << previousIndex
+               << "| nextCandidateIndex=" << request.candidateIndex
+               << "| nextTargetImageId=" << next.targetImageId
+               << "| nextImageType=" << next.imageType
+               << "| nextHasTag=" << !next.imageTag.isEmpty();
+    enqueueImageRetry(itemId, request);
+}
+
+bool MediaListModel::isImageRequestCurrent(
+    const QString& itemId, const PendingImageRequest& request) const
+{
+    for (const MediaItem& item : m_items) {
+        if (item.id == itemId) {
+            return buildImageIdentity(item) == request.imageIdentity;
+        }
+    }
+    return false;
+}
+
+void MediaListModel::invalidateItemImageRequest(const QString& itemId)
+{
+    m_imageCache.remove(itemId);
+    m_loadingImages.remove(itemId);
+    m_failedImageItems.remove(itemId);
+    m_pendingImageRequests.remove(itemId);
+    m_pendingImageOrder.removeAll(itemId);
+    m_pendingImageNotifyIds.remove(itemId);
 }
 
 void MediaListModel::queueImageDataChanged(const QString& itemId)

--- a/src/qEmbyApp/views/media/medialistmodel.h
+++ b/src/qEmbyApp/views/media/medialistmodel.h
@@ -22,15 +22,19 @@ public:
     };
 
     explicit MediaListModel(int imageMaxWidth, QEmbyCore* core, QObject *parent = nullptr);
+    ~MediaListModel() override;
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
     void setItems(const QList<MediaItem>& items);
     MediaItem getItem(const QModelIndex& index) const;
+    QList<MediaItem> items() const { return m_items; }
 
     
-    void setPreferThumb(bool prefer) { m_preferThumb = prefer; }
+    void setPreferThumb(bool prefer);
+    void setImageMaxWidth(int maxWidth);
+    void setForceNetworkImages(bool forceNetwork);
 
     
     
@@ -42,53 +46,66 @@ public:
     
     void removeItem(const QString& itemId);
     void setPriorityRows(const QList<int>& rows);
+    void suspendImageRequests();
+    void resumeImageRequests();
 
     
-    void clearImageCache()
-    {
-        ++m_imageRequestGeneration;
-        m_imageCache.clear();
-        m_loadingImages.clear();
-        m_pendingImageRequests.clear();
-        m_pendingImageOrder.clear();
-        m_priorityImageIds.clear();
-        m_pendingImageNotifyIds.clear();
-        m_activeImageFetches = 0;
-        if (m_imageNotifyTimer) {
-            m_imageNotifyTimer->stop();
-        }
-    }
+    void clearImageCache();
+
+    
+    
+    
+    
+    
+    void clearFailedImageItems();
 
 private:
-    struct PendingImageRequest {
+    struct ImageCandidate {
         QString targetImageId;
         QString imageType;
         QString imageTag;
         int maxWidth = 0;
     };
 
+    struct PendingImageRequest {
+        QList<ImageCandidate> candidates;
+        int candidateIndex = 0;
+        int transientRetryCount = 0;
+        bool highPriority = false;
+        QString imageIdentity;
+    };
+
     QString buildTooltipText(const MediaItem &item) const;
-    void ensureImageRequested(const MediaItem& item);
+    void ensureImageRequested(const MediaItem& item,
+                              bool highPriority = false);
     void enqueueImageFetch(const QString& itemId,
+                           const PendingImageRequest& request);
+    void enqueueImageRetry(const QString& itemId,
                            const PendingImageRequest& request);
     void scheduleImageFetches();
     QString takeNextPendingImageId();
     void queueImageDataChanged(const QString& itemId);
     void flushPendingImageDataChanges();
+    void retryNextImageCandidate(const QString& itemId,
+                                 PendingImageRequest request, int generation);
+    bool isImageRequestCurrent(const QString& itemId,
+                               const PendingImageRequest& request) const;
+    void invalidateItemImageRequest(const QString& itemId);
 
     
     static QCoro::Task<void> executeImageFetch(
         QPointer<MediaListModel> safeThis, QString itemId,
-        QString targetImageId, QString imgType, QString imgTag, int maxWidth,
-        int generation, QEmbyCore* core);
+        PendingImageRequest request, int generation, QEmbyCore* core);
 
     bool m_preferThumb = false;
+    bool m_forceNetworkImages = false;
     int m_imageMaxWidth;
     QEmbyCore* m_core;
     QList<MediaItem> m_items;
 
     mutable QHash<QString, QPixmap> m_imageCache;
     mutable QSet<QString> m_loadingImages;
+    mutable QSet<QString> m_failedImageItems;
     QHash<QString, PendingImageRequest> m_pendingImageRequests;
     QStringList m_pendingImageOrder;
     QStringList m_priorityImageIds;
@@ -96,6 +113,8 @@ private:
     QTimer* m_imageNotifyTimer = nullptr;
     int m_activeImageFetches = 0;
     int m_imageRequestGeneration = 0;
+    QObject* m_imageRequestContext = nullptr;
+    bool m_imageRequestsSuspended = false;
 };
 
 #endif 

--- a/src/qEmbyApp/views/media/playerview.cpp
+++ b/src/qEmbyApp/views/media/playerview.cpp
@@ -1063,39 +1063,68 @@ void PlayerView::pausePlayback()
 
 
 
+
 void PlayerView::resumePlayback()
 {
-    if (!m_mpvWidget || m_currentMediaId.isEmpty())
+    if (!m_mpvWidget || m_currentMediaId.isEmpty() || m_isViewTearingDown || m_hasReportedStop)
         return;
 
-    
-    QString newStreamUrl = m_originalStreamUrl;
+    qInfo().noquote() << "[PlayerView] Resume after window restore"
+                      << "| mediaId:" << m_currentMediaId
+                      << "| position:" << m_currentPosition;
+
+    updateOverlayLayout();
+    m_mpvWidget->update();
+    showControls();
+    m_mpvWidget->resumeAfterContextRestore();
+}
+
+void PlayerView::restoreAfterWindowShow(bool shouldResumePlaying)
+{
+    if (!m_mpvWidget || m_currentMediaId.isEmpty() || m_isViewTearingDown || m_hasReportedStop)
+        return;
+
+    const double restorePosition = qMax(0.0, m_currentPosition);
+    QString streamUrl = m_originalStreamUrl;
     if (m_currentSourceInfoVar.isValid())
     {
         MediaSourceInfo sourceInfo;
         if (m_currentSourceInfoVar.canConvert<PlayerLaunchContext>())
-        {
             sourceInfo = m_currentSourceInfoVar.value<PlayerLaunchContext>().selectedSource;
-        }
         else if (m_currentSourceInfoVar.canConvert<MediaSourceInfo>())
-        {
             sourceInfo = m_currentSourceInfoVar.value<MediaSourceInfo>();
-        }
 
-        QString directUrl = m_core->mediaService()->getStreamUrl(m_currentMediaId, sourceInfo);
-        if (!directUrl.isEmpty())
-        {
-            newStreamUrl = directUrl;
-        }
+        const QString refreshedUrl = m_core->mediaService()->getStreamUrl(m_currentMediaId, sourceInfo);
+        if (!refreshedUrl.isEmpty())
+            streamUrl = refreshedUrl;
     }
 
-    
-    m_pendingSeekSeconds = m_currentPosition;
+    if (streamUrl.isEmpty())
+    {
+        qWarning().noquote() << "[PlayerView] Cannot restore playback: stream URL is empty"
+                             << "| mediaId:" << m_currentMediaId;
+        return;
+    }
+
+    qInfo().noquote() << "[PlayerView] Restore playback after window show"
+                      << "| mediaId:" << m_currentMediaId
+                      << "| position:" << restorePosition
+                      << "| shouldPlay:" << shouldResumePlaying;
+
+    m_pendingSeekSeconds = restorePosition;
+    m_windowRestorePending = true;
+    m_windowRestoreShouldPlay = shouldResumePlaying;
     m_isBuffering = true;
     updateLoadingState();
+    updateOverlayLayout();
+    showControls();
+
+    if (m_danmakuController) {
+        m_danmakuController->prepareForMediaReload();
+    }
+
     const QString activeServerId = m_core->serverManager()->activeProfile().id;
-    m_mpvWidget->loadMedia(newStreamUrl, activeServerId);
-    m_mpvWidget->play(); 
+    m_mpvWidget->loadMedia(streamUrl, activeServerId);
 }
 
 
@@ -1135,6 +1164,22 @@ void PlayerView::setupUi()
     connect(m_mpvWidget->controller(), &MpvController::fileLoaded, this,
             [this]()
             {
+                if (m_windowRestorePending)
+                {
+                    const double restorePosition = m_pendingSeekSeconds;
+                    m_windowRestorePending = false;
+                    m_pendingSeekSeconds = 0.0;
+                    if (restorePosition > 0.0)
+                        m_mpvWidget->seek(restorePosition);
+                    if (m_windowRestoreShouldPlay)
+                        m_mpvWidget->play();
+                    else
+                        m_mpvWidget->pause();
+
+                    qInfo().noquote() << "[PlayerView] Window restore state applied"
+                                      << "| position:" << restorePosition
+                                      << "| playing:" << m_windowRestoreShouldPlay;
+                }
                 m_isBuffering = false;
                 updateLoadingState();
                 applySubtitleStyleSettings();
@@ -1250,11 +1295,11 @@ void PlayerView::setupUi()
             });
 
     
+    
+    
     connect(m_closeBtn, &QPushButton::clicked, this,
             [this]()
             {
-                beginViewTeardown();
-                stopAndReport();
                 window()->close();
             });
 #endif
@@ -1656,6 +1701,10 @@ QString PlayerView::formatDanmakuProviderLabel(QString provider) const
     if (provider == QLatin1String("dandanplay"))
     {
         return tr("DandanPlay");
+    }
+    if (provider == QLatin1String("danmu_api"))
+    {
+        return tr("LogVar / danmu_api");
     }
     return provider.isEmpty() ? tr("Unknown Source") : provider;
 }
@@ -2152,15 +2201,21 @@ QCoro::Task<void> PlayerView::switchFromMediaSwitcher(QString mediaId, QString t
         {
             int sourceIdx = MediaSourcePreferenceUtils::resolvePreferredMediaSourceIndex(
                 detail.mediaSources,
-                ConfigStore::instance()->get<QString>(ConfigKeys::PlayerPreferredVersion).trimmed());
+                ConfigStore::instance()->get<QString>(ConfigKeys::PlayerPreferredVersion).trimmed(),
+                MediaSourcePreferenceUtils::rememberedMediaSourceId(
+                    m_core->serverManager() ? m_core->serverManager()->activeProfile().id : QString(),
+                    detail.id));
             if (sourceIdx < 0 || sourceIdx >= detail.mediaSources.size())
             {
                 sourceIdx = 0;
             }
 
             selectedSource = detail.mediaSources.at(sourceIdx);
-            PlayerPreferenceUtils::applyPreferredStreamRules(
-                selectedSource, ConfigStore::instance()->get<QString>(ConfigKeys::PlayerAudioLang, "auto"),
+            PlayerPreferenceUtils::applyRememberedOrPreferredStreamRules(
+                selectedSource,
+                m_core->serverManager() ? m_core->serverManager()->activeProfile().id : QString(),
+                detail.id,
+                ConfigStore::instance()->get<QString>(ConfigKeys::PlayerAudioLang, "auto"),
                 ConfigStore::instance()->get<QString>(ConfigKeys::PlayerSubLang, "auto"));
             mediaSourceId = selectedSource.id;
         }
@@ -4626,6 +4681,62 @@ QCoro::Task<void> PlayerView::executeFetchLogo(QPointer<PlayerView> safeThis, QE
     }
 }
 
+QCoro::Task<void> PlayerView::resolveDanmakuPlaybackContext(
+    QPointer<PlayerView> safeThis,
+    QPointer<QEmbyCore> core,
+    QString mediaId,
+    QString fallbackTitle,
+    MediaSourceInfo sourceInfo)
+{
+    if (!safeThis || !core || !core->mediaService() || mediaId.isEmpty()) {
+        co_return;
+    }
+
+    try {
+        MediaItem detail = co_await core->mediaService()->getItemDetail(mediaId);
+        if (!safeThis || safeThis->m_currentMediaId != mediaId ||
+            !safeThis->m_danmakuController) {
+            co_return;
+        }
+        if (detail.id.isEmpty()) {
+            detail.id = mediaId;
+        }
+        if (detail.name.isEmpty()) {
+            detail.name = fallbackTitle;
+        }
+        if (sourceInfo.id.isEmpty() && !detail.mediaSources.isEmpty()) {
+            const auto selectedIt = std::find_if(
+                detail.mediaSources.cbegin(), detail.mediaSources.cend(),
+                [safeThis](const MediaSourceInfo &candidate) {
+                    return safeThis &&
+                           candidate.id == safeThis->m_currentMediaSourceId;
+                });
+            sourceInfo = selectedIt == detail.mediaSources.cend()
+                             ? detail.mediaSources.first()
+                             : *selectedIt;
+        }
+
+        PlayerLaunchContext context;
+        context.mediaItem = detail;
+        context.selectedSource = sourceInfo;
+        qDebug().noquote()
+            << "[Danmaku][PlayerView] Resolved complete playback context"
+            << "| mediaId:" << detail.id
+            << "| sourceId:" << sourceInfo.id
+            << "| itemType:" << detail.type
+            << "| title:" << detail.name
+            << "| providerIds:" << detail.providerIds.keys().join(QStringLiteral(","));
+        safeThis->m_danmakuController->setPlaybackContext(context);
+    } catch (const std::exception &e) {
+        if (safeThis && safeThis->m_currentMediaId == mediaId) {
+            qWarning().noquote()
+                << "[Danmaku][PlayerView] Failed to resolve complete playback context"
+                << "| mediaId:" << mediaId
+                << "| error:" << e.what();
+        }
+    }
+}
+
 void PlayerView::playMedia(const QString &mediaId, const QString &title, const QString &streamUrl,
                            long long startPositionTicks, const QVariant &sourceInfoVar)
 {
@@ -4841,13 +4952,11 @@ void PlayerView::playMedia(const QString &mediaId, const QString &title, const Q
     const QString activeServerId = m_core->serverManager()->activeProfile().id;
     m_mpvWidget->loadMedia(actualStreamUrl, activeServerId);
 
-    if (!resolvedItem.id.isEmpty() || !resolvedSourceInfo.id.isEmpty())
+    const bool hasCompleteDanmakuContext =
+        !resolvedItem.id.isEmpty() && !resolvedItem.name.trimmed().isEmpty() &&
+        !resolvedItem.type.trimmed().isEmpty();
+    if (hasCompleteDanmakuContext)
     {
-        if (resolvedItem.id.isEmpty())
-        {
-            resolvedItem.id = mediaId;
-            resolvedItem.name = title;
-        }
         PlayerLaunchContext danmakuContext;
         danmakuContext.mediaItem = resolvedItem;
         danmakuContext.selectedSource = resolvedSourceInfo;
@@ -4857,10 +4966,21 @@ void PlayerView::playMedia(const QString &mediaId, const QString &title, const Q
                            << "| title:" << danmakuContext.mediaItem.name;
         m_danmakuController->setPlaybackContext(danmakuContext);
     }
+    else if (!mediaId.isEmpty())
+    {
+        m_danmakuController->clearPlaybackContext();
+        qDebug().noquote()
+            << "[Danmaku][PlayerView] Playback metadata incomplete, resolving before danmaku search"
+            << "| mediaId:" << mediaId
+            << "| sourceId:" << resolvedSourceInfo.id
+            << "| sourceInfoValid:" << sourceInfoVar.isValid();
+        QCoro::connect(resolveDanmakuPlaybackContext(
+                           QPointer<PlayerView>(this), QPointer<QEmbyCore>(m_core),
+                           mediaId, title, resolvedSourceInfo),
+                       this, []() {});
+    }
     else
     {
-        qDebug().noquote() << "[Danmaku][PlayerView] No playback context available for danmaku"
-                           << "| mediaId:" << mediaId << "| sourceInfoValid:" << sourceInfoVar.isValid();
         m_danmakuController->clearPlaybackContext();
     }
 
@@ -4887,6 +5007,7 @@ void PlayerView::playMedia(const QString &mediaId, const QString &title, const Q
         m_targetSubStreamIndex = -2;
         bool hasExternalDefault = false;
         bool foundDefaultAudio = false;
+        PlayerPreferenceUtils::RememberedStreamSelection remembered;
 
         for (const auto &stream : sourceInfo.mediaStreams)
         {
@@ -4908,11 +5029,28 @@ void PlayerView::playMedia(const QString &mediaId, const QString &title, const Q
             }
         }
 
+        if (m_core && m_core->serverManager())
+        {
+            remembered =
+                PlayerPreferenceUtils::validatedRememberedStreamSelection(
+                    m_core->serverManager()->activeProfile().id, mediaId,
+                    sourceInfo);
+            if (remembered.audioIndex.has_value())
+            {
+                m_targetAudioStreamIndex = *remembered.audioIndex;
+            }
+            if (remembered.subtitleIndex.has_value())
+            {
+                
+                m_targetSubStreamIndex = *remembered.subtitleIndex;
+            }
+        }
+
         
         
 
         
-        if (hasExternalDefault)
+        if (hasExternalDefault && !remembered.subtitleIndex.has_value())
         {
             m_targetSubStreamIndex = -2;
         }
@@ -4993,7 +5131,11 @@ void PlayerView::playMedia(const QString &mediaId, const QString &title, const Q
 
                 
                 
-                QString flag = stream.isDefault ? "select" : "auto";
+                const bool selectExternal =
+                    remembered.subtitleIndex.has_value()
+                        ? *remembered.subtitleIndex == stream.index
+                        : stream.isDefault;
+                QString flag = selectExternal ? "select" : "auto";
 
                 
                 QVariantMap subMap;
@@ -5304,7 +5446,9 @@ void PlayerView::onDurationChanged(double duration)
         applyPersistedExternalSubtitleIfAny();
     }
 
-    if (m_pendingSeekSeconds > 0 && duration > 0)
+    
+    
+    if (!m_windowRestorePending && m_pendingSeekSeconds > 0 && duration > 0)
     {
         m_mpvWidget->seek(m_pendingSeekSeconds);
         m_pendingSeekSeconds = 0.0;

--- a/src/qEmbyApp/views/media/playerview.h
+++ b/src/qEmbyApp/views/media/playerview.h
@@ -7,6 +7,7 @@
 #include "../../components/loadingoverlay.h" 
 #include "../../components/playerdanmakucontroller.h"
 #include <models/media/mediaitem.h>
+#include <models/media/playbackinfo.h>
 #include <services/introdb/introdbservice.h>
 
 #include <QVariant>
@@ -49,6 +50,7 @@ public:
     bool isMediaPlaying() const;
     void pausePlayback();
     void resumePlayback();
+    void restoreAfterWindowShow(bool shouldResumePlaying);
     void stopAndReport(); 
 
 signals:
@@ -183,6 +185,12 @@ private:
 
     
     static QCoro::Task<void> executeFetchLogo(QPointer<PlayerView> safeThis, QEmbyCore* core, QString mediaId);
+    static QCoro::Task<void> resolveDanmakuPlaybackContext(
+        QPointer<PlayerView> safeThis,
+        QPointer<QEmbyCore> core,
+        QString mediaId,
+        QString fallbackTitle,
+        MediaSourceInfo sourceInfo);
 
     MpvWidget *m_mpvWidget;
     NativeDanmakuOverlay *m_nativeDanmakuOverlay = nullptr;
@@ -281,6 +289,8 @@ private:
     double m_currentPosition;
     double m_totalDuration = 0.0; 
     double m_pendingSeekSeconds = 0.0;
+    bool m_windowRestorePending = false;
+    bool m_windowRestoreShouldPlay = false;
     double m_osdSeekPreviewPosition = -1.0;
     
     double m_currentSpeed = 1.0;

--- a/src/qEmbyApp/views/media/seasonview.cpp
+++ b/src/qEmbyApp/views/media/seasonview.cpp
@@ -26,6 +26,7 @@
 #include <config/config_keys.h>
 #include <config/configstore.h>
 #include <qembycore.h>
+#include <services/manager/servermanager.h>
 #include <services/media/mediaservice.h>
 
 SeasonView::SeasonView(QEmbyCore *core, QWidget *parent) : BaseView(core, parent)
@@ -105,6 +106,12 @@ void SeasonView::setupUi()
     m_favBtn->setFixedSize(36, 36);
     m_favBtn->setCursor(Qt::PointingHandCursor);
 
+    m_playedBtn = new QPushButton(m_contentWidget);
+    m_playedBtn->setObjectName("detail-played-btn");
+    m_playedBtn->setIconSize(QSize(20, 20));
+    m_playedBtn->setFixedSize(36, 36);
+    m_playedBtn->setCursor(Qt::PointingHandCursor);
+
     
     m_extPlayerBtn = new SplitPlayerButton(m_contentWidget);
     m_extPlayerBtn->setObjectName("detail-ext-player-btn");
@@ -114,6 +121,7 @@ void SeasonView::setupUi()
     actionsLayout->addWidget(m_playBtn);
     actionsLayout->addWidget(m_extPlayerBtn);
     actionsLayout->addWidget(m_favBtn);
+    actionsLayout->addWidget(m_playedBtn);
 
     textLayout->addWidget(m_seriesTitleLabel);
     textLayout->addWidget(m_titleLabel);
@@ -230,6 +238,25 @@ void SeasonView::setupUi()
                 }
             });
 
+    connect(m_playedBtn, &QPushButton::clicked, this,
+            [this]()
+            {
+                if (m_currentSeasonItem.id.isEmpty())
+                    return;
+
+                if (m_currentSeasonItem.userData.played)
+                    handleMarkUnplayedRequested(m_currentSeasonItem);
+                else
+                    handleMarkPlayedRequested(m_currentSeasonItem);
+            });
+
+    connect(ThemeManager::instance(), &ThemeManager::themeChanged, this,
+            [this]()
+            {
+                updateFavBtnState();
+                updatePlayedBtnState();
+            });
+
     connect(m_sortButton, &ModernSortButton::sortChanged, this, [this]() { onFilterChanged(); });
 
     connect(m_mediaGrid, &MediaGridWidget::itemClicked, this,
@@ -254,6 +281,47 @@ void SeasonView::updateFavBtnState()
     m_favBtn->style()->polish(m_favBtn);
 }
 
+void SeasonView::updatePlayedBtnState()
+{
+    const bool played = m_currentSeasonItem.userData.played;
+    m_playedBtn->setProperty("played", played);
+    m_playedBtn->setToolTip(played ? tr("Mark as Unplayed") : tr("Mark as Played"));
+
+    const QString themeDir = ThemeManager::instance()->isDarkMode() ? "dark" : "light";
+    m_playedBtn->setIcon(played ? QIcon(":/svg/dark/played-check.svg")
+                                : QIcon(QString(":/svg/%1/unplayed-check.svg").arg(themeDir)));
+
+    m_playedBtn->style()->unpolish(m_playedBtn);
+    m_playedBtn->style()->polish(m_playedBtn);
+}
+
+void SeasonView::syncSeasonPlayedStateFromEpisodes()
+{
+    if (m_currentEpisodes.isEmpty() || m_currentSeasonItem.id.isEmpty())
+        return;
+
+    int total = 0;
+    int played = 0;
+    for (const MediaItem &episode : m_currentEpisodes)
+    {
+        if (episode.type != "Episode")
+            continue;
+
+        ++total;
+        if (episode.userData.played)
+            ++played;
+    }
+
+    const bool allPlayed = total > 0 && played == total;
+    if (m_currentSeasonItem.userData.played != allPlayed)
+    {
+        m_currentSeasonItem.userData.played = allPlayed;
+        m_currentSeasonItem.userData.playbackPositionTicks = 0;
+        m_currentSeasonItem.userData.playedPercentage = allPlayed ? 100.0 : 0.0;
+        updatePlayedBtnState();
+    }
+}
+
 QCoro::Task<void> SeasonView::loadSeason(QString seriesId, QString seasonId, QString seasonName)
 {
     QPointer<SeasonView> guard(this);
@@ -261,6 +329,8 @@ QCoro::Task<void> SeasonView::loadSeason(QString seriesId, QString seasonId, QSt
     m_currentSeasonId = seasonId;
     m_currentSeasonItem = MediaItem();
     m_currentSeasonItem.id = seasonId; 
+    m_currentSeasonItem.name = seasonName;
+    m_currentSeasonItem.type = "Season";
 
     m_seriesTitleLabel->setText(tr("Loading..."));
     m_titleLabel->setText(seasonName);
@@ -271,6 +341,7 @@ QCoro::Task<void> SeasonView::loadSeason(QString seriesId, QString seasonId, QSt
 
     m_isFavorite = false;
     updateFavBtnState();
+    updatePlayedBtnState();
 
     m_contentWidget->setBackdrop(QPixmap());
     m_posterLabel->setPixmap(QPixmap());
@@ -318,6 +389,7 @@ QCoro::Task<void> SeasonView::loadSeason(QString seriesId, QString seasonId, QSt
                 m_currentSeasonItem = detail;
                 m_isFavorite = detail.isFavorite();
                 updateFavBtnState();
+                updatePlayedBtnState();
 
                 
                 if (!detail.overview.isEmpty())
@@ -497,6 +569,7 @@ QCoro::Task<void> SeasonView::onFilterChanged(bool preserveScroll)
             co_return;
 
         m_currentEpisodes = episodes; 
+        syncSeasonPlayedStateFromEpisodes();
         m_statsLabel->setText(tr("%1 Episodes").arg(episodes.size()));
         m_mediaGrid->setItems(episodes);
 
@@ -542,6 +615,20 @@ void SeasonView::onMediaItemUpdated(const MediaItem &item)
         m_currentSeasonItem = item;
         m_isFavorite = item.isFavorite();
         updateFavBtnState();
+        updatePlayedBtnState();
+
+        if (item.type == "Season")
+        {
+            for (MediaItem &episode : m_currentEpisodes)
+            {
+                episode.userData.played = item.userData.played;
+                episode.userData.playbackPositionTicks = 0;
+                episode.userData.playedPercentage = item.userData.played ? 100.0 : 0.0;
+                episode.userData.lastPlayedDate = item.userData.lastPlayedDate;
+                if (m_mediaGrid)
+                    m_mediaGrid->updateItem(episode);
+            }
+        }
     }
     if (m_mediaGrid)
     {
@@ -554,6 +641,7 @@ void SeasonView::onMediaItemUpdated(const MediaItem &item)
         if (ep.id == item.id)
         {
             ep = item;
+            syncSeasonPlayedStateFromEpisodes();
             break;
         }
     }
@@ -661,14 +749,19 @@ QCoro::Task<void> SeasonView::executeExternalPlay(MediaItem targetItem, QString 
 
         int sourceIdx = MediaSourcePreferenceUtils::resolvePreferredMediaSourceIndex(
             actualItem.mediaSources,
-            ConfigStore::instance()->get<QString>(ConfigKeys::PlayerPreferredVersion).trimmed());
+            ConfigStore::instance()->get<QString>(ConfigKeys::PlayerPreferredVersion).trimmed(),
+            MediaSourcePreferenceUtils::rememberedMediaSourceId(
+                m_core->serverManager() ? m_core->serverManager()->activeProfile().id : QString(),
+                actualItem.id));
 
         if (sourceIdx >= actualItem.mediaSources.size())
             sourceIdx = 0;
         MediaSourceInfo modifiedSource = actualItem.mediaSources[sourceIdx];
 
-        PlayerPreferenceUtils::applyPreferredStreamRules(
+        PlayerPreferenceUtils::applyRememberedOrPreferredStreamRules(
             modifiedSource,
+            m_core->serverManager() ? m_core->serverManager()->activeProfile().id : QString(),
+            actualItem.id,
             ConfigStore::instance()->get<QString>(ConfigKeys::PlayerAudioLang, "auto"),
             ConfigStore::instance()->get<QString>(ConfigKeys::PlayerSubLang, "auto"));
 
@@ -706,14 +799,19 @@ QCoro::Task<void> SeasonView::executeInternalPlay(MediaItem targetItem)
 
         int sourceIdx = MediaSourcePreferenceUtils::resolvePreferredMediaSourceIndex(
             actualItem.mediaSources,
-            ConfigStore::instance()->get<QString>(ConfigKeys::PlayerPreferredVersion).trimmed());
+            ConfigStore::instance()->get<QString>(ConfigKeys::PlayerPreferredVersion).trimmed(),
+            MediaSourcePreferenceUtils::rememberedMediaSourceId(
+                m_core->serverManager() ? m_core->serverManager()->activeProfile().id : QString(),
+                actualItem.id));
 
         if (sourceIdx >= actualItem.mediaSources.size())
             sourceIdx = 0;
         MediaSourceInfo modifiedSource = actualItem.mediaSources[sourceIdx];
 
-        PlayerPreferenceUtils::applyPreferredStreamRules(
+        PlayerPreferenceUtils::applyRememberedOrPreferredStreamRules(
             modifiedSource,
+            m_core->serverManager() ? m_core->serverManager()->activeProfile().id : QString(),
+            actualItem.id,
             ConfigStore::instance()->get<QString>(ConfigKeys::PlayerAudioLang, "auto"),
             ConfigStore::instance()->get<QString>(ConfigKeys::PlayerSubLang, "auto"));
 

--- a/src/qEmbyApp/views/media/seasonview.h
+++ b/src/qEmbyApp/views/media/seasonview.h
@@ -30,6 +30,8 @@ private slots:
 private:
   void setupUi();
   void updateFavBtnState();
+  void updatePlayedBtnState();
+  void syncSeasonPlayedStateFromEpisodes();
   void refreshExtPlayerButton();
   QCoro::Task<void> loadImages(const QString &fallbackSeriesBackdropTag);
   QCoro::Task<void> updatePlayButtonFromNextUp();
@@ -53,6 +55,7 @@ private:
 
   QPushButton *m_playBtn = nullptr;
   QPushButton *m_favBtn = nullptr;
+  QPushButton *m_playedBtn = nullptr;
   ModernSortButton *m_sortButton = nullptr;
   QLabel *m_statsLabel = nullptr;
   MediaGridWidget *m_mediaGrid = nullptr;

--- a/src/qEmbyApp/views/settings/pageabout.cpp
+++ b/src/qEmbyApp/views/settings/pageabout.cpp
@@ -1,17 +1,27 @@
 #include "pageabout.h"
 #include "../../components/flowlayout.h"
 #include "../../components/licensesdialog.h"
+#include "../../components/modernmessagebox.h"
+#include "../../components/moderntoast.h"
+#include "../../components/updatedialog.h"
+#include "../../components/updateprogressdialog.h"
+#include "../../managers/updatemanager.h"
 #include <QCoreApplication>
-#include <QGuiApplication>
 #include <QDebug>
+#include <QEvent>
 #include <QFrame>
+#include <QGuiApplication>
 #include <QHBoxLayout>
+#include <QMouseEvent>
+#include <QSizePolicy>
 #include <QVBoxLayout>
 #include <QVector>
 
-namespace {
+namespace
+{
 
-struct ThanksEntry {
+struct ThanksEntry
+{
     QString name;
     QString contribution;
     QString initials;
@@ -19,33 +29,80 @@ struct ThanksEntry {
 
 } 
 
-PageAbout::PageAbout(QEmbyCore* core, QWidget *parent)
-    : SettingsPageBase(core, tr("About"), parent)
+PageAbout::PageAbout(QEmbyCore *core, QWidget *parent) : SettingsPageBase(core, tr("About"), parent)
 {
     m_mainLayout->addStretch(1);
 
     m_logoLabel = new QLabel(this);
     QPixmap logoPixmap(":/svg/qemby_logo.svg");
-    if (!logoPixmap.isNull()) {
+    if (!logoPixmap.isNull())
+    {
         m_logoLabel->setPixmap(logoPixmap.scaled(80, 80, Qt::KeepAspectRatio, Qt::SmoothTransformation));
     }
     m_logoLabel->setAlignment(Qt::AlignCenter);
     m_logoLabel->setObjectName("AboutLogoLabel");
-    m_mainLayout->addWidget(m_logoLabel);
+    m_logoLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    m_logoLabel->setCursor(Qt::PointingHandCursor);
+    m_logoLabel->setToolTip(tr("Check for Updates"));
+    m_logoLabel->installEventFilter(this);
+    m_mainLayout->addWidget(m_logoLabel, 0, Qt::AlignHCenter);
 
     m_appNameLabel = new QLabel(tr("qEmby"), this);
     m_appNameLabel->setAlignment(Qt::AlignCenter);
     m_appNameLabel->setObjectName("AboutAppNameLabel");
-    m_mainLayout->addWidget(m_appNameLabel);
+    m_appNameLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
+    m_appNameLabel->setCursor(Qt::PointingHandCursor);
+    m_appNameLabel->setToolTip(tr("Check for Updates"));
+    m_appNameLabel->installEventFilter(this);
+    m_mainLayout->addWidget(m_appNameLabel, 0, Qt::AlignHCenter);
 
     QString versionStr = QCoreApplication::applicationVersion();
-    if (versionStr.isEmpty()) {
-        versionStr = "0.0.1";
+    if (versionStr.isEmpty())
+    {
+        versionStr = "0.0.6";
     }
     m_versionLabel = new QLabel(tr("Version %1").arg(versionStr), this);
     m_versionLabel->setAlignment(Qt::AlignCenter);
     m_versionLabel->setObjectName("AboutVersionLabel");
-    m_mainLayout->addWidget(m_versionLabel);
+    m_versionLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
+    m_versionLabel->setCursor(Qt::PointingHandCursor);
+    m_versionLabel->setToolTip(tr("Check for Updates"));
+    m_versionLabel->installEventFilter(this);
+    m_mainLayout->addWidget(m_versionLabel, 0, Qt::AlignHCenter);
+
+    auto *updateManager = UpdateManager::instance();
+    connect(updateManager, &UpdateManager::noUpdateAvailable, this,
+            [](UpdateManager::CheckMode mode)
+            {
+                if (mode == UpdateManager::CheckMode::Manual)
+                {
+                    ModernToast::showMessage(PageAbout::tr("You are using the latest version"), 2200);
+                }
+            });
+    connect(updateManager, &UpdateManager::checkFailed, this,
+            [this](const QString &error, UpdateManager::CheckMode mode)
+            {
+                if (mode == UpdateManager::CheckMode::Manual)
+                {
+                    ModernMessageBox::warning(window(), tr("Update Check Failed"), error);
+                }
+            });
+    connect(updateManager, &UpdateManager::updateAvailable, this,
+            [this](const UpdateInfo &info, UpdateManager::CheckMode mode)
+            {
+                if (mode != UpdateManager::CheckMode::Manual)
+                {
+                    return;
+                }
+
+                UpdateDialog dialog(info, UpdateDialog::Mode::Manual, window());
+                dialog.exec();
+                if (dialog.decision() != UpdateDialog::Decision::Update)
+                {
+                    return;
+                }
+                UpdateProgressDialog::startUpdate(info, window());
+            });
 
     m_authorLabel = new QLabel(tr("© 2026 AlanHJ. All rights reserved."), this);
     m_authorLabel->setAlignment(Qt::AlignCenter);
@@ -53,12 +110,10 @@ PageAbout::PageAbout(QEmbyCore* core, QWidget *parent)
     m_mainLayout->addWidget(m_authorLabel);
 
     m_linkLabel = new QLabel(this);
-    m_linkLabel->setText(
-        QString("<a href=\"https://github.com/AlanHJ/qEmby\">%1</a> &nbsp;|&nbsp; "
-                "<a href=\"https://github.com/AlanHJ/qEmby/issues\">%2</a>")
-            .arg(tr("GitHub Repository"))
-            .arg(tr("Report an Issue"))
-        );
+    m_linkLabel->setText(QString("<a href=\"https://github.com/AlanHJ/qEmby\">%1</a> &nbsp;|&nbsp; "
+                                 "<a href=\"https://github.com/AlanHJ/qEmby/issues\">%2</a>")
+                             .arg(tr("GitHub Repository"))
+                             .arg(tr("Report an Issue")));
     m_linkLabel->setOpenExternalLinks(true);
     m_linkLabel->setAlignment(Qt::AlignCenter);
     m_linkLabel->setObjectName("AboutLinkLabel");
@@ -70,9 +125,9 @@ PageAbout::PageAbout(QEmbyCore* core, QWidget *parent)
     line->setObjectName("AboutSeparatorLine");
     m_mainLayout->addWidget(line);
 
-    m_licenseLabel = new QLabel(
-        tr("This project is open-source software built with Qt 6 and modern C++.\n"
-           "Special thanks to the Emby and Jellyfin communities for their fantastic APIs."), this);
+    m_licenseLabel = new QLabel(tr("This project is open-source software built with Qt 6 and modern C++.\n"
+                                   "Special thanks to the Emby and Jellyfin communities for their fantastic APIs."),
+                                this);
     m_licenseLabel->setAlignment(Qt::AlignCenter);
     m_licenseLabel->setWordWrap(true);
     m_licenseLabel->setObjectName("AboutIntroLabel");
@@ -90,6 +145,34 @@ PageAbout::PageAbout(QEmbyCore* core, QWidget *parent)
     m_mainLayout->addWidget(m_licenseBtn, 0, Qt::AlignHCenter);
 
     m_mainLayout->addStretch(2);
+}
+
+bool PageAbout::eventFilter(QObject *watched, QEvent *event)
+{
+    if (event->type() == QEvent::MouseButtonRelease &&
+        (watched == m_logoLabel || watched == m_appNameLabel ||
+         watched == m_versionLabel)) {
+        const auto *mouseEvent = static_cast<QMouseEvent *>(event);
+        const auto *label = qobject_cast<QLabel *>(watched);
+        if (mouseEvent->button() == Qt::LeftButton && label &&
+            label->rect().contains(mouseEvent->position().toPoint())) {
+            checkForUpdates();
+            return true;
+        }
+    }
+    return SettingsPageBase::eventFilter(watched, event);
+}
+
+void PageAbout::checkForUpdates()
+{
+    UpdateManager *manager = UpdateManager::instance();
+    if (manager->isChecking(UpdateManager::CheckMode::Manual))
+    {
+        ModernToast::showMessage(tr("Checking for updates…"), 1500);
+        return;
+    }
+    ModernToast::showMessage(tr("Checking for updates…"), 1200);
+    manager->checkForUpdates(UpdateManager::CheckMode::Manual);
 }
 
 QWidget *PageAbout::createAcknowledgementsPanel()
@@ -118,7 +201,8 @@ QWidget *PageAbout::createAcknowledgementsPanel()
     const QVector<ThanksEntry> thanksEntries = {
         {QStringLiteral("Arkoth79"), tr("French translation"), QStringLiteral("A")},
     };
-    for (const auto &entry : thanksEntries) {
+    for (const auto &entry : thanksEntries)
+    {
         auto *card = new QFrame(cardsWidget);
         card->setObjectName("AboutThanksCard");
         auto *cardLayout = new QHBoxLayout(card);

--- a/src/qEmbyApp/views/settings/pageabout.h
+++ b/src/qEmbyApp/views/settings/pageabout.h
@@ -13,9 +13,13 @@ public:
     explicit PageAbout(QEmbyCore* core, QWidget *parent = nullptr);
     ~PageAbout() override = default;
 
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
 private slots:
     
     void showLicensesDialog();
+    void checkForUpdates();
 
 private:
     QWidget *createAcknowledgementsPanel();

--- a/src/qEmbyApp/views/settings/pagegeneral.cpp
+++ b/src/qEmbyApp/views/settings/pagegeneral.cpp
@@ -45,6 +45,17 @@ PageGeneral::PageGeneral(QEmbyCore *core, QWidget *parent)
       tr("Minimize to system tray instead of exiting the application"),
       new ModernSwitch(this), ConfigKeys::CloseToTray, this));
 
+  m_mainLayout->addWidget(new SettingsCard(
+      ":/svg/dark/appearance-window-state.svg", tr("Single Application Mode"),
+      tr("Allow only one qEmby instance and activate it when launched again "
+         "(requires restart)"),
+      new ModernSwitch(this), ConfigKeys::SingleApplication, this, false));
+
+  m_mainLayout->addWidget(new SettingsCard(
+      ":/svg/dark/refresh.svg", tr("Check for Updates"),
+      tr("Automatically check GitHub for a new qEmby version on startup"),
+      new ModernSwitch(this), ConfigKeys::CheckForUpdates, this, true));
+
   
   
   

--- a/src/qEmbyApp/views/settings/pagelibrary.cpp
+++ b/src/qEmbyApp/views/settings/pagelibrary.cpp
@@ -302,14 +302,8 @@ PageLibrary::PageLibrary(QEmbyCore *core, QWidget *parent)
                        tr("Remove all cached images from disk"),
                        imgClearWidget, QString(), this));
   connect(clearImgBtn, &QPushButton::clicked, this, [this]() {
-    
-    QString cachePath = QStandardPaths::writableLocation(
-                            QStandardPaths::CacheLocation)
-                        + "/qEmby_ImageCache";
-    QDir cacheDir(cachePath);
-    if (cacheDir.exists()) {
-      cacheDir.removeRecursively();
-      QDir().mkpath(cachePath); 
+    if (m_core && m_core->mediaService()) {
+      m_core->mediaService()->clearImageCaches();
     }
     updateCacheSizes();
     ModernToast::showMessage(tr("Image cache cleared"), 1500);

--- a/src/qEmbyApp/views/settings/pageplayer.cpp
+++ b/src/qEmbyApp/views/settings/pageplayer.cpp
@@ -44,6 +44,7 @@
 #include <QVariantAnimation>
 #include <QVBoxLayout>
 #include <QtConcurrent/QtConcurrent>
+#include <algorithm>
 #include <memory>
 #include <qembycore.h>
 
@@ -591,26 +592,42 @@ PagePlayer::PagePlayer(QEmbyCore *core, QWidget *parent)
           serverName = selectedServer.baseUrl.trimmed();
         }
 
-        const QUrl serverUrl =
-            QUrl::fromUserInput(selectedServer.baseUrl.trimmed());
-        const bool isOfficialDandanPlay =
-            serverUrl.host().trimmed().compare(
-                QStringLiteral("api.dandanplay.net"), Qt::CaseInsensitive) == 0;
+        const bool isDandanPlay =
+            selectedServer.provider.trimmed().compare(
+                QStringLiteral("dandanplay"), Qt::CaseInsensitive) == 0;
+        const bool isDanmuApi =
+            selectedServer.provider.trimmed().compare(
+                QStringLiteral("danmu_api"), Qt::CaseInsensitive) == 0;
+        const QList<DanmakuServerDefinition> servers =
+            DanmakuSettings::loadServers(sid);
+        const int enabledServerCount =
+            std::count_if(servers.cbegin(), servers.cend(),
+                          [](const DanmakuServerDefinition &server) {
+                            return server.enabled;
+                          });
         QStringList summaryLines;
-        summaryLines.append(tr("Current server: %1").arg(serverName));
+        summaryLines.append(tr("Preferred server: %1").arg(serverName));
+        summaryLines.append(
+            tr("Server type: %1")
+                .arg(isDanmuApi ? tr("LogVar / danmu_api")
+                                : tr("DandanPlay")));
         summaryLines.append(
             tr("Address: %1").arg(selectedServer.baseUrl.trimmed()));
-        if (selectedServer.builtIn &&
-            selectedServer.contentScope.trimmed().compare(
-                QStringLiteral("anime"), Qt::CaseInsensitive) == 0) {
+        summaryLines.append(
+            tr("Enabled servers: %1").arg(enabledServerCount));
+        if (isDandanPlay && selectedServer.contentScope.trimmed().compare(
+                                QStringLiteral("anime"),
+                                Qt::CaseInsensitive) == 0) {
           summaryLines.append(tr("Supported content: Anime only"));
+        } else if (isDanmuApi) {
+          summaryLines.append(tr("Supported content: General video"));
         }
         if (!selectedServer.builtIn &&
             !selectedServer.description.trimmed().isEmpty()) {
           summaryLines.append(
               tr("Description: %1").arg(selectedServer.description.trimmed()));
         }
-        if (isOfficialDandanPlay &&
+        if (isDandanPlay && !selectedServer.builtIn &&
             (selectedServer.appId.trimmed().isEmpty() ||
              selectedServer.appSecret.trimmed().isEmpty())) {
           summaryLines.append(

--- a/src/qEmbyApp/views/user/categoryview.cpp
+++ b/src/qEmbyApp/views/user/categoryview.cpp
@@ -5,6 +5,7 @@
 #include "../../managers/thememanager.h"
 #include "../../utils/dashboardrequestlimitutils.h"
 #include "../../utils/mediaitemutils.h"
+#include "../../utils/resumeitemresolver.h"
 #include <QDebug>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -13,8 +14,7 @@
 #include <QPropertyAnimation>
 #include <QPushButton>
 #include <QScrollArea>
-#include <QSet> 
-#include <QStringList>
+#include <QSet>
 #include <QVBoxLayout>
 #include <config/config_keys.h>
 #include <config/configstore.h>
@@ -22,7 +22,6 @@
 #include <services/manager/servermanager.h>
 #include <services/media/mediaservice.h>
 #include <utility>
-#include <vector>
 
 namespace {
 constexpr int kDashboardCategoryFirstPageSize = 100;
@@ -370,67 +369,25 @@ CategoryView::fetchDashboardCategoryPage(DashboardCategoryQuery query,
                                          int startIndex, int limit) {
   QPointer<CategoryView> guard(this);
   DashboardCategoryPage categoryPage;
-  auto *mediaService = m_core->mediaService();
+  QPointer<MediaService> mediaService(m_core->mediaService());
+  if (!mediaService)
+    co_return categoryPage;
   MediaQueryPage page;
 
   if (query.category == "resume") {
     page = co_await mediaService->getResumeItemsPage(
         query.sortBy, query.sortOrder, startIndex, limit);
-    if (!guard)
+    if (!guard || !mediaService)
       co_return categoryPage;
 
     categoryPage.rawItemCount = page.items.size();
     categoryPage.fingerprint = pageFingerprint(page.items);
 
-    QSet<QString> seenSeriesIds;
-    QStringList seriesIdsToFetch;
-    QList<int> insertIndices;
-    QList<MediaItem> resumeContextItems;
-    QList<MediaItem> displayItems;
-
-    for (MediaItem item : page.items) {
-      if (item.type == "Episode" && !item.seriesId.isEmpty()) {
-        if (seenSeriesIds.contains(item.seriesId)) {
-          continue;
-        }
-        seenSeriesIds.insert(item.seriesId);
-        seriesIdsToFetch.append(item.seriesId);
-        insertIndices.append(displayItems.size());
-        resumeContextItems.append(item);
-        displayItems.append(MediaItem {});
-      } else {
-        displayItems.append(MediaItemUtils::withResumeContext(item, item));
-      }
-    }
-
-    std::vector<QCoro::Task<MediaItem>> detailTasks;
-    detailTasks.reserve(seriesIdsToFetch.size());
-    for (const QString &seriesId : std::as_const(seriesIdsToFetch)) {
-      detailTasks.push_back(mediaService->getItemDetail(seriesId));
-    }
-
-    for (int i = 0; i < static_cast<int>(detailTasks.size()); ++i) {
-      try {
-        MediaItem seriesItem = co_await std::move(detailTasks[i]);
-        if (!guard)
-          co_return categoryPage;
-        displayItems[insertIndices[i]] = MediaItemUtils::withResumeContext(
-            seriesItem, resumeContextItems[i]);
-      } catch (const std::exception &e) {
-        if (!guard)
-          co_return categoryPage;
-        qWarning() << "[CategoryView] failed to resolve resume series"
-                   << "| seriesId=" << seriesIdsToFetch.value(i)
-                   << "| error=" << e.what();
-      }
-    }
-
-    for (int i = displayItems.size() - 1; i >= 0; --i) {
-      if (displayItems.at(i).id.isEmpty()) {
-        displayItems.removeAt(i);
-      }
-    }
-    categoryPage.items = std::move(displayItems);
+    categoryPage.items = co_await ResumeItemResolver::resolve(
+        mediaService.data(), std::move(page.items),
+        QStringLiteral("category-page"));
+    if (!guard)
+      co_return categoryPage;
   } else if (query.category == "latest") {
     page = co_await mediaService->getLatestItemsPage(
         query.sortBy, query.sortOrder, startIndex, limit);
@@ -567,7 +524,8 @@ QCoro::Task<void> CategoryView::loadCategory(const QString &categoryType,
     m_sortButton->setCurrentIndex(1); 
     m_sortButton->setDescending(true);
     m_sortButton->setEnabled(true);
-  } else if (categoryType == "Favorite_Movie" || categoryType == "Movie") {
+  } else if (categoryType == "Favorite_Movie" || categoryType == "Movie" ||
+             categoryType == "Favorite_Series" || categoryType == "Series") {
     m_sortButton->setCurrentIndex(1); 
     m_sortButton->setDescending(true);
     m_sortButton->setEnabled(true);
@@ -640,7 +598,9 @@ QCoro::Task<void> CategoryView::onFilterChanged() {
 
   const int requestLimit = dashboardCategoryRequestLimit(m_currentCategory);
 
-  auto *mediaService = m_core->mediaService();
+  QPointer<MediaService> mediaService(m_core->mediaService());
+  if (!mediaService)
+    co_return;
 
   try {
     QList<MediaItem> resultItems;
@@ -650,31 +610,14 @@ QCoro::Task<void> CategoryView::onFilterChanged() {
       QList<MediaItem> rawItems =
           co_await mediaService->getResumeItems(requestLimit, sortBy,
                                                 sortOrder);
-      if (!guard)
+      if (!guard || !mediaService)
         co_return;
 
-      
-      QSet<QString> seenSeriesIds;
-      for (MediaItem item : rawItems) {
-        if (item.type == "Episode" && !item.seriesId.isEmpty()) {
-          if (seenSeriesIds.contains(item.seriesId))
-            continue;
-          seenSeriesIds.insert(item.seriesId);
-          try {
-            MediaItem seriesItem =
-                co_await mediaService->getItemDetail(item.seriesId);
-            if (!guard)
-              co_return;
-            resultItems.append(
-                MediaItemUtils::withResumeContext(seriesItem, item));
-          } catch (...) {
-            if (!guard)
-              co_return;
-          }
-        } else {
-          resultItems.append(MediaItemUtils::withResumeContext(item, item));
-        }
-      }
+      resultItems = co_await ResumeItemResolver::resolve(
+          mediaService.data(), std::move(rawItems),
+          QStringLiteral("category"));
+      if (!guard)
+        co_return;
     } else if (m_currentCategory == "latest") {
       resultItems =
           co_await mediaService->getLatestItems(requestLimit, sortBy,
@@ -690,6 +633,10 @@ QCoro::Task<void> CategoryView::onFilterChanged() {
                m_currentCategory == "Movie") {
       resultItems =
           co_await mediaService->getFavoriteMovies(0, sortBy, sortOrder);
+    } else if (m_currentCategory == "Favorite_Series" ||
+               m_currentCategory == "Series") {
+      resultItems =
+          co_await mediaService->getFavoriteSeries(0, sortBy, sortOrder);
     } else if (m_currentCategory == "Favorite_BoxSet" ||
                m_currentCategory == "BoxSet") {
       resultItems =

--- a/src/qEmbyApp/views/user/dashboardview.cpp
+++ b/src/qEmbyApp/views/user/dashboardview.cpp
@@ -8,6 +8,7 @@
 #include "../../utils/dashboardrequestlimitutils.h"
 #include "../../utils/dashboardsectionorderutils.h"
 #include "../../utils/mediaitemutils.h"
+#include "../../utils/resumeitemresolver.h"
 #include "../../utils/smoothscrollcontroller.h"
 #include "../../utils/textwraputils.h"
 #include "../media/mediacarddelegate.h"
@@ -22,14 +23,12 @@
 #include <QResizeEvent>
 #include <QScrollArea>
 #include <QScrollBar>
-#include <QSet>
 #include <QShowEvent>
 #include <QStyle>
 #include <QTimer>
 #include <QVBoxLayout>
 #include <QWheelEvent>
 #include <utility>
-#include <vector>
 #include <config/config_keys.h>
 #include <config/configstore.h>
 #include <qembycore.h>
@@ -878,7 +877,8 @@ QCoro::Task<void> DashboardView::loadDashboardData()
 
     if (m_resumeSection) {
         m_resumeSection->setVisible(showResume);
-        if (showResume && shimmerEnabled && m_resumeGallery) {
+        if (showResume && shimmerEnabled && m_resumeGallery &&
+            m_resumeGallery->itemCount() == 0) {
             m_resumeGallery->setLoading(true);
         }
     }
@@ -907,11 +907,12 @@ QCoro::Task<void> DashboardView::loadDashboardData()
         m_librarySectionsContainer->setVisible(showEachLibrary);
     }
 
-    loadResumeSection(showResume, generation);
-    loadLatestSection(showLatest, generation);
-    loadRecommendedSection(showRecommended, generation);
-    loadCompletedSection(showCompleted, generation);
-    loadLibrarySections(showLibraries, showEachLibrary, generation);
+    launchDashboardTask(loadResumeSection(showResume, generation));
+    launchDashboardTask(loadLatestSection(showLatest, generation));
+    launchDashboardTask(loadRecommendedSection(showRecommended, generation));
+    launchDashboardTask(loadCompletedSection(showCompleted, generation));
+    launchDashboardTask(
+        loadLibrarySections(showLibraries, showEachLibrary, generation));
     co_return;
 }
 
@@ -1018,7 +1019,10 @@ QCoro::Task<void> DashboardView::loadResumeSection(bool show, int generation)
     }
 
     QPointer<DashboardView> guard(this);
-    auto* mediaService = m_core->mediaService();
+    QPointer<MediaService> mediaService(m_core->mediaService());
+    if (!mediaService) {
+        co_return;
+    }
     const int requestLimit =
         DashboardRequestLimitUtils::homeSectionRequestLimit(
             currentServerId(), ConfigKeys::ContinueWatchingRequestLimit, 0);
@@ -1026,65 +1030,66 @@ QCoro::Task<void> DashboardView::loadResumeSection(bool show, int generation)
     try {
         QList<MediaItem> rawResumeItems =
             co_await mediaService->getResumeItems(requestLimit);
+        if (!guard || !mediaService || m_loadGeneration != generation) {
+            co_return;
+        }
+
+        QList<MediaItem> resumeItems =
+            ResumeItemResolver::buildFallbackItems(
+                std::move(rawResumeItems), QStringLiteral("dashboard"));
         if (!guard || m_loadGeneration != generation) {
             co_return;
         }
 
-        QList<MediaItem> resumeItems;
-        QSet<QString> seenSeriesIds;
-        QStringList seriesIdsToFetch;
-        QList<int> insertIndices;
-        QList<MediaItem> resumeContextItems;
+        const QList<MediaItem> existingResumeItems =
+            m_resumeGallery ? m_resumeGallery->items() : QList<MediaItem> {};
 
-        for (const MediaItem& item : rawResumeItems) {
-            if (item.type == "Episode" && !item.seriesId.isEmpty()) {
-                if (seenSeriesIds.contains(item.seriesId)) {
-                    continue;
-                }
+        if (resumeItems.isEmpty()) {
+            m_resumeGallery->setItems({});
+            m_resumeGallery->setLoading(false);
+            if (m_resumeSection) {
+                m_resumeSection->setVisible(false);
+            }
+            qDebug() << "[DashboardView] resume response is empty"
+                     << "| generation=" << generation
+                     << "| clearedExisting=" << !existingResumeItems.isEmpty();
+            co_return;
+        }
 
-                seenSeriesIds.insert(item.seriesId);
-                seriesIdsToFetch.append(item.seriesId);
-                insertIndices.append(resumeItems.size());
-                resumeContextItems.append(item);
-                resumeItems.append(MediaItem {});
-            } else {
-                resumeItems.append(MediaItemUtils::withResumeContext(item, item));
+        
+        
+        
+        
+        if (existingResumeItems.isEmpty()) {
+            m_resumeGallery->setItems(resumeItems);
+            if (m_resumeSection) {
+                m_resumeSection->setVisible(!resumeItems.isEmpty());
             }
         }
 
-        std::vector<QCoro::Task<MediaItem>> detailTasks;
-        detailTasks.reserve(seriesIdsToFetch.size());
-        for (const QString& seriesId : seriesIdsToFetch) {
-            detailTasks.push_back(mediaService->getItemDetail(seriesId));
+        qDebug() << "[DashboardView] prepared resume fallbacks"
+                 << "| generation=" << generation
+                 << "| retainedExisting=" << !existingResumeItems.isEmpty()
+                 << "| display=" << resumeItems.size();
+
+        resumeItems = co_await ResumeItemResolver::enrichSeriesCards(
+            mediaService.data(), std::move(resumeItems),
+            QStringLiteral("dashboard"));
+        if (!guard || m_loadGeneration != generation) {
+            co_return;
         }
 
-        for (int i = 0; i < static_cast<int>(detailTasks.size()); ++i) {
-            try {
-                MediaItem seriesItem = co_await std::move(detailTasks[i]);
-                if (!guard || m_loadGeneration != generation) {
-                    co_return;
-                }
-
-                resumeItems[insertIndices[i]] =
-                    MediaItemUtils::withResumeContext(seriesItem,
-                                                      resumeContextItems[i]);
-            } catch (...) {
-                if (!guard || m_loadGeneration != generation) {
-                    co_return;
-                }
-            }
-        }
-
-        for (int i = resumeItems.size() - 1; i >= 0; --i) {
-            if (resumeItems[i].id.isEmpty()) {
-                resumeItems.removeAt(i);
-            }
-        }
-
+        resumeItems = ResumeItemResolver::preserveExistingResolvedCards(
+            std::move(resumeItems), existingResumeItems,
+            QStringLiteral("dashboard"));
         m_resumeGallery->setItems(resumeItems);
         if (m_resumeSection) {
             m_resumeSection->setVisible(!resumeItems.isEmpty());
         }
+
+        qDebug() << "[DashboardView] committed enriched resume items"
+                 << "| generation=" << generation
+                 << "| display=" << resumeItems.size();
     } catch (const std::exception& e) {
         if (!guard || m_loadGeneration != generation) {
             co_return;
@@ -1095,7 +1100,8 @@ QCoro::Task<void> DashboardView::loadResumeSection(bool show, int generation)
             m_resumeGallery->setLoading(false);
         }
         if (m_resumeSection) {
-            m_resumeSection->setVisible(false);
+            m_resumeSection->setVisible(
+                m_resumeGallery && m_resumeGallery->itemCount() > 0);
         }
     }
 }

--- a/src/qEmbyApp/views/user/homeview.cpp
+++ b/src/qEmbyApp/views/user/homeview.cpp
@@ -1218,8 +1218,8 @@ void HomeView::goHome()
 {
     if (m_contentSwitcher->currentWidget() == m_dashboardView)
     {
-        
-        m_dashboardView->loadDashboardData();
+        QCoro::connect(m_dashboardView->loadDashboardData(), m_dashboardView,
+                       []() {});
         return;
     }
     m_libraryList->clearSelection();

--- a/src/qEmbyCore/api/networkmanager.cpp
+++ b/src/qEmbyCore/api/networkmanager.cpp
@@ -10,6 +10,7 @@
 #include <qcoronetwork.h>
 #include <limits>
 #include <stdexcept>
+#include <utility>
 
 namespace {
 
@@ -80,6 +81,42 @@ bool tryParseJsonWithEncoding(const QByteArray &responseData,
     return parseError.error == QJsonParseError::NoError;
 }
 
+QString safeUrlForLog(QUrl url)
+{
+    url.setUserInfo(QString());
+    url.setQuery(QString());
+    url.setFragment(QString());
+    
+    
+    QString path = url.path();
+    const int apiIndex = path.indexOf(QStringLiteral("/api/v2/"),
+                                      0, Qt::CaseInsensitive);
+    if (apiIndex > 0) {
+        const int tokenSlash = path.lastIndexOf('/', apiIndex - 1);
+        if (tokenSlash >= 0 && tokenSlash + 1 < apiIndex) {
+            path.replace(tokenSlash + 1, apiIndex - tokenSlash - 1,
+                         QStringLiteral("<redacted>"));
+            url.setPath(path);
+        }
+    }
+    return url.toString(QUrl::RemoveUserInfo | QUrl::RemoveQuery |
+                        QUrl::RemoveFragment);
+}
+
+QString safeNetworkErrorForLog(QString errorText, const QUrl &requestUrl)
+{
+    const QString fullUrl = requestUrl.toString();
+    if (!fullUrl.isEmpty()) {
+        errorText.replace(fullUrl, safeUrlForLog(requestUrl));
+    }
+
+    static const QRegularExpression sensitiveQueryValue(
+        QStringLiteral("([?&](?:api_key|access_token|token|X-Emby-Token)=)[^&\\s\\\"]+"),
+        QRegularExpression::CaseInsensitiveOption);
+    errorText.replace(sensitiveQueryValue, QStringLiteral("\\1<redacted>"));
+    return errorText;
+}
+
 } 
 
 NetworkManager::NetworkManager(QObject *parent)
@@ -107,11 +144,15 @@ void NetworkManager::applyRequestOptions(QNetworkRequest& request,
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
                          QNetworkRequest::NoLessSafeRedirectPolicy);
 
+    if (options.timeoutMs > 0) {
+        request.setTransferTimeout(options.timeoutMs);
+    }
+
     if (options.ignoreSslErrors &&
         request.url().scheme().compare(QStringLiteral("https"),
                                        Qt::CaseInsensitive) == 0) {
         qWarning() << "[NetworkManager] SSL certificate verification is DISABLED"
-                   << "| url:" << request.url().toString();
+                   << "| url:" << safeUrlForLog(request.url());
     }
 }
 
@@ -136,7 +177,7 @@ void NetworkManager::attachReplyHandlers(QNetworkReply* reply,
 
                 qWarning() << "[NetworkManager]" << requestKind
                            << "TLS validation errors"
-                           << "| url:" << reply->url().toString()
+                           << "| url:" << safeUrlForLog(reply->url())
                            << "| ignoreSslErrors:" << options.ignoreSslErrors
                            << "| errors:" << summary;
 
@@ -144,7 +185,7 @@ void NetworkManager::attachReplyHandlers(QNetworkReply* reply,
                     qWarning() << "[NetworkManager]" << requestKind
                                << "Ignoring TLS validation errors for trusted "
                                   "server"
-                               << "| url:" << reply->url().toString();
+                               << "| url:" << safeUrlForLog(reply->url());
                     reply->ignoreSslErrors();
                     reply->setProperty("sslErrorsIgnored", true);
                 }
@@ -156,7 +197,7 @@ QString NetworkManager::buildReplyErrorMessage(QNetworkReply* reply,
     QString errorMsg =
         QString(NetworkManager::tr("请求失败(HTTP %1): %2"))
             .arg(httpStatus)
-            .arg(reply->errorString());
+            .arg(safeNetworkErrorForLog(reply->errorString(), reply->url()));
 
     const QString sslSummary = reply->property("sslErrorsSummary").toString();
     if (!sslSummary.isEmpty() &&
@@ -180,7 +221,7 @@ QJsonObject NetworkManager::parseReply(QNetworkReply* reply) {
         int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         QByteArray responseBody = reply->readAll();
         qWarning() << "[NetworkManager] Request FAILED"
-                   << "| url:" << reply->url().toString()
+                   << "| url:" << safeUrlForLog(reply->url())
                    << "| httpStatus:" << httpStatus
                    << "| qtError:" << reply->error()
                    << "| errorString:" << reply->errorString()
@@ -257,7 +298,7 @@ QJsonObject NetworkManager::parseReply(QNetworkReply* reply) {
 
     if (!hasValidJson) {
         qWarning() << "[NetworkManager] JSON parse failed"
-                   << "| url:" << reply->url().toString()
+                   << "| url:" << safeUrlForLog(reply->url())
                    << "| contentType:" << contentType
                    << "| charset:" << charsetName
                    << "| parseError:" << parseError.errorString()
@@ -269,7 +310,7 @@ QJsonObject NetworkManager::parseReply(QNetworkReply* reply) {
     if (!charsetName.isEmpty() || parseSource != QStringLiteral("raw-utf8") ||
         replacementCount > 0) {
         qDebug() << "[NetworkManager] JSON decoded"
-                 << "| url:" << reply->url().toString()
+                 << "| url:" << safeUrlForLog(reply->url())
                  << "| contentType:" << contentType
                  << "| charset:" << charsetName
                  << "| source:" << parseSource
@@ -303,6 +344,36 @@ QCoro::Task<QJsonObject> NetworkManager::get(
     co_return parseReply(reply);
 }
 
+QCoro::Task<QList<NetworkJsonResult>> NetworkManager::getBatch(
+    QList<NetworkJsonGetRequest> requests)
+{
+    QList<QNetworkReply *> replies;
+    replies.reserve(requests.size());
+    for (const NetworkJsonGetRequest &item : std::as_const(requests)) {
+        QNetworkRequest request{QUrl(item.url)};
+        applyHeaders(request, item.headers);
+        applyRequestOptions(request, item.options);
+        request.setHeader(QNetworkRequest::ContentTypeHeader, QVariant());
+        QNetworkReply *reply = m_networkManager->get(request);
+        attachReplyHandlers(reply, item.options, QStringLiteral("GET_BATCH"));
+        replies.append(reply);
+    }
+
+    QList<NetworkJsonResult> results;
+    results.reserve(replies.size());
+    for (QNetworkReply *reply : std::as_const(replies)) {
+        NetworkJsonResult result;
+        co_await reply;
+        try {
+            result.object = parseReply(reply);
+        } catch (const std::exception &e) {
+            result.errorMessage = QString::fromUtf8(e.what()).trimmed();
+        }
+        results.append(result);
+    }
+    co_return results;
+}
+
 
 QCoro::Task<QString> NetworkManager::getText(
     const QString& url, const QMap<QString, QString>& headers,
@@ -327,7 +398,7 @@ QString NetworkManager::parseReplyAsText(QNetworkReply* reply) {
     if (reply->error() != QNetworkReply::NoError) {
         int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         qWarning() << "[NetworkManager] getText FAILED"
-                   << "| url:" << reply->url().toString()
+                   << "| url:" << safeUrlForLog(reply->url())
                    << "| httpStatus:" << httpStatus
                    << "| errorString:" << reply->errorString()
                    << "| ignoreSslErrors:"
@@ -371,6 +442,60 @@ QCoro::Task<QByteArray> NetworkManager::getBytes(
     co_return parseReplyAsBytes(reply, QStringLiteral("getBytes"));
 }
 
+QCoro::Task<QByteArray> NetworkManager::getBytesLimited(
+    QString url,
+    QMap<QString, QString> headers,
+    qint64 maximumBytes,
+    NetworkRequestOptions options)
+{
+    if (maximumBytes <= 0) {
+        co_return QByteArray{};
+    }
+
+    QNetworkRequest request{QUrl(url)};
+    applyHeaders(request, headers);
+    applyRequestOptions(request, options);
+    request.setHeader(QNetworkRequest::ContentTypeHeader, QVariant());
+    request.setRawHeader(
+        "Range",
+        QStringLiteral("bytes=0-%1").arg(maximumBytes - 1).toLatin1());
+
+    QNetworkReply *reply = m_networkManager->get(request);
+    attachReplyHandlers(reply, options, QStringLiteral("GET_LIMITED"));
+
+    QByteArray data;
+    data.reserve(static_cast<qsizetype>(qMin<qint64>(maximumBytes, 16 * 1024 * 1024)));
+    const auto consumeAvailable = [reply, &data, maximumBytes]() {
+        const qint64 remaining = maximumBytes - data.size();
+        if (remaining > 0) {
+            data.append(reply->read(remaining));
+        }
+        if (data.size() >= maximumBytes && !reply->isFinished()) {
+            reply->abort();
+        }
+    };
+    const QMetaObject::Connection readyReadConnection =
+        connect(reply, &QNetworkReply::readyRead, reply, consumeAvailable);
+
+    co_await reply;
+    disconnect(readyReadConnection);
+    consumeAvailable();
+
+    const bool stoppedAfterLimit =
+        reply->error() == QNetworkReply::OperationCanceledError &&
+        data.size() >= maximumBytes;
+    if (reply->error() != QNetworkReply::NoError && !stoppedAfterLimit) {
+        const int httpStatus =
+            reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        const QString errorMessage = buildReplyErrorMessage(reply, httpStatus);
+        reply->deleteLater();
+        throw std::runtime_error(errorMessage.toStdString());
+    }
+
+    reply->deleteLater();
+    co_return data;
+}
+
 QByteArray NetworkManager::parseReplyAsBytes(QNetworkReply* reply,
                                              const QString& requestKind) {
     reply->deleteLater();
@@ -378,7 +503,7 @@ QByteArray NetworkManager::parseReplyAsBytes(QNetworkReply* reply,
     if (reply->error() != QNetworkReply::NoError) {
         int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         qWarning() << "[NetworkManager]" << requestKind << "FAILED"
-                   << "| url:" << reply->url().toString()
+                   << "| url:" << safeUrlForLog(reply->url())
                    << "| httpStatus:" << httpStatus
                    << "| errorString:" << reply->errorString()
                    << "| ignoreSslErrors:"

--- a/src/qEmbyCore/api/networkmanager.h
+++ b/src/qEmbyCore/api/networkmanager.h
@@ -9,6 +9,7 @@
 #include <QNetworkReply>
 #include <QJsonObject>
 #include <QJsonDocument>
+#include <QList>
 #include <QMap>
 #include <QSslError>
 #include <QUrlQuery>
@@ -16,6 +17,20 @@
 
 struct NetworkRequestOptions {
     bool ignoreSslErrors = false;
+    int timeoutMs = 0;
+};
+
+struct NetworkJsonGetRequest {
+    QString url;
+    QMap<QString, QString> headers;
+    NetworkRequestOptions options;
+};
+
+struct NetworkJsonResult {
+    QJsonObject object;
+    QString errorMessage;
+
+    bool succeeded() const { return errorMessage.isEmpty(); }
 };
 
 class QEMBYCORE_EXPORT NetworkManager : public QObject
@@ -37,6 +52,8 @@ public:
     QCoro::Task<QJsonObject> get(const QString& url,
                                  const QMap<QString, QString>& headers,
                                  const NetworkRequestOptions& options = {});
+    QCoro::Task<QList<NetworkJsonResult>> getBatch(
+        QList<NetworkJsonGetRequest> requests);
 
     
     QCoro::Task<QString> getText(const QString& url,
@@ -47,6 +64,11 @@ public:
     QCoro::Task<QByteArray> getBytes(const QString& url,
                                      const QMap<QString, QString>& headers,
                                      const NetworkRequestOptions& options = {});
+    QCoro::Task<QByteArray> getBytesLimited(
+        QString url,
+        QMap<QString, QString> headers,
+        qint64 maximumBytes,
+        NetworkRequestOptions options = {});
 
     
     QCoro::Task<QJsonObject> post(const QString& url,

--- a/src/qEmbyCore/config/config_keys.h
+++ b/src/qEmbyCore/config/config_keys.h
@@ -26,11 +26,21 @@ inline QString forServerMedia(const QString& serverId, const QString& mediaId, c
 }
 
 
+inline QString forServerMediaSource(const QString& serverId, const QString& mediaId,
+                                    const QString& sourceId, const char* baseKey) {
+    return QStringLiteral("%1/%2/%3/%4")
+        .arg(QString::fromLatin1(baseKey), serverId, mediaId, sourceId);
+}
+
+
 
 constexpr const char* Language = "general/language";
 constexpr const char* RememberServer = "general/remember_server";
 constexpr const char* LastSelectedServerId = "general/last_selected_server_id";
 constexpr const char* CloseToTray = "general/close_to_tray";
+constexpr const char* SingleApplication = "general/single_application";
+constexpr const char* CheckForUpdates = "general/check_for_updates";
+constexpr const char* IgnoredUpdateVersion = "general/ignored_update_version";
 constexpr const char* LogEnable = "general/log_enable";
 constexpr const char* ApiTimeout = "general/api_timeout";
 constexpr const char* ImageCacheLimit = "general/image_cache_limit";
@@ -110,6 +120,11 @@ constexpr const char* PlayerDefaultScale = "player/default_scale";
 constexpr const char* PlayerAudioLang = "player/audio_lang";
 constexpr const char* PlayerSubLang = "player/sub_lang";
 constexpr const char* PlayerPreferredVersion = "player/preferred_version";
+
+constexpr const char* PlayerSelectedMediaSource = "player/selected_media_source";
+
+constexpr const char* PlayerSelectedAudioStream = "player/selected_audio_stream";
+constexpr const char* PlayerSelectedSubtitleStream = "player/selected_subtitle_stream";
 constexpr const char* PlayerVolNormal = "player/vol_normalization";
 constexpr const char* PlayerContinuousPlay = "player/continuous_play";
 constexpr const char* PlayerSeekStep = "player/seek_step";

--- a/src/qEmbyCore/config/configstore.cpp
+++ b/src/qEmbyCore/config/configstore.cpp
@@ -66,6 +66,9 @@ ConfigStore::ConfigStore(QObject* parent) : QObject(parent) {
     if (!m_settings->contains(ConfigKeys::ImageCacheDuration)) {
         m_settings->setValue(ConfigKeys::ImageCacheDuration, "7");
     }
+    if (!m_settings->contains(canonicalStorageKey(ConfigKeys::CheckForUpdates))) {
+        m_settings->setValue(canonicalStorageKey(ConfigKeys::CheckForUpdates), true);
+    }
 }
 
 ConfigStore::~ConfigStore() {
@@ -80,6 +83,9 @@ void ConfigStore::migrateLegacyGeneralSettings() {
         ConfigKeys::RememberServer,
         ConfigKeys::LastSelectedServerId,
         ConfigKeys::CloseToTray,
+        ConfigKeys::SingleApplication,
+        ConfigKeys::CheckForUpdates,
+        ConfigKeys::IgnoredUpdateVersion,
         ConfigKeys::LogEnable,
         ConfigKeys::ApiTimeout,
         ConfigKeys::ImageCacheLimit,

--- a/src/qEmbyCore/models/danmaku/danmakumodels.h
+++ b/src/qEmbyCore/models/danmaku/danmakumodels.h
@@ -19,6 +19,9 @@ struct QEMBYCORE_EXPORT DanmakuServerDefinition {
     QString appId;
     QString appSecret;
     
+    
+    QString accessToken;
+    
     QString contentScope;
     bool builtIn = false;
     bool enabled = true;
@@ -41,6 +44,7 @@ struct QEMBYCORE_EXPORT DanmakuProviderConfig {
     QString endpointName;
     QString appId;
     QString appSecret;
+    QString accessToken;
     
     QString contentScope;
     bool enabled = true;
@@ -62,6 +66,14 @@ struct QEMBYCORE_EXPORT DanmakuMediaContext {
     int episodeNumber = -1;
     qint64 durationMs = 0;
     QString path;
+    QString fileName;
+    qint64 fileSize = 0;
+    QString fileHash;
+    QDateTime mediaModifiedAt;
+    
+    
+    QString mediaUrl;
+    QStringList genres;
     QVariantMap providerIds;
 
     QString cacheKey() const {
@@ -101,6 +113,16 @@ struct QEMBYCORE_EXPORT DanmakuMatchCandidate {
     double score = 0.0;
     QString matchReason;
     int commentCount = 0;
+
+    bool isHashMatch() const {
+        return matchReason.compare(QStringLiteral("hash"),
+                                   Qt::CaseInsensitive) == 0;
+    }
+
+    bool isProviderIdMatch() const {
+        return matchReason.compare(QStringLiteral("tmdb"),
+                                   Qt::CaseInsensitive) == 0;
+    }
 
     bool isValid() const {
         return !provider.isEmpty() && !targetId.isEmpty();

--- a/src/qEmbyCore/models/media/mediaitem.h
+++ b/src/qEmbyCore/models/media/mediaitem.h
@@ -225,6 +225,10 @@ public:
     QString resumeItemId;
     MediaUserDataInfo resumeUserData;
     bool hasResumeContext = false;
+    
+    
+    
+    bool isResumeDisplayFallback = false;
 
     QList<MediaPersonInfo> people;
     QList<MediaStudioInfo> studios; 

--- a/src/qEmbyCore/services/danmaku/dandanplayprovider.cpp
+++ b/src/qEmbyCore/services/danmaku/dandanplayprovider.cpp
@@ -8,16 +8,115 @@
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QMap>
+#include <QRegularExpression>
+#include <QSet>
+#include <QFile>
 #include <QFileInfo>
 #include <QUrl>
 #include <QUrlQuery>
 #include <algorithm>
 #include <cstdlib>
 #include <exception>
+#include <limits>
 #include <stdexcept>
 #include <utility>
+#include <QtConcurrent/QtConcurrent>
+#include <qcorofuture.h>
 
 namespace {
+
+constexpr qint64 kDandanplayHashSampleBytes = 16LL * 1024 * 1024;
+constexpr int kDanmakuRequestTimeoutMs = 10000;
+
+struct MediaFingerprint {
+    QString hash;
+    qint64 fileSize = 0;
+
+    bool isValid() const
+    {
+        return hash.size() == 32 && fileSize > 0;
+    }
+};
+
+NetworkRequestOptions danmakuRequestOptions()
+{
+    NetworkRequestOptions options;
+    options.timeoutMs = kDanmakuRequestTimeoutMs;
+    return options;
+}
+
+QCoro::Task<MediaFingerprint> resolveMediaFingerprint(
+    NetworkManager *networkManager,
+    DanmakuMediaContext context)
+{
+    MediaFingerprint fingerprint;
+    const QString providedHash = context.fileHash.trimmed().toLower();
+    if (providedHash.size() == 32 && context.fileSize > 0) {
+        fingerprint.hash = providedHash;
+        fingerprint.fileSize = context.fileSize;
+        co_return fingerprint;
+    }
+
+    const QString localPath = context.path.trimmed();
+    const QFileInfo localInfo(localPath);
+    if (!localPath.isEmpty() && localInfo.exists() && localInfo.isFile()) {
+        auto hashFuture = QtConcurrent::run(
+            [localPath]() -> MediaFingerprint {
+                MediaFingerprint result;
+                QFile file(localPath);
+                if (!file.open(QIODevice::ReadOnly)) {
+                    return result;
+                }
+                result.fileSize = file.size();
+                const QByteArray sample = file.read(kDandanplayHashSampleBytes);
+                const qint64 expectedBytes =
+                    qMin(result.fileSize, kDandanplayHashSampleBytes);
+                if (result.fileSize <= 0 || sample.size() != expectedBytes) {
+                    return {};
+                }
+                result.hash = QString::fromLatin1(
+                    QCryptographicHash::hash(sample, QCryptographicHash::Md5)
+                        .toHex());
+                return result;
+            });
+        fingerprint = co_await hashFuture;
+        co_return fingerprint;
+    }
+
+    if (!networkManager || context.mediaUrl.trimmed().isEmpty() ||
+        context.fileSize <= 0) {
+        co_return fingerprint;
+    }
+    if (context.durationMs >= 10 * 60 * 1000 &&
+        context.fileSize < kDandanplayHashSampleBytes) {
+        qWarning().noquote()
+            << "[Danmaku][DandanPlay] Ignoring implausible remote media size"
+            << "| mediaId:" << context.mediaId
+            << "| fileSize:" << context.fileSize
+            << "| durationMs:" << context.durationMs;
+        co_return fingerprint;
+    }
+
+    const qint64 expectedBytes =
+        qMin(context.fileSize, kDandanplayHashSampleBytes);
+    try {
+        const QByteArray sample = co_await networkManager->getBytesLimited(
+            context.mediaUrl, {}, expectedBytes, danmakuRequestOptions());
+        if (sample.size() != expectedBytes) {
+            co_return fingerprint;
+        }
+        fingerprint.fileSize = context.fileSize;
+        fingerprint.hash = QString::fromLatin1(
+            QCryptographicHash::hash(sample, QCryptographicHash::Md5).toHex());
+    } catch (const std::exception &e) {
+        qWarning().noquote()
+            << "[Danmaku][DandanPlay] Media fingerprint unavailable"
+            << "| mediaId:" << context.mediaId
+            << "| expectedBytes:" << expectedBytes
+            << "| error:" << e.what();
+    }
+    co_return fingerprint;
+}
 
 QString firstNonEmpty(std::initializer_list<QString> values)
 {
@@ -102,6 +201,27 @@ QString providerIdValue(const QVariantMap &providerIds,
     return {};
 }
 
+bool isExplicitlyNonAnime(const DanmakuMediaContext &context,
+                          const DanmakuProviderConfig &config)
+{
+    if (config.contentScope.compare(QStringLiteral("anime"),
+                                    Qt::CaseInsensitive) != 0 ||
+        context.genres.isEmpty()) {
+        return false;
+    }
+    for (const QString &genre : context.genres) {
+        const QString normalized = genre.trimmed().toLower();
+        if (normalized == QLatin1String("animation") ||
+            normalized == QLatin1String("anime") ||
+            normalized.contains(QStringLiteral("动画")) ||
+            normalized.contains(QStringLiteral("動漫")) ||
+            normalized.contains(QStringLiteral("アニメ"))) {
+            return false;
+        }
+    }
+    return true;
+}
+
 QString normalizedHost(const QString &baseUrl)
 {
     const QUrl url = QUrl::fromUserInput(baseUrl.trimmed());
@@ -111,6 +231,21 @@ QString normalizedHost(const QString &baseUrl)
 bool isOfficialDandanplayEndpoint(const DanmakuProviderConfig &config)
 {
     return normalizedHost(config.baseUrl) == QStringLiteral("api.dandanplay.net");
+}
+
+bool supportsV2SearchEngine(const QString &apiPath)
+{
+    QString normalizedPath = apiPath.trimmed().toLower();
+    if (!normalizedPath.startsWith('/')) {
+        normalizedPath.prepend('/');
+    }
+    while (normalizedPath.endsWith('/') && normalizedPath.size() > 1) {
+        normalizedPath.chop(1);
+    }
+
+    return normalizedPath == QStringLiteral("/api/v2/search/anime") ||
+           normalizedPath == QStringLiteral("/api/v2/search/episodes") ||
+           normalizedPath == QStringLiteral("/api/v2/search/adv");
 }
 
 QString missingCredentialsMessage()
@@ -189,7 +324,16 @@ QString buildUrl(const DanmakuProviderConfig &config,
     url.setPath(path);
 
     QUrlQuery query;
+    
+    
+    
+    if (supportsV2SearchEngine(apiPath)) {
+        query.addQueryItem(QStringLiteral("v2"), QStringLiteral("true"));
+    }
     for (const auto &item : queryItems) {
+        if (item.first.compare(QStringLiteral("v2"), Qt::CaseInsensitive) == 0) {
+            continue;
+        }
         if (!item.second.trimmed().isEmpty()) {
             query.addQueryItem(item.first, item.second.trimmed());
         }
@@ -287,18 +431,36 @@ double titleScore(const QString &lhs, const QString &rhs)
         return 0.45;
     }
 
-    int overlap = 0;
-    for (const QChar ch : cleanLhs.isEmpty() ? rawLhs : cleanLhs) {
-        const QString &target = cleanRhs.isEmpty() ? rawRhs : cleanRhs;
-        if (!ch.isSpace() && target.contains(ch)) {
-            ++overlap;
+    auto comparable = [](QString value) {
+        value.remove(QRegularExpression(QStringLiteral(R"([^\p{L}\p{N}]+)")));
+        return value;
+    };
+    const QString comparableLhs = comparable(
+        cleanLhs.isEmpty() ? rawLhs : cleanLhs);
+    const QString comparableRhs = comparable(
+        cleanRhs.isEmpty() ? rawRhs : cleanRhs);
+    if (comparableLhs.size() < 2 || comparableRhs.size() < 2) {
+        return comparableLhs == comparableRhs ? 1.0 : 0.0;
+    }
+
+    auto bigrams = [](const QString &value) {
+        QSet<QString> result;
+        for (int i = 0; i + 1 < value.size(); ++i) {
+            result.insert(value.mid(i, 2));
+        }
+        return result;
+    };
+    const QSet<QString> lhsBigrams = bigrams(comparableLhs);
+    const QSet<QString> rhsBigrams = bigrams(comparableRhs);
+    int common = 0;
+    for (const QString &gram : lhsBigrams) {
+        if (rhsBigrams.contains(gram)) {
+            ++common;
         }
     }
-    const int base = cleanLhs.isEmpty() ? rawLhs.size()
-                                        : cleanLhs.size();
-    return base == 0
-               ? 0.0
-               : qBound(0.0, overlap / static_cast<double>(base), 0.35);
+    const double dice =
+        (2.0 * common) / (lhsBigrams.size() + rhsBigrams.size());
+    return qBound(0.0, dice * 0.55, 0.55);
 }
 
 int extractYear(const QString &title)
@@ -416,6 +578,17 @@ int extractSeasonNumber(const QString &title)
         }
     }
 
+    static const QRegularExpression ordinalSeasonPattern(
+        QStringLiteral(R"((?:^|[^A-Za-z0-9])0*(\d{1,2})(?:st|nd|rd|th)?\s*(?:Season|期)(?:[^A-Za-z0-9]|$))"),
+        QRegularExpression::CaseInsensitiveOption);
+    match = ordinalSeasonPattern.match(trimmed);
+    if (match.hasMatch()) {
+        const int parsed = match.captured(1).toInt();
+        if (parsed > 0) {
+            return parsed;
+        }
+    }
+
     static const QRegularExpression romanPattern(
         QStringLiteral(R"((?:^|\s)(VIII|VII|VI|IV|IX|III|II|V|X)\s*$)"));
     match = romanPattern.match(trimmed);
@@ -436,6 +609,89 @@ int extractSeasonNumber(const QString &title)
     return 0;
 }
 
+int extractEpisodeNumber(const QString &title)
+{
+    const QString trimmed = title.trimmed();
+    if (trimmed.isEmpty()) {
+        return 0;
+    }
+
+    static const QRegularExpression seasonEpisodePattern(
+        QStringLiteral(R"((?:^|[^A-Za-z0-9])S\s*0*\d{1,2}\s*E\s*0*(\d{1,4})(?:[^A-Za-z0-9]|$))"),
+        QRegularExpression::CaseInsensitiveOption);
+    QRegularExpressionMatch match = seasonEpisodePattern.match(trimmed);
+    if (match.hasMatch()) {
+        return match.captured(1).toInt();
+    }
+
+    static const QRegularExpression chineseEpisodePattern(
+        QStringLiteral(R"(第\s*0*(\d{1,4})\s*[话話集期])"));
+    match = chineseEpisodePattern.match(trimmed);
+    if (match.hasMatch()) {
+        return match.captured(1).toInt();
+    }
+
+    static const QRegularExpression englishEpisodePattern(
+        QStringLiteral(R"((?:^|[^A-Za-z0-9])(?:EP?|Episode)\s*[._-]?\s*0*(\d{1,4})(?:[^A-Za-z0-9]|$))"),
+        QRegularExpression::CaseInsensitiveOption);
+    match = englishEpisodePattern.match(trimmed);
+    if (match.hasMatch()) {
+        return match.captured(1).toInt();
+    }
+
+    static const QRegularExpression numberOnlyPattern(
+        QStringLiteral(R"(^\s*0*(\d{1,4})(?:\s|$|[._-])?)"));
+    match = numberOnlyPattern.match(trimmed);
+    return match.hasMatch() ? match.captured(1).toInt() : 0;
+}
+
+struct ManualSearchHint {
+    QString keyword;
+    int seasonNumber = -1;
+    int episodeNumber = -1;
+    bool hasExplicitEpisode = false;
+};
+
+ManualSearchHint parseManualSearchHint(const QString &input)
+{
+    ManualSearchHint hint;
+    hint.keyword = input.trimmed();
+
+    static const QRegularExpression seasonEpisodePattern(
+        QStringLiteral(R"((?:^|[\s._-])S\s*0*(\d{1,2})\s*E\s*0*(\d{1,4})(?=$|[\s._-]))"),
+        QRegularExpression::CaseInsensitiveOption);
+    QRegularExpressionMatch match = seasonEpisodePattern.match(hint.keyword);
+    if (match.hasMatch()) {
+        hint.seasonNumber = match.captured(1).toInt();
+        hint.episodeNumber = match.captured(2).toInt();
+        hint.hasExplicitEpisode = hint.episodeNumber > 0;
+        hint.keyword.remove(match.capturedStart(), match.capturedLength());
+    } else {
+        static const QRegularExpression chineseSeasonEpisodePattern(
+            QStringLiteral(R"(第\s*0*(\d{1,2})\s*季\s*第?\s*0*(\d{1,4})\s*[话話集期])"));
+        match = chineseSeasonEpisodePattern.match(hint.keyword);
+        if (match.hasMatch()) {
+            hint.seasonNumber = match.captured(1).toInt();
+            hint.episodeNumber = match.captured(2).toInt();
+            hint.hasExplicitEpisode = hint.episodeNumber > 0;
+            hint.keyword.remove(match.capturedStart(), match.capturedLength());
+        }
+    }
+
+    hint.keyword.replace(QRegularExpression(QStringLiteral(R"([\s._-]{2,})")),
+                         QStringLiteral(" "));
+    hint.keyword = hint.keyword.trimmed();
+    return hint;
+}
+
+bool isClearlyEpisodicAnimeType(const QString &type)
+{
+    const QString normalized = type.trimmed().toLower();
+    return normalized == QLatin1String("tvseries") ||
+           normalized == QLatin1String("jpdrama") ||
+           normalized == QLatin1String("tmdbtv");
+}
+
 double computeScore(const DanmakuMediaContext &context,
                     const DanmakuMatchCandidate &candidate,
                     const QString &queryKeyword)
@@ -449,7 +705,7 @@ double computeScore(const DanmakuMediaContext &context,
     score += titleScore(subjectTitle, candidateSubject) * 55.0;
     score += titleScore(context.originalTitle, candidateSubject) * 18.0;
     score += titleScore(context.title, candidate.title) * 18.0;
-    score += titleScore(queryKeyword, candidate.displayText()) * 12.0;
+    score += titleScore(queryKeyword, candidate.displayText()) * 6.0;
 
     if (context.isEpisode() && context.episodeNumber > 0 &&
         candidate.episodeNumber > 0 &&
@@ -483,11 +739,14 @@ double computeScore(const DanmakuMediaContext &context,
             score += 12.0;
         } else if (diff <= 90 * 1000) {
             score += 6.0;
+        } else if (diff > std::max<qint64>(5 * 60 * 1000,
+                                           context.durationMs * 18 / 100)) {
+            score -= 22.0;
         }
     }
 
     if (candidate.commentCount > 0) {
-        score += std::min(10.0, candidate.commentCount / 80.0);
+        score += std::min(4.0, candidate.commentCount / 200.0);
     }
 
     if (context.productionYear > 0) {
@@ -500,6 +759,8 @@ double computeScore(const DanmakuMediaContext &context,
                 score += 8.0;
             } else if (yearDiff <= 3) {
                 score += 3.0;
+            } else {
+                score -= 20.0;
             }
         }
     }
@@ -507,14 +768,39 @@ double computeScore(const DanmakuMediaContext &context,
     return score;
 }
 
-QList<DanmakuMatchCandidate> parseSearchResponse(const QJsonObject &response,
-                                                 const DanmakuMediaContext &context,
-                                                 const QString &queryKeyword)
+qint64 normalizeCandidateDurationMs(qint64 value, qint64 expectedDurationMs)
+{
+    if (value <= 0) {
+        return 0;
+    }
+    if (value <= 24 * 60 * 60) {
+        const qint64 secondsValue = value * 1000;
+        if (expectedDurationMs <= 0 ||
+            std::llabs(secondsValue - expectedDurationMs) <
+                std::llabs(value - expectedDurationMs)) {
+            return secondsValue;
+        }
+    }
+    return value;
+}
+
+QList<DanmakuMatchCandidate> parseSearchResponse(
+    const QJsonObject &response,
+    const DanmakuMediaContext &context,
+    const QString &queryKeyword,
+    int requestedEpisodeNumber,
+    bool excludeClearlyEpisodicWorks)
 {
     QList<DanmakuMatchCandidate> candidates;
     auto parseArray = [&](const QJsonArray &animeArray) {
         for (const QJsonValue &animeValue : animeArray) {
             const QJsonObject animeObj = animeValue.toObject();
+            const QString animeType =
+                stringField(animeObj, {"type", "animeType"});
+            if (excludeClearlyEpisodicWorks &&
+                isClearlyEpisodicAnimeType(animeType)) {
+                continue;
+            }
             const QString animeTitle = firstNonEmpty(
                 {stringField(animeObj, {"animeTitle", "title", "name"}),
                  stringField(animeObj, {"animeTitleCN", "animeTitleJP"})});
@@ -523,23 +809,6 @@ QList<DanmakuMatchCandidate> parseSearchResponse(const QJsonObject &response,
             if (episodes.isEmpty() &&
                 !animeObj.value(QStringLiteral("episodeId")).isUndefined()) {
                 episodes.append(animeObj);
-            }
-            if (episodes.isEmpty() &&
-                (!animeObj.value(QStringLiteral("animeId")).isUndefined() ||
-                 !animeObj.value(QStringLiteral("bangumiId")).isUndefined())) {
-                QJsonObject fallbackEpisodeObj = animeObj;
-                const QString animeIdStr = stringField(
-                    animeObj, {"animeId", "bangumiId"});
-                if (!animeIdStr.isEmpty()) {
-                    fallbackEpisodeObj.insert(
-                        QStringLiteral("episodeId"), animeIdStr);
-                }
-                if (fallbackEpisodeObj.value(
-                        QStringLiteral("episodeTitle")).isUndefined()) {
-                    fallbackEpisodeObj.insert(
-                        QStringLiteral("episodeTitle"), animeTitle);
-                }
-                episodes.append(fallbackEpisodeObj);
             }
 
             for (const QJsonValue &episodeValue : episodes) {
@@ -551,13 +820,24 @@ QList<DanmakuMatchCandidate> parseSearchResponse(const QJsonObject &response,
                 candidate.title = stringField(
                     episodeObj, {"episodeTitle", "title", "name", "episodeName"});
                 candidate.subtitle = animeTitle;
-                candidate.episodeNumber =
-                    intField(episodeObj, {"episodeNumber", "episode", "sort"}, -1);
+                candidate.seasonNumber = extractSeasonNumber(animeTitle);
+                candidate.episodeNumber = intField(
+                    episodeObj, {"episodeNumber", "episode", "sort"}, -1);
+                if (candidate.episodeNumber <= 0) {
+                    candidate.episodeNumber =
+                        extractEpisodeNumber(candidate.title);
+                }
+                if (candidate.episodeNumber <= 0 &&
+                    requestedEpisodeNumber > 0) {
+                    
+                    
+                    
+                    candidate.episodeNumber = requestedEpisodeNumber;
+                }
                 candidate.durationMs = longField(
                     episodeObj, {"durationMs", "duration", "videoDuration"}, 0);
-                if (candidate.durationMs > 0 && candidate.durationMs < 1000) {
-                    candidate.durationMs *= 1000;
-                }
+                candidate.durationMs = normalizeCandidateDurationMs(
+                    candidate.durationMs, context.durationMs);
                 candidate.commentCount = intField(
                     episodeObj, {"commentCount", "comments", "danmakuCount"}, 0);
                 candidate.score = computeScore(context, candidate, queryKeyword);
@@ -671,7 +951,8 @@ QList<DanmakuMatchCandidate> deduplicateCandidates(
 QList<DanmakuMatchCandidate> parseMatchResponse(
     const QJsonObject &response,
     const DanmakuMediaContext &context,
-    const QString &fileName)
+    const QString &fileName,
+    bool hashMatchRequest)
 {
     QList<DanmakuMatchCandidate> candidates;
     const bool isMatched = response.value(QStringLiteral("isMatched")).toBool();
@@ -693,32 +974,35 @@ QList<DanmakuMatchCandidate> parseMatchResponse(
             matchObj, {"episodeTitle", "title", "name", "episodeName"});
         candidate.subtitle = stringField(
             matchObj, {"animeTitle", "animeTitleCN", "animeName"});
+        candidate.seasonNumber = extractSeasonNumber(candidate.subtitle);
         candidate.episodeNumber =
             intField(matchObj, {"episodeNumber", "episode", "sort"}, -1);
+        if (candidate.episodeNumber <= 0) {
+            candidate.episodeNumber = extractEpisodeNumber(candidate.title);
+        }
         candidate.durationMs = longField(
             matchObj, {"durationMs", "duration", "videoDuration"}, 0);
-        if (candidate.durationMs > 0 && candidate.durationMs < 1000) {
-            candidate.durationMs *= 1000;
-        }
+        candidate.durationMs = normalizeCandidateDurationMs(
+            candidate.durationMs, context.durationMs);
         candidate.commentCount = intField(
             matchObj, {"commentCount", "comments", "danmakuCount"}, 0);
 
-        if (candidate.targetId.isEmpty()) {
-            const QString animeIdStr =
-                stringField(matchObj, {"animeId", "bangumiId"});
-            if (!animeIdStr.isEmpty()) {
-                candidate.targetId = animeIdStr;
-            }
-        }
         if (candidate.title.isEmpty()) {
             candidate.title = candidate.subtitle;
         }
 
         candidate.score = computeScore(context, candidate, fileName);
-        if (isMatched) {
-            candidate.score += 30.0;
+        if (isMatched && hashMatchRequest) {
+            candidate.score = qMax(candidate.score, 200.0);
+            candidate.matchReason = QStringLiteral("hash");
+        } else if (isMatched) {
+            
+            
+            candidate.score += 8.0;
+            candidate.matchReason = QStringLiteral("filename");
+        } else {
+            candidate.matchReason = QStringLiteral("match-candidate");
         }
-        candidate.matchReason = QStringLiteral("match");
         if (candidate.isValid()) {
             candidates.append(candidate);
         }
@@ -739,6 +1023,21 @@ DandanplayProvider::DandanplayProvider(NetworkManager *networkManager)
 {
 }
 
+QCoro::Task<DanmakuMediaContext> DandanplayProvider::enrichMediaFingerprint(
+    DanmakuMediaContext context) const
+{
+    if (!context.fileHash.trimmed().isEmpty() && context.fileSize > 0) {
+        co_return context;
+    }
+    const MediaFingerprint fingerprint =
+        co_await resolveMediaFingerprint(m_networkManager, context);
+    if (fingerprint.isValid()) {
+        context.fileHash = fingerprint.hash;
+        context.fileSize = fingerprint.fileSize;
+    }
+    co_return context;
+}
+
 QCoro::Task<QList<DanmakuMatchCandidate>> DandanplayProvider::searchCandidates(
     DanmakuMediaContext context,
     DanmakuProviderConfig config,
@@ -751,6 +1050,15 @@ QCoro::Task<QList<DanmakuMatchCandidate>> DandanplayProvider::searchCandidates(
 
     bool hadSuccessfulSearchResponse = false;
     QString lastSearchError;
+    const bool isManualSearch = !manualKeyword.trimmed().isEmpty();
+    const ManualSearchHint manualHint =
+        isManualSearch ? parseManualSearchHint(manualKeyword)
+                       : ManualSearchHint{};
+    DanmakuMediaContext searchContext = context;
+    if (isManualSearch && manualHint.hasExplicitEpisode) {
+        searchContext.seasonNumber = manualHint.seasonNumber;
+        searchContext.episodeNumber = manualHint.episodeNumber;
+    }
 
     
     
@@ -760,8 +1068,31 @@ QCoro::Task<QList<DanmakuMatchCandidate>> DandanplayProvider::searchCandidates(
     
     
     QStringList keywords;
-    if (!manualKeyword.trimmed().isEmpty()) {
-        keywords << manualKeyword.trimmed();
+    QString manualSubject;
+    if (isManualSearch) {
+        manualSubject = firstNonEmpty(
+            {manualHint.keyword,
+             searchContext.isEpisode() ? searchContext.seriesName
+                                       : searchContext.title});
+        
+        
+        
+        if (searchContext.isEpisode()) {
+            searchContext.seriesName = manualSubject;
+        } else {
+            searchContext.title = manualSubject;
+        }
+        searchContext.originalTitle.clear();
+        if (searchContext.isEpisode() && searchContext.seasonNumber > 1 &&
+            extractSeasonNumber(manualSubject) <= 0) {
+            const QString ordinal =
+                chineseOrdinalString(searchContext.seasonNumber);
+            if (!ordinal.isEmpty()) {
+                keywords << QStringLiteral("%1 第%2季")
+                                .arg(manualSubject, ordinal);
+            }
+        }
+        keywords << manualSubject;
     } else if (context.isEpisode()) {
         const QString trimmedSeries = context.seriesName.trimmed();
         const QString trimmedOriginal = context.originalTitle.trimmed();
@@ -797,13 +1128,40 @@ QCoro::Task<QList<DanmakuMatchCandidate>> DandanplayProvider::searchCandidates(
     keywords = normalizedKeywords;
     keywords.removeDuplicates();
 
-    const QString tmdbId = providerIdValue(
-        context.providerIds, {"Tmdb", "tmdb", "TMDb", "tmdbid"});
+    const QString currentSubject =
+        context.isEpisode() ? context.seriesName.trimmed()
+                            : context.title.trimmed();
+    const bool manualTargetsCurrentMedia =
+        isManualSearch && !manualSubject.isEmpty() &&
+        titleScore(manualSubject, currentSubject) >= 0.92;
+    
+    
+    
+    const QString tmdbId =
+        (!isManualSearch || manualTargetsCurrentMedia)
+            ? providerIdValue(context.providerIds,
+                              {"Tmdb", "tmdb", "TMDb", "tmdbid"})
+            : QString();
+    const bool strongLookupOnly =
+        manualKeyword.trimmed().isEmpty() &&
+        isExplicitlyNonAnime(context, config);
 
     const QString filePath = context.path.trimmed();
-    const QString fileName =
-        filePath.isEmpty() ? QString()
-                           : QFileInfo(filePath).fileName().trimmed();
+    QString normalizedFilePath = filePath;
+    const QUrl filePathUrl = QUrl::fromUserInput(normalizedFilePath);
+    if (filePathUrl.scheme().compare(QStringLiteral("http"),
+                                     Qt::CaseInsensitive) == 0 ||
+        filePathUrl.scheme().compare(QStringLiteral("https"),
+                                     Qt::CaseInsensitive) == 0) {
+        normalizedFilePath = filePathUrl.path();
+    }
+    normalizedFilePath.replace(QLatin1Char('\\'), QLatin1Char('/'));
+    const QString fileName = firstNonEmpty(
+        {context.fileName, filePath.isEmpty()
+                               ? QString()
+                               : QFileInfo(normalizedFilePath)
+                                     .completeBaseName()
+                                     .trimmed()});
 
     qDebug().noquote()
         << "[Danmaku][DandanPlay] Search start"
@@ -813,30 +1171,56 @@ QCoro::Task<QList<DanmakuMatchCandidate>> DandanplayProvider::searchCandidates(
         << "| seriesName:" << context.seriesName.trimmed()
         << "| seasonNumber:" << context.seasonNumber
         << "| episodeNumber:" << context.episodeNumber
+        << "| requestedSeason:" << searchContext.seasonNumber
+        << "| requestedEpisode:" << searchContext.episodeNumber
+        << "| explicitManualEpisode:" << manualHint.hasExplicitEpisode
+        << "| manualTargetsCurrentMedia:" << manualTargetsCurrentMedia
+        << "| tmdbConstraint:" << !tmdbId.isEmpty()
         << "| contentScope:" << config.contentScope
         << "| fileName:" << fileName
         << "| keywords:" << keywords.join(QStringLiteral(" | "));
 
-    if (!fileName.isEmpty() && manualKeyword.trimmed().isEmpty()) {
+    MediaFingerprint fingerprint;
+    if (manualKeyword.trimmed().isEmpty()) {
+        fingerprint = co_await resolveMediaFingerprint(m_networkManager, context);
+    }
+    if (manualKeyword.trimmed().isEmpty() &&
+        (!fileName.isEmpty() || fingerprint.isValid())) {
         try {
+            const bool useHashMatch = fingerprint.isValid();
             const QString matchPath = QStringLiteral("/api/v2/match");
             ensureOfficialAuthentication(config, matchPath);
             QJsonObject payload;
             payload.insert(QStringLiteral("fileName"), fileName);
-            payload.insert(QStringLiteral("fileHash"), QString());
-            payload.insert(QStringLiteral("fileSize"), 0);
+            payload.insert(QStringLiteral("fileHash"), fingerprint.hash);
+            payload.insert(QStringLiteral("fileSize"), fingerprint.fileSize);
+            payload.insert(
+                QStringLiteral("videoDuration"),
+                context.durationMs > 0
+                    ? static_cast<int>(qMin<qint64>(
+                          context.durationMs / 1000,
+                          std::numeric_limits<int>::max()))
+                    : 0);
             payload.insert(QStringLiteral("matchMode"),
-                           QStringLiteral("fileNameOnly"));
+                           useHashMatch
+                               ? (fileName.isEmpty()
+                                      ? QStringLiteral("hashOnly")
+                                      : QStringLiteral("hashAndFileName"))
+                               : QStringLiteral("fileNameOnly"));
             const QString matchUrl = buildUrl(config, matchPath, {});
             qDebug().noquote()
                 << "[Danmaku][DandanPlay] Match request"
                 << "| fileName:" << fileName
+                << "| hashAvailable:" << useHashMatch
+                << "| fileSize:" << fingerprint.fileSize
                 << "| url:" << matchUrl;
             const QJsonObject matchResponse = co_await m_networkManager->post(
-                matchUrl, buildHeaders(config, matchPath), payload);
+                matchUrl, buildHeaders(config, matchPath), payload,
+                danmakuRequestOptions());
             hadSuccessfulSearchResponse = true;
             const QList<DanmakuMatchCandidate> matchCandidates =
-                parseMatchResponse(matchResponse, context, fileName);
+                parseMatchResponse(matchResponse, context, fileName,
+                                   useHashMatch);
             qDebug().noquote()
                 << "[Danmaku][DandanPlay] Match result"
                 << "| fileName:" << fileName
@@ -844,7 +1228,18 @@ QCoro::Task<QList<DanmakuMatchCandidate>> DandanplayProvider::searchCandidates(
                 << matchResponse.value(QStringLiteral("isMatched")).toBool()
                 << "| count:" << matchCandidates.size();
             if (!matchCandidates.isEmpty()) {
-                allCandidates.append(matchCandidates);
+                if (matchCandidates.first().isHashMatch()) {
+                    allCandidates.append(matchCandidates);
+                    qDebug().noquote()
+                        << "[Danmaku][DandanPlay] Verified hash match found,"
+                           " skipping title searches"
+                        << "| mediaId:" << context.mediaId
+                        << "| targetId:" << matchCandidates.first().targetId;
+                    co_return deduplicateCandidates(allCandidates);
+                }
+                if (!strongLookupOnly) {
+                    allCandidates.append(matchCandidates);
+                }
             }
         } catch (const std::exception &e) {
             const QString errorMessage =
@@ -860,122 +1255,116 @@ QCoro::Task<QList<DanmakuMatchCandidate>> DandanplayProvider::searchCandidates(
         }
     }
 
-    for (const QString &keyword : std::as_const(keywords)) {
-        QList<DanmakuMatchCandidate> keywordCandidates;
-        try {
-            const QString apiPath = QStringLiteral("/api/v2/search/episodes");
-            ensureOfficialAuthentication(config, apiPath);
-            QList<QPair<QString, QString>> queryItems;
-            queryItems.append({QStringLiteral("anime"), keyword});
-            if (context.isEpisode()) {
-                if (context.episodeNumber > 0) {
-                    queryItems.append({QStringLiteral("episode"),
-                                       QString::number(context.episodeNumber)});
-                }
-                if (!tmdbId.isEmpty()) {
-                    queryItems.append({QStringLiteral("tmdbId"), tmdbId});
-                }
-            }
+    if (strongLookupOnly && tmdbId.isEmpty()) {
+        qDebug().noquote()
+            << "[Danmaku][DandanPlay] Skipping fuzzy title search for non-anime media"
+            << "| mediaId:" << context.mediaId;
+        co_return deduplicateCandidates(allCandidates);
+    }
 
-            const QString url = buildUrl(config, apiPath, queryItems);
-            qDebug().noquote()
-                << "[Danmaku][DandanPlay] Search request"
-                << "| path:" << apiPath
-                << "| keyword:" << keyword
-                << "| url:" << url;
-            const QJsonObject response =
-                co_await m_networkManager->get(url, buildHeaders(config, apiPath));
-            hadSuccessfulSearchResponse = true;
-            keywordCandidates =
-                parseSearchResponse(response, context, keyword);
-            if (!keywordCandidates.isEmpty()) {
-                qDebug().noquote()
-                    << "[Danmaku][DandanPlay] Search hit"
-                    << "| path:" << apiPath
+    QString requestedEpisodeParameter;
+    int requestedEpisodeNumber = -1;
+    if (searchContext.isEpisode() && searchContext.episodeNumber > 0) {
+        requestedEpisodeNumber = searchContext.episodeNumber;
+        requestedEpisodeParameter =
+            searchContext.seasonNumber == 0
+                ? QStringLiteral("S%1").arg(searchContext.episodeNumber)
+                : QString::number(searchContext.episodeNumber);
+    } else if (!searchContext.isEpisode()) {
+        requestedEpisodeNumber = 1;
+        requestedEpisodeParameter = QStringLiteral("1");
+    }
+
+    if (!keywords.isEmpty()) {
+        const QString apiPath = QStringLiteral("/api/v2/search/episodes");
+        ensureOfficialAuthentication(config, apiPath);
+        QList<NetworkJsonGetRequest> requests;
+        requests.reserve(keywords.size());
+        for (const QString &keyword : std::as_const(keywords)) {
+            QList<QPair<QString, QString>> queryItems = {
+                {QStringLiteral("anime"), keyword},
+                {QStringLiteral("v2"), QStringLiteral("true")}};
+            if (!requestedEpisodeParameter.isEmpty()) {
+                queryItems.append({QStringLiteral("episode"),
+                                   requestedEpisodeParameter});
+            }
+            if (!tmdbId.isEmpty()) {
+                queryItems.append({QStringLiteral("tmdbId"), tmdbId});
+                queryItems.append(
+                    {QStringLiteral("tmdbIdType"),
+                     context.isEpisode() ? QStringLiteral("0")
+                                         : QStringLiteral("1")});
+            }
+            requests.append({buildUrl(config, apiPath, queryItems),
+                             buildHeaders(config, apiPath),
+                             danmakuRequestOptions()});
+        }
+
+        qDebug().noquote()
+            << "[Danmaku][DandanPlay] Parallel episode search"
+            << "| requestCount:" << requests.size()
+            << "| episodeParameter:" << requestedEpisodeParameter
+            << "| keywords:" << keywords.join(QStringLiteral(" | "));
+        const QList<NetworkJsonResult> responses =
+            co_await m_networkManager->getBatch(requests);
+        for (int i = 0; i < responses.size(); ++i) {
+            const QString keyword = keywords.value(i);
+            const NetworkJsonResult &response = responses.at(i);
+            if (!response.succeeded()) {
+                lastSearchError = response.errorMessage;
+                qWarning().noquote()
+                    << "[Danmaku][DandanPlay] Episode search failed"
                     << "| keyword:" << keyword
-                    << "| count:" << keywordCandidates.size();
-                allCandidates.append(keywordCandidates);
+                    << "| error:" << response.errorMessage;
+                continue;
             }
-        } catch (const std::exception &e) {
-            const QString errorMessage = QString::fromUtf8(e.what()).trimmed();
-            if (isMissingCredentialsErrorMessage(errorMessage)) {
-                throw;
-            }
-            lastSearchError = errorMessage;
-            qWarning().noquote()
-                << "[Danmaku][DandanPlay] Search request failed"
-                << "| keyword:" << keyword
-                << "| path: /api/v2/search/episodes"
-                << "| error:" << errorMessage;
-        }
-
-        if (!keywordCandidates.isEmpty()) {
-            
-            
-            
-            if (context.isEpisode() && context.seasonNumber > 0 &&
-                context.episodeNumber > 0) {
-                bool hasConfidentMatch = false;
-                for (const DanmakuMatchCandidate &c : keywordCandidates) {
-                    const QString candidateSubject =
-                        c.subtitle.isEmpty() ? c.title : c.subtitle;
-                    const int candidateSeason =
-                        extractSeasonNumber(candidateSubject);
-                    const bool seasonHit =
-                        candidateSeason == context.seasonNumber ||
-                        (candidateSeason == 0 && context.seasonNumber == 1);
-                    const bool episodeHit =
-                        c.episodeNumber == context.episodeNumber;
-                    if (seasonHit && episodeHit && c.score >= 60.0) {
-                        hasConfidentMatch = true;
-                        break;
-                    }
-                }
-                if (hasConfidentMatch) {
-                    qDebug().noquote()
-                        << "[Danmaku][DandanPlay] Confident match found,"
-                           " skipping remaining keywords"
-                        << "| keyword:" << keyword
-                        << "| seasonNumber:" << context.seasonNumber
-                        << "| episodeNumber:" << context.episodeNumber;
-                    break;
-                }
-            }
-            continue;
-        }
-
-        const QString fallbackPath = QStringLiteral("/api/v2/search/anime");
-        const QString fallbackUrl = buildUrl(
-            config, fallbackPath, {{QStringLiteral("keyword"), keyword}});
-        try {
-            ensureOfficialAuthentication(config, fallbackPath);
-            qDebug().noquote()
-                << "[Danmaku][DandanPlay] Search fallback request"
-                << "| path:" << fallbackPath
-                << "| keyword:" << keyword
-                << "| url:" << fallbackUrl;
-            const QJsonObject fallbackResponse =
-                co_await m_networkManager->get(
-                    fallbackUrl, buildHeaders(config, fallbackPath));
             hadSuccessfulSearchResponse = true;
-            const QList<DanmakuMatchCandidate> fallbackCandidates =
-                parseSearchResponse(fallbackResponse, context, keyword);
-            qDebug().noquote()
-                << "[Danmaku][DandanPlay] Search fallback result"
-                << "| keyword:" << keyword
-                << "| count:" << fallbackCandidates.size();
-            allCandidates.append(fallbackCandidates);
-        } catch (const std::exception &e) {
-            const QString errorMessage = QString::fromUtf8(e.what()).trimmed();
-            if (isMissingCredentialsErrorMessage(errorMessage)) {
-                throw;
+            QList<DanmakuMatchCandidate> candidates =
+                parseSearchResponse(
+                    response.object, searchContext, keyword,
+                    requestedEpisodeNumber,
+                    !searchContext.isEpisode());
+            if (searchContext.isEpisode()) {
+                candidates.erase(
+                    std::remove_if(
+                        candidates.begin(), candidates.end(),
+                        [&searchContext](const DanmakuMatchCandidate &candidate) {
+                            if (searchContext.episodeNumber > 0 &&
+                                candidate.episodeNumber > 0 &&
+                                candidate.episodeNumber !=
+                                    searchContext.episodeNumber) {
+                                return true;
+                            }
+                            if (searchContext.seasonNumber > 0 &&
+                                candidate.seasonNumber > 0 &&
+                                candidate.seasonNumber !=
+                                    searchContext.seasonNumber) {
+                                return true;
+                            }
+                            return searchContext.seasonNumber > 1 &&
+                                   candidate.seasonNumber <= 0;
+                        }),
+                    candidates.end());
             }
-            lastSearchError = errorMessage;
-            qWarning().noquote()
-                << "[Danmaku][DandanPlay] Search fallback failed"
-                << "| keyword:" << keyword
-                << "| path:" << fallbackPath
-                << "| error:" << errorMessage;
+            if (!tmdbId.isEmpty()) {
+                for (DanmakuMatchCandidate &candidate : candidates) {
+                    candidate.matchReason = QStringLiteral("tmdb");
+                    candidate.score = qMax(candidate.score, 160.0);
+                }
+            }
+            if (!candidates.isEmpty()) {
+                allCandidates.append(candidates);
+                qDebug().noquote()
+                    << "[Danmaku][DandanPlay] Episode search hit"
+                    << "| keyword:" << keyword
+                    << "| count:" << candidates.size();
+            }
+            if (response.object.value(QStringLiteral("hasMore")).toBool()) {
+                qWarning().noquote()
+                    << "[Danmaku][DandanPlay] Search result truncated by server"
+                    << "| keyword:" << keyword
+                    << "| returnedCount:" << candidates.size();
+            }
         }
     }
 
@@ -993,7 +1382,7 @@ QCoro::Task<QList<DanmakuMatchCandidate>> DandanplayProvider::searchCandidates(
         << "| deduplicatedCount:" << deduplicated.size();
 
     
-    if (context.isEpisode() && !deduplicated.isEmpty()) {
+    if (!deduplicated.isEmpty()) {
         const int topN = std::min<int>(deduplicated.size(), 5);
         for (int i = 0; i < topN; ++i) {
             const DanmakuMatchCandidate &c = deduplicated.at(i);
@@ -1014,6 +1403,7 @@ QCoro::Task<QList<DanmakuMatchCandidate>> DandanplayProvider::searchCandidates(
                 << (context.episodeNumber > 0 && c.episodeNumber > 0 &&
                     c.episodeNumber == context.episodeNumber)
                 << "| score:" << c.score
+                << "| matchReason:" << c.matchReason
                 << "| commentCount:" << c.commentCount;
         }
     }
@@ -1043,7 +1433,8 @@ QCoro::Task<QList<DanmakuComment>> DandanplayProvider::fetchComments(
         << "| withRelated:" << config.withRelated
         << "| url:" << url;
     const QJsonObject response =
-        co_await m_networkManager->get(url, buildHeaders(config, apiPath));
+        co_await m_networkManager->get(url, buildHeaders(config, apiPath),
+                                      danmakuRequestOptions());
     comments = parseCommentsResponse(response);
     qDebug().noquote()
         << "[Danmaku][DandanPlay] Fetch comments result"

--- a/src/qEmbyCore/services/danmaku/dandanplayprovider.h
+++ b/src/qEmbyCore/services/danmaku/dandanplayprovider.h
@@ -9,6 +9,9 @@ class DandanplayProvider
 public:
     explicit DandanplayProvider(NetworkManager *networkManager);
 
+    QCoro::Task<DanmakuMediaContext> enrichMediaFingerprint(
+        DanmakuMediaContext context) const;
+
     QCoro::Task<QList<DanmakuMatchCandidate>> searchCandidates(
         DanmakuMediaContext context,
         DanmakuProviderConfig config,

--- a/src/qEmbyCore/services/danmaku/danmakucachestore.cpp
+++ b/src/qEmbyCore/services/danmaku/danmakucachestore.cpp
@@ -7,6 +7,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QSaveFile>
 #include <QStandardPaths>
 
 namespace {
@@ -95,53 +96,154 @@ QString commentCacheKey(const QString &provider,
 
 bool DanmakuCacheStore::loadMatch(const DanmakuMediaContext &context,
                                   DanmakuMatchCandidate *candidate,
-                                  bool *manualOverride) const
+                                  bool *manualOverride,
+                                  int automaticMaxAgeHours) const
 {
     if (!candidate) {
         return false;
     }
 
-    QFile file(matchesFilePath(context.serverId));
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        return false;
+    QJsonObject entry;
+    bool loadedLegacyEntry = false;
+    QFile entryFile(matchEntryFilePath(context));
+    if (entryFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        entry = QJsonDocument::fromJson(entryFile.readAll()).object();
+    } else {
+        
+        QFile legacyFile(matchesFilePath(context.serverId));
+        if (!legacyFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            return false;
+        }
+        const QJsonObject legacyRoot =
+            QJsonDocument::fromJson(legacyFile.readAll()).object();
+        entry = legacyRoot.value(context.cacheKey()).toObject();
+        loadedLegacyEntry = !entry.isEmpty();
     }
-
-    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
-    const QJsonObject root = doc.object();
-    const QJsonObject entry = root.value(context.cacheKey()).toObject();
     if (entry.isEmpty()) {
         return false;
     }
 
+    const bool isManual = entry.value("manualOverride").toBool(false);
+    const qint64 cachedMediaFileSize =
+        entry.value("mediaFileSize").toVariant().toLongLong();
+    const QDateTime cachedMediaModifiedAt = QDateTime::fromString(
+        entry.value("mediaModifiedAt").toString(), Qt::ISODate);
+    if (context.fileSize > 0 && cachedMediaFileSize > 0 &&
+        context.fileSize != cachedMediaFileSize) {
+        return false;
+    }
+    if (context.mediaModifiedAt.isValid() && cachedMediaModifiedAt.isValid() &&
+        context.mediaModifiedAt != cachedMediaModifiedAt) {
+        return false;
+    }
+    if (!isManual) {
+        const int algorithmVersion = entry.value("algorithmVersion").toInt(0);
+        const QDateTime updatedAt = QDateTime::fromString(
+            entry.value("updatedAt").toString(), Qt::ISODate);
+        const qint64 maximumAgeSeconds =
+            static_cast<qint64>(automaticMaxAgeHours) * 3600;
+        if (algorithmVersion != CurrentMatchAlgorithmVersion ||
+            !updatedAt.isValid() || automaticMaxAgeHours <= 0 ||
+            updatedAt.secsTo(QDateTime::currentDateTimeUtc()) >
+                maximumAgeSeconds) {
+            return false;
+        }
+    }
+
     *candidate = candidateFromJson(entry.value("candidate").toObject());
     if (manualOverride) {
-        *manualOverride = entry.value("manualOverride").toBool(false);
+        *manualOverride = isManual;
     }
-    return candidate->isValid();
+    const bool valid = candidate->isValid();
+    if (valid && loadedLegacyEntry && isManual) {
+        saveMatch(context, *candidate, true);
+    }
+    return valid;
 }
 
 void DanmakuCacheStore::saveMatch(const DanmakuMediaContext &context,
                                   const DanmakuMatchCandidate &candidate,
                                   bool manualOverride) const
 {
-    const QString filePath = matchesFilePath(context.serverId);
+    const QString filePath = matchEntryFilePath(context);
     ensureParentDir(filePath);
-
-    QJsonObject root;
-    QFile file(filePath);
-    if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        root = QJsonDocument::fromJson(file.readAll()).object();
-        file.close();
-    }
-
     QJsonObject entry;
     entry["candidate"] = candidateToJson(candidate);
     entry["manualOverride"] = manualOverride;
+    entry["algorithmVersion"] = CurrentMatchAlgorithmVersion;
+    entry["mediaFileSize"] = QString::number(context.fileSize);
+    entry["mediaModifiedAt"] = context.mediaModifiedAt.toString(Qt::ISODate);
     entry["updatedAt"] = QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
-    root[context.cacheKey()] = entry;
+    QSaveFile file(filePath);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        file.write(QJsonDocument(entry).toJson(QJsonDocument::Compact));
+        file.commit();
+    }
+}
 
-    if (file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
-        file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+void DanmakuCacheStore::removeMatch(const DanmakuMediaContext &context) const
+{
+    const QString filePath = matchEntryFilePath(context);
+    if (!filePath.isEmpty() && QFile::exists(filePath) &&
+        !QFile::remove(filePath)) {
+        qWarning().noquote()
+            << "[Danmaku][Cache] Failed to remove match entry"
+            << "| mediaId:" << context.mediaId
+            << "| sourceId:" << context.mediaSourceId;
+    }
+}
+
+bool DanmakuCacheStore::loadFingerprint(const DanmakuMediaContext &context,
+                                        QString *fileHash,
+                                        int maxAgeHours) const
+{
+    if (!fileHash || context.fileSize <= 0) {
+        return false;
+    }
+    QFile file(fingerprintEntryFilePath(context));
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return false;
+    }
+    const QJsonObject entry = QJsonDocument::fromJson(file.readAll()).object();
+    const QDateTime updatedAt = QDateTime::fromString(
+        entry.value("updatedAt").toString(), Qt::ISODate);
+    const qint64 cachedSize =
+        entry.value("fileSize").toVariant().toLongLong();
+    const QString cachedHash = entry.value("fileHash").toString().trimmed();
+    const QDateTime cachedMediaModifiedAt = QDateTime::fromString(
+        entry.value("mediaModifiedAt").toString(), Qt::ISODate);
+    if (cachedSize != context.fileSize || cachedHash.size() != 32 ||
+        !updatedAt.isValid() || maxAgeHours <= 0 ||
+        updatedAt.secsTo(QDateTime::currentDateTimeUtc()) >
+            static_cast<qint64>(maxAgeHours) * 3600) {
+        return false;
+    }
+    if (context.mediaModifiedAt.isValid() && cachedMediaModifiedAt.isValid() &&
+        context.mediaModifiedAt != cachedMediaModifiedAt) {
+        return false;
+    }
+    *fileHash = cachedHash;
+    return true;
+}
+
+void DanmakuCacheStore::saveFingerprint(const DanmakuMediaContext &context,
+                                        const QString &fileHash) const
+{
+    const QString normalizedHash = fileHash.trimmed().toLower();
+    if (context.fileSize <= 0 || normalizedHash.size() != 32) {
+        return;
+    }
+    const QString filePath = fingerprintEntryFilePath(context);
+    ensureParentDir(filePath);
+    QJsonObject entry;
+    entry["fileSize"] = QString::number(context.fileSize);
+    entry["fileHash"] = normalizedHash;
+    entry["updatedAt"] = QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
+    entry["mediaModifiedAt"] = context.mediaModifiedAt.toString(Qt::ISODate);
+    QSaveFile file(filePath);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        file.write(QJsonDocument(entry).toJson(QJsonDocument::Compact));
+        file.commit();
     }
 }
 
@@ -262,6 +364,30 @@ QString DanmakuCacheStore::baseDirPath() const
 QString DanmakuCacheStore::matchesFilePath(const QString &serverId) const
 {
     return baseDirPath() + QStringLiteral("/matches/%1.json").arg(serverId);
+}
+
+QString DanmakuCacheStore::matchEntryFilePath(
+    const DanmakuMediaContext &context) const
+{
+    const QByteArray rawKey =
+        QStringLiteral("%1|%2").arg(context.serverId, context.cacheKey()).toUtf8();
+    const QString hashedKey = QString::fromLatin1(
+        QCryptographicHash::hash(rawKey, QCryptographicHash::Sha1).toHex());
+    return baseDirPath() +
+           QStringLiteral("/matches-v2/%1/%2.json")
+               .arg(context.serverId, hashedKey);
+}
+
+QString DanmakuCacheStore::fingerprintEntryFilePath(
+    const DanmakuMediaContext &context) const
+{
+    const QByteArray rawKey =
+        QStringLiteral("%1|%2").arg(context.serverId, context.cacheKey()).toUtf8();
+    const QString hashedKey = QString::fromLatin1(
+        QCryptographicHash::hash(rawKey, QCryptographicHash::Sha1).toHex());
+    return baseDirPath() +
+           QStringLiteral("/fingerprints/%1/%2.json")
+               .arg(context.serverId, hashedKey);
 }
 
 QString DanmakuCacheStore::commentsFilePath(const QString &provider,

--- a/src/qEmbyCore/services/danmaku/danmakucachestore.h
+++ b/src/qEmbyCore/services/danmaku/danmakucachestore.h
@@ -8,14 +8,25 @@
 class DanmakuCacheStore
 {
 public:
+    static constexpr int CurrentMatchAlgorithmVersion = 2;
+    static constexpr int AutomaticMatchMaxAgeHours = 24 * 30;
+
     DanmakuCacheStore() = default;
 
     bool loadMatch(const DanmakuMediaContext &context,
                    DanmakuMatchCandidate *candidate,
-                   bool *manualOverride) const;
+                   bool *manualOverride,
+                   int automaticMaxAgeHours = AutomaticMatchMaxAgeHours) const;
     void saveMatch(const DanmakuMediaContext &context,
                    const DanmakuMatchCandidate &candidate,
                    bool manualOverride) const;
+    void removeMatch(const DanmakuMediaContext &context) const;
+
+    bool loadFingerprint(const DanmakuMediaContext &context,
+                         QString *fileHash,
+                         int maxAgeHours = 24 * 30) const;
+    void saveFingerprint(const DanmakuMediaContext &context,
+                         const QString &fileHash) const;
 
     QList<DanmakuComment> loadComments(const QString &provider,
                                        const QString &cacheScope,
@@ -37,6 +48,8 @@ public:
 private:
     QString baseDirPath() const;
     QString matchesFilePath(const QString &serverId) const;
+    QString matchEntryFilePath(const DanmakuMediaContext &context) const;
+    QString fingerprintEntryFilePath(const DanmakuMediaContext &context) const;
     QString commentsFilePath(const QString &provider,
                              const QString &cacheScope,
                              const QString &targetId) const;

--- a/src/qEmbyCore/services/danmaku/danmakuservice.cpp
+++ b/src/qEmbyCore/services/danmaku/danmakuservice.cpp
@@ -1,34 +1,42 @@
 #include "danmakuservice.h"
 
-#include "danmakuasscomposer.h"
-#include "danmakucachestore.h"
-#include "dandanplayprovider.h"
-#include "danmakusettings.h"
 #include "../../api/networkmanager.h"
 #include "../../config/config_keys.h"
 #include "../../config/configstore.h"
 #include "../manager/servermanager.h"
+#include "dandanplayprovider.h"
+#include "danmakuasscomposer.h"
+#include "danmakucachestore.h"
+#include "danmakusettings.h"
+#include "danmuapiprovider.h"
 
 #include <QCoreApplication>
 #include <QCryptographicHash>
+#include <QDebug>
 #include <QDir>
 #include <QDirIterator>
-#include <QDebug>
 #include <QFile>
 #include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QPromise>
 #include <QRegularExpression>
+#include <QSet>
+#include <QSharedPointer>
 #include <QStandardPaths>
 #include <QXmlStreamReader>
 #include <QtConcurrent/QtConcurrent>
-#include <qcorofuture.h>
 #include <algorithm>
 #include <exception>
+#include <qcorofuture.h>
 #include <stdexcept>
+#include <utility>
 
-namespace {
+namespace
+{
 
 constexpr auto kLocalDanmakuProvider = "local-file";
 constexpr auto kDanmakuSourceModePreferOnline = "prefer-online";
@@ -42,7 +50,8 @@ QStringList parseBlockedKeywords(const QString &value)
     QString normalized = value;
     normalized.replace('\n', ',');
     QStringList parts = normalized.split(',', Qt::SkipEmptyParts);
-    for (QString &part : parts) {
+    for (QString &part : parts)
+    {
         part = part.trimmed();
     }
     parts.removeAll(QString());
@@ -63,23 +72,20 @@ QString preferredProviderTitle(const DanmakuMatchCandidate &candidate)
 QString safeDirectoryComponent(QString value)
 {
     value = value.trimmed();
-    value.replace(QRegularExpression(QStringLiteral(R"([^A-Za-z0-9._-])")),
-                  QStringLiteral("_"));
+    value.replace(QRegularExpression(QStringLiteral(R"([^A-Za-z0-9._-])")), QStringLiteral("_"));
     return value.isEmpty() ? QStringLiteral("default") : value;
 }
 
 QString legacyLocalDanmakuRootPath()
 {
-    return QStandardPaths::writableLocation(
-               QStandardPaths::AppLocalDataLocation) +
-           QStringLiteral("/danmaku/local");
+    return QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + QStringLiteral("/danmaku/local");
 }
 
 QString preferredLocalDanmakuRootPath()
 {
-    const QString appDir =
-        QDir::cleanPath(QCoreApplication::applicationDirPath());
-    if (appDir.isEmpty()) {
+    const QString appDir = QDir::cleanPath(QCoreApplication::applicationDirPath());
+    if (appDir.isEmpty())
+    {
         return legacyLocalDanmakuRootPath();
     }
 
@@ -88,40 +94,43 @@ QString preferredLocalDanmakuRootPath()
 
 QString legacyLocalDanmakuDirectoryPath(QString serverId)
 {
-    return QDir(legacyLocalDanmakuRootPath())
-        .filePath(safeDirectoryComponent(serverId));
+    return QDir(legacyLocalDanmakuRootPath()).filePath(safeDirectoryComponent(serverId));
 }
 
-bool copyDirectoryRecursively(const QString &sourcePath,
-                              const QString &targetPath)
+bool copyDirectoryRecursively(const QString &sourcePath, const QString &targetPath)
 {
     const QDir sourceDir(sourcePath);
-    if (!sourceDir.exists()) {
+    if (!sourceDir.exists())
+    {
         return false;
     }
 
-    if (!QDir().mkpath(targetPath)) {
+    if (!QDir().mkpath(targetPath))
+    {
         return false;
     }
 
-    const QFileInfoList entries = sourceDir.entryInfoList(
-        QDir::NoDotAndDotDot | QDir::AllEntries);
-    for (const QFileInfo &entry : entries) {
+    const QFileInfoList entries = sourceDir.entryInfoList(QDir::NoDotAndDotDot | QDir::AllEntries);
+    for (const QFileInfo &entry : entries)
+    {
         const QString sourceEntryPath = entry.absoluteFilePath();
-        const QString targetEntryPath =
-            QDir(targetPath).filePath(entry.fileName());
+        const QString targetEntryPath = QDir(targetPath).filePath(entry.fileName());
 
-        if (entry.isDir()) {
-            if (!copyDirectoryRecursively(sourceEntryPath, targetEntryPath)) {
+        if (entry.isDir())
+        {
+            if (!copyDirectoryRecursively(sourceEntryPath, targetEntryPath))
+            {
                 return false;
             }
             continue;
         }
 
-        if (QFile::exists(targetEntryPath)) {
+        if (QFile::exists(targetEntryPath))
+        {
             continue;
         }
-        if (!QFile::copy(sourceEntryPath, targetEntryPath)) {
+        if (!QFile::copy(sourceEntryPath, targetEntryPath))
+        {
             return false;
         }
     }
@@ -131,9 +140,9 @@ bool copyDirectoryRecursively(const QString &sourcePath,
 QString normalizedSourceMode(QString value)
 {
     value = value.trimmed().toLower();
-    if (value == QLatin1String(kDanmakuSourceModePreferLocal) ||
-        value == QLatin1String(kDanmakuSourceModeOnlineOnly) ||
-        value == QLatin1String(kDanmakuSourceModeLocalOnly)) {
+    if (value == QLatin1String(kDanmakuSourceModePreferLocal) || value == QLatin1String(kDanmakuSourceModeOnlineOnly) ||
+        value == QLatin1String(kDanmakuSourceModeLocalOnly))
+    {
         return value;
     }
     return QString::fromLatin1(kDanmakuSourceModePreferLocal);
@@ -142,7 +151,8 @@ QString normalizedSourceMode(QString value)
 QString cacheScopeForConfig(const DanmakuProviderConfig &config)
 {
     const QString endpointId = config.endpointId.trimmed();
-    if (!endpointId.isEmpty()) {
+    if (!endpointId.isEmpty())
+    {
         return endpointId;
     }
     return config.baseUrl.trimmed().toLower();
@@ -151,7 +161,8 @@ QString cacheScopeForConfig(const DanmakuProviderConfig &config)
 QString endpointDisplayName(const DanmakuProviderConfig &config)
 {
     const QString endpointName = config.endpointName.trimmed();
-    if (!endpointName.isEmpty()) {
+    if (!endpointName.isEmpty())
+    {
         return endpointName;
     }
 
@@ -159,80 +170,82 @@ QString endpointDisplayName(const DanmakuProviderConfig &config)
     return baseUrl.isEmpty() ? config.provider.trimmed() : baseUrl;
 }
 
-DanmakuProviderConfig providerConfigFromServerDefinition(
-    const DanmakuServerDefinition &server,
-    const QString &serverId,
-    bool allowLegacyCredentialFallback)
+DanmakuProviderConfig providerConfigFromServerDefinition(const DanmakuServerDefinition &server, const QString &serverId,
+                                                         bool allowLegacyCredentialFallback)
 {
     auto *store = ConfigStore::instance();
     DanmakuProviderConfig config;
-    config.provider = server.provider.trimmed().isEmpty()
-                          ? QStringLiteral("dandanplay")
-                          : server.provider.trimmed();
-    config.baseUrl = server.baseUrl.trimmed().isEmpty()
-                         ? QStringLiteral("https://api.dandanplay.net")
-                         : server.baseUrl.trimmed();
+    config.provider =
+        server.provider.trimmed().isEmpty() ? QStringLiteral("dandanplay") : server.provider.trimmed().toLower();
+    config.baseUrl =
+        server.baseUrl.trimmed().isEmpty() ? QStringLiteral("https://api.dandanplay.net") : server.baseUrl.trimmed();
     config.endpointId = server.id.trimmed();
     config.endpointName = server.displayName();
     config.enabled = server.enabled;
     config.appId = server.appId.trimmed();
     config.appSecret = server.appSecret.trimmed();
+    config.accessToken = server.accessToken.trimmed();
 
-    if (server.builtIn) {
+    if (server.builtIn)
+    {
         config.appId = server.appId.trimmed();
         config.appSecret = server.appSecret.trimmed();
-    } else if (allowLegacyCredentialFallback) {
-        if (config.appId.isEmpty()) {
-            config.appId = store->get<QString>(
-                providerKey(serverId, ConfigKeys::DanmakuProviderAppId));
+    }
+    else if (allowLegacyCredentialFallback)
+    {
+        if (config.appId.isEmpty())
+        {
+            config.appId = store->get<QString>(providerKey(serverId, ConfigKeys::DanmakuProviderAppId));
         }
-        if (config.appSecret.isEmpty()) {
-            config.appSecret = store->get<QString>(
-                providerKey(serverId, ConfigKeys::DanmakuProviderAppSecret));
+        if (config.appSecret.isEmpty())
+        {
+            config.appSecret = store->get<QString>(providerKey(serverId, ConfigKeys::DanmakuProviderAppSecret));
         }
     }
 
     config.contentScope = server.contentScope.trimmed().toLower();
-    config.withRelated = store->get<bool>(
-        providerKey(serverId, ConfigKeys::DanmakuWithRelated), true);
-    config.cacheHours = store->get<QString>(
-                            providerKey(serverId, ConfigKeys::DanmakuCacheHours),
-                            QStringLiteral("24"))
-                            .toInt();
+    config.withRelated = store->get<bool>(providerKey(serverId, ConfigKeys::DanmakuWithRelated), true);
+    config.cacheHours =
+        store->get<QString>(providerKey(serverId, ConfigKeys::DanmakuCacheHours), QStringLiteral("24")).toInt();
     return config;
 }
 
-void applyEndpointMetadata(DanmakuMatchCandidate *candidate,
-                           const DanmakuProviderConfig &config)
+void applyEndpointMetadata(DanmakuMatchCandidate *candidate, const DanmakuProviderConfig &config)
 {
-    if (!candidate) {
+    if (!candidate)
+    {
         return;
     }
 
-    if (candidate->cacheScope.trimmed().isEmpty()) {
+    if (candidate->cacheScope.trimmed().isEmpty())
+    {
         candidate->cacheScope = cacheScopeForConfig(config);
     }
-    if (candidate->endpointId.trimmed().isEmpty()) {
+    if (candidate->endpointId.trimmed().isEmpty())
+    {
         candidate->endpointId = config.endpointId.trimmed();
     }
-    if (candidate->endpointName.trimmed().isEmpty()) {
+    if (candidate->endpointName.trimmed().isEmpty())
+    {
         candidate->endpointName = endpointDisplayName(config);
     }
 }
 
-bool candidateBelongsToConfig(const DanmakuMatchCandidate &candidate,
-                              const DanmakuProviderConfig &config)
+bool candidateBelongsToConfig(const DanmakuMatchCandidate &candidate, const DanmakuProviderConfig &config)
 {
     const QString endpointId = candidate.endpointId.trimmed();
-    if (!endpointId.isEmpty()) {
+    if (!endpointId.isEmpty())
+    {
         return endpointId == config.endpointId.trimmed();
     }
 
     const QString cacheScope = candidate.cacheScope.trimmed();
-    if (cacheScope.isEmpty()) {
+    if (cacheScope.isEmpty())
+    {
         return false;
     }
-    if (cacheScope == cacheScopeForConfig(config)) {
+    if (cacheScope == cacheScopeForConfig(config))
+    {
         return true;
     }
     const QString legacyBaseUrlScope = config.baseUrl.trimmed().toLower();
@@ -242,7 +255,8 @@ bool candidateBelongsToConfig(const DanmakuMatchCandidate &candidate,
 QString localCandidateTitle(const QFileInfo &fileInfo)
 {
     QString title = fileInfo.completeBaseName().trimmed();
-    if (title.endsWith(QStringLiteral(".danmaku"), Qt::CaseInsensitive)) {
+    if (title.endsWith(QStringLiteral(".danmaku"), Qt::CaseInsensitive))
+    {
         title.chop(QStringLiteral(".danmaku").size());
     }
     return title.trimmed().isEmpty() ? fileInfo.fileName() : title.trimmed();
@@ -250,47 +264,49 @@ QString localCandidateTitle(const QFileInfo &fileInfo)
 
 QString firstNonEmpty(std::initializer_list<QString> values)
 {
-    for (const QString &value : values) {
-        if (!value.trimmed().isEmpty()) {
+    for (const QString &value : values)
+    {
+        if (!value.trimmed().isEmpty())
+        {
             return value.trimmed();
         }
     }
     return {};
 }
 
-QString jsonStringField(const QJsonObject &obj,
-                        std::initializer_list<const char *> keys)
+QString jsonStringField(const QJsonObject &obj, std::initializer_list<const char *> keys)
 {
-    for (const char *key : keys) {
-        const QString value =
-            obj.value(QLatin1String(key)).toVariant().toString().trimmed();
-        if (!value.isEmpty()) {
+    for (const char *key : keys)
+    {
+        const QString value = obj.value(QLatin1String(key)).toVariant().toString().trimmed();
+        if (!value.isEmpty())
+        {
             return value;
         }
     }
     return {};
 }
 
-int jsonIntField(const QJsonObject &obj,
-                 std::initializer_list<const char *> keys,
-                 int defaultValue = 0)
+int jsonIntField(const QJsonObject &obj, std::initializer_list<const char *> keys, int defaultValue = 0)
 {
-    for (const char *key : keys) {
+    for (const char *key : keys)
+    {
         const QJsonValue value = obj.value(QLatin1String(key));
-        if (!value.isUndefined() && !value.isNull()) {
+        if (!value.isUndefined() && !value.isNull())
+        {
             return value.toVariant().toInt();
         }
     }
     return defaultValue;
 }
 
-qint64 jsonLongField(const QJsonObject &obj,
-                     std::initializer_list<const char *> keys,
-                     qint64 defaultValue = 0)
+qint64 jsonLongField(const QJsonObject &obj, std::initializer_list<const char *> keys, qint64 defaultValue = 0)
 {
-    for (const char *key : keys) {
+    for (const char *key : keys)
+    {
         const QJsonValue value = obj.value(QLatin1String(key));
-        if (!value.isUndefined() && !value.isNull()) {
+        if (!value.isUndefined() && !value.isNull())
+        {
             return value.toVariant().toLongLong();
         }
     }
@@ -299,15 +315,18 @@ qint64 jsonLongField(const QJsonObject &obj,
 
 QColor parseColor(const QJsonValue &value)
 {
-    if (value.isString()) {
+    if (value.isString())
+    {
         const QColor color(value.toString());
-        if (color.isValid()) {
+        if (color.isValid())
+        {
             return color;
         }
 
         bool ok = false;
         const uint rgb = value.toString().toUInt(&ok, 10);
-        if (ok) {
+        if (ok)
+        {
             return QColor::fromRgb(rgb);
         }
     }
@@ -319,37 +338,157 @@ QColor parseColor(const QJsonValue &value)
 
 double titleScore(const QString &lhs, const QString &rhs)
 {
-    if (lhs.isEmpty() || rhs.isEmpty()) {
+    if (lhs.isEmpty() || rhs.isEmpty())
+    {
         return 0.0;
     }
 
     const QString normalizedLhs = lhs.trimmed().toLower();
     const QString normalizedRhs = rhs.trimmed().toLower();
-    if (normalizedLhs == normalizedRhs) {
+    if (normalizedLhs == normalizedRhs)
+    {
         return 1.0;
     }
-    if (normalizedLhs.contains(normalizedRhs) ||
-        normalizedRhs.contains(normalizedLhs)) {
+    if (normalizedLhs.contains(normalizedRhs) || normalizedRhs.contains(normalizedLhs))
+    {
         return 0.78;
     }
 
-    int overlap = 0;
-    for (const QChar ch : normalizedLhs) {
-        if (!ch.isSpace() && normalizedRhs.contains(ch)) {
-            ++overlap;
+    auto comparable = [](QString value)
+    {
+        value.remove(QRegularExpression(QStringLiteral(R"([^\p{L}\p{N}]+)")));
+        return value;
+    };
+    const QString lhsValue = comparable(normalizedLhs);
+    const QString rhsValue = comparable(normalizedRhs);
+    if (lhsValue.size() < 2 || rhsValue.size() < 2)
+    {
+        return lhsValue == rhsValue ? 1.0 : 0.0;
+    }
+    auto bigrams = [](const QString &value)
+    {
+        QSet<QString> result;
+        for (int i = 0; i + 1 < value.size(); ++i)
+        {
+            result.insert(value.mid(i, 2));
+        }
+        return result;
+    };
+    const QSet<QString> lhsBigrams = bigrams(lhsValue);
+    const QSet<QString> rhsBigrams = bigrams(rhsValue);
+    int common = 0;
+    for (const QString &gram : lhsBigrams)
+    {
+        if (rhsBigrams.contains(gram))
+        {
+            ++common;
         }
     }
-    return normalizedLhs.isEmpty()
-               ? 0.0
-               : qBound(0.0, overlap / static_cast<double>(normalizedLhs.size()),
-                        0.6);
+    return (2.0 * common) / static_cast<double>(lhsBigrams.size() + rhsBigrams.size());
 }
 
-void parseSeasonEpisodeHint(const QString &text,
-                            int *seasonNumber,
-                            int *episodeNumber)
+int yearHint(const QString &title)
 {
-    if (!seasonNumber || !episodeNumber) {
+    static const QRegularExpression yearPattern(QStringLiteral(R"((?:^|[^0-9])((?:19|20)[0-9]{2})(?:[^0-9]|$))"));
+    const QRegularExpressionMatch match = yearPattern.match(title);
+    return match.hasMatch() ? match.captured(1).toInt() : 0;
+}
+
+bool isAnimationGenre(const QString &genre)
+{
+    const QString normalized = genre.trimmed().toLower();
+    return normalized == QLatin1String("animation") || normalized == QLatin1String("anime") ||
+           normalized.contains(QStringLiteral("动画")) || normalized.contains(QStringLiteral("動漫")) ||
+           normalized.contains(QStringLiteral("アニメ"));
+}
+
+bool contentScopeAllowsContext(const DanmakuProviderConfig &config, const DanmakuMediaContext &context)
+{
+    if (config.contentScope.compare(QStringLiteral("anime"), Qt::CaseInsensitive) != 0 || context.genres.isEmpty())
+    {
+        return true;
+    }
+    if (std::any_of(context.genres.cbegin(), context.genres.cend(), isAnimationGenre))
+    {
+        return true;
+    }
+
+    const bool hasTmdbId = !context.providerIds.value(QStringLiteral("Tmdb")).toString().trimmed().isEmpty() ||
+                           !context.providerIds.value(QStringLiteral("TMDb")).toString().trimmed().isEmpty() ||
+                           !context.providerIds.value(QStringLiteral("tmdb")).toString().trimmed().isEmpty();
+    const bool localFileAccessible = !context.path.trimmed().isEmpty() && QFileInfo(context.path.trimmed()).isFile();
+    const bool remoteSampleAvailable = context.fileSize > 0 && !context.mediaUrl.trimmed().isEmpty();
+    const bool canUseFileFingerprint = localFileAccessible || remoteSampleAvailable;
+    
+    
+    
+    return hasTmdbId || canUseFileFingerprint;
+}
+
+double bestCandidateTitleScore(const DanmakuMediaContext &context, const DanmakuMatchCandidate &candidate)
+{
+    const QString subject = context.isEpisode() ? context.seriesName : context.title;
+    const QString candidateSubject = candidate.subtitle.isEmpty() ? candidate.title : candidate.subtitle;
+    return std::max({titleScore(subject, candidateSubject), titleScore(context.originalTitle, candidateSubject),
+                     titleScore(context.title, candidate.title)});
+}
+
+bool isPlausibleOnlineCandidate(const DanmakuMediaContext &context, const DanmakuMatchCandidate &candidate)
+{
+    if (!candidate.isValid())
+    {
+        return false;
+    }
+    if (candidate.isHashMatch() || candidate.isProviderIdMatch())
+    {
+        return true;
+    }
+
+    const double minimumTitleScore = context.isEpisode() ? 0.48 : 0.58;
+    if (bestCandidateTitleScore(context, candidate) < minimumTitleScore)
+    {
+        return false;
+    }
+
+    if (context.isEpisode() && context.episodeNumber > 0 && candidate.episodeNumber > 0 &&
+        context.episodeNumber != candidate.episodeNumber)
+    {
+        return false;
+    }
+    if (context.isEpisode() && context.seasonNumber > 0 && candidate.seasonNumber > 0 &&
+        context.seasonNumber != candidate.seasonNumber)
+    {
+        return false;
+    }
+
+    const QString candidateSubject = candidate.subtitle.isEmpty() ? candidate.title : candidate.subtitle;
+    const int candidateYear = yearHint(candidateSubject);
+    if (!context.isEpisode() && context.productionYear > 0 && candidateYear > 0 &&
+        std::abs(context.productionYear - candidateYear) > 1)
+    {
+        return false;
+    }
+
+    if (context.durationMs > 0 && candidate.durationMs > 0)
+    {
+        const qint64 allowedDifference = std::max<qint64>(5 * 60 * 1000, context.durationMs * 18 / 100);
+        if (std::llabs(context.durationMs - candidate.durationMs) > allowedDifference)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+double onlineConfidenceThreshold(const DanmakuMediaContext &context)
+{
+    return context.isEpisode() ? 72.0 : 62.0;
+}
+
+void parseSeasonEpisodeHint(const QString &text, int *seasonNumber, int *episodeNumber)
+{
+    if (!seasonNumber || !episodeNumber)
+    {
         return;
     }
 
@@ -361,46 +500,45 @@ void parseSeasonEpisodeHint(const QString &text,
         QStringLiteral(R"((?:^|[^A-Za-z0-9])S(\d{1,2})\s*E(\d{1,3})(?:[^A-Za-z0-9]|$))"),
         QRegularExpression::CaseInsensitiveOption);
     QRegularExpressionMatch match = seasonEpisodePattern.match(normalized);
-    if (match.hasMatch()) {
+    if (match.hasMatch())
+    {
         *seasonNumber = match.captured(1).toInt();
         *episodeNumber = match.captured(2).toInt();
         return;
     }
 
-    const QRegularExpression episodeOnlyPattern(
-        QStringLiteral(R"(第\s*0*(\d{1,3})\s*[话集])"));
+    const QRegularExpression episodeOnlyPattern(QStringLiteral(R"(第\s*0*(\d{1,3})\s*[话集])"));
     match = episodeOnlyPattern.match(normalized);
-    if (match.hasMatch()) {
+    if (match.hasMatch())
+    {
         *episodeNumber = match.captured(1).toInt();
     }
 }
 
-double computeLocalCandidateScore(const DanmakuMediaContext &context,
-                                  const QString &candidateTitle,
-                                  int candidateSeason,
-                                  int candidateEpisode,
-                                  const QString &manualKeyword)
+double computeLocalCandidateScore(const DanmakuMediaContext &context, const QString &candidateTitle,
+                                  int candidateSeason, int candidateEpisode, const QString &manualKeyword)
 {
     double score = 0.0;
-    const QString subjectTitle =
-        context.isEpisode() ? context.seriesName : context.title;
+    const QString subjectTitle = context.isEpisode() ? context.seriesName : context.title;
     score += titleScore(subjectTitle, candidateTitle) * 55.0;
     score += titleScore(context.originalTitle, candidateTitle) * 18.0;
     score += titleScore(context.title, candidateTitle) * 18.0;
     score += titleScore(manualKeyword, candidateTitle) * 12.0;
 
-    if (!context.path.trimmed().isEmpty()) {
-        const QString fileStem =
-            QFileInfo(context.path.trimmed()).completeBaseName().trimmed();
+    if (!context.path.trimmed().isEmpty())
+    {
+        const QString fileStem = QFileInfo(context.path.trimmed()).completeBaseName().trimmed();
         score += titleScore(fileStem, candidateTitle) * 14.0;
     }
 
-    if (context.isEpisode() && context.episodeNumber > 0 &&
-        candidateEpisode > 0 && context.episodeNumber == candidateEpisode) {
+    if (context.isEpisode() && context.episodeNumber > 0 && candidateEpisode > 0 &&
+        context.episodeNumber == candidateEpisode)
+    {
         score += 24.0;
     }
-    if (context.isEpisode() && context.seasonNumber > 0 &&
-        candidateSeason > 0 && context.seasonNumber == candidateSeason) {
+    if (context.isEpisode() && context.seasonNumber > 0 && candidateSeason > 0 &&
+        context.seasonNumber == candidateSeason)
+    {
         score += 8.0;
     }
     return score;
@@ -410,9 +548,11 @@ int countAssDialogueLines(const QByteArray &rawData)
 {
     int dialogueCount = 0;
     const QList<QByteArray> lines = rawData.split('\n');
-    for (QByteArray line : lines) {
+    for (QByteArray line : lines)
+    {
         line = line.trimmed();
-        if (line.toLower().startsWith("dialogue:")) {
+        if (line.toLower().startsWith("dialogue:"))
+        {
             ++dialogueCount;
         }
     }
@@ -422,7 +562,8 @@ int countAssDialogueLines(const QByteArray &rawData)
 int countAssDialogueLinesFromFile(const QString &filePath)
 {
     QFile file(filePath);
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+    {
         return 0;
     }
     return countAssDialogueLines(file.readAll());
@@ -430,7 +571,8 @@ int countAssDialogueLinesFromFile(const QString &filePath)
 
 void updateCommentCountFromAss(DanmakuLoadResult *result)
 {
-    if (!result || result->commentCount > 0 || result->assFilePath.isEmpty()) {
+    if (!result || result->commentCount > 0 || result->assFilePath.isEmpty())
+    {
         return;
     }
 
@@ -439,57 +581,102 @@ void updateCommentCountFromAss(DanmakuLoadResult *result)
 
 bool isSupportedLocalDanmakuFile(const QFileInfo &fileInfo)
 {
-    if (!fileInfo.isFile()) {
+    if (!fileInfo.isFile())
+    {
         return false;
     }
 
     const QString suffix = fileInfo.suffix().trimmed().toLower();
-    return suffix == QLatin1String("ass") || suffix == QLatin1String("json") ||
-           suffix == QLatin1String("xml");
+    return suffix == QLatin1String("ass") || suffix == QLatin1String("json") || suffix == QLatin1String("xml");
 }
 
-QList<DanmakuMatchCandidate> searchLocalDanmakuCandidates(
-    const QString &directoryPath,
-    const DanmakuMediaContext &context,
-    const QString &manualKeyword)
+QList<DanmakuMatchCandidate> searchLocalDanmakuCandidates(const QString &directoryPath,
+                                                          const DanmakuMediaContext &context,
+                                                          const QString &manualKeyword)
 {
+    struct IndexedLocalFile
+    {
+        QString path;
+        QString title;
+        int seasonNumber = -1;
+        int episodeNumber = -1;
+    };
+    struct LocalIndexCacheEntry
+    {
+        QDateTime indexedAt;
+        QList<IndexedLocalFile> files;
+    };
+    static QMutex indexMutex;
+    static QHash<QString, LocalIndexCacheEntry> indexCache;
+
     QList<DanmakuMatchCandidate> candidates;
     const QDir dir(directoryPath);
-    if (!dir.exists()) {
+    if (!dir.exists())
+    {
         return candidates;
     }
 
-    QDirIterator iterator(directoryPath, QDir::Files, QDirIterator::Subdirectories);
-    while (iterator.hasNext()) {
-        iterator.next();
-        const QFileInfo fileInfo = iterator.fileInfo();
-        if (!isSupportedLocalDanmakuFile(fileInfo)) {
-            continue;
+    QList<IndexedLocalFile> indexedFiles;
+    bool indexCacheHit = false;
+    {
+        QMutexLocker locker(&indexMutex);
+        const auto existing = indexCache.constFind(directoryPath);
+        if (existing != indexCache.constEnd() && existing->indexedAt.secsTo(QDateTime::currentDateTimeUtc()) < 60)
+        {
+            indexedFiles = existing->files;
+            indexCacheHit = true;
         }
+    }
 
+    if (!indexCacheHit)
+    {
+        QDirIterator iterator(directoryPath, QDir::Files, QDirIterator::Subdirectories);
+        while (iterator.hasNext())
+        {
+            iterator.next();
+            const QFileInfo fileInfo = iterator.fileInfo();
+            if (!isSupportedLocalDanmakuFile(fileInfo))
+            {
+                continue;
+            }
+            IndexedLocalFile indexed;
+            indexed.path = fileInfo.canonicalFilePath();
+            if (indexed.path.isEmpty())
+            {
+                indexed.path = fileInfo.absoluteFilePath();
+            }
+            indexed.title = localCandidateTitle(fileInfo);
+            parseSeasonEpisodeHint(indexed.title, &indexed.seasonNumber, &indexed.episodeNumber);
+            indexedFiles.append(indexed);
+        }
+        QMutexLocker locker(&indexMutex);
+        indexCache.insert(directoryPath, {QDateTime::currentDateTimeUtc(), indexedFiles});
+    }
+
+    candidates.reserve(indexedFiles.size());
+    for (const IndexedLocalFile &indexed : std::as_const(indexedFiles))
+    {
         DanmakuMatchCandidate candidate;
         candidate.provider = QString::fromLatin1(kLocalDanmakuProvider);
         candidate.cacheScope = QDir::fromNativeSeparators(directoryPath);
-        candidate.targetId = fileInfo.canonicalFilePath();
-        if (candidate.targetId.isEmpty()) {
-            candidate.targetId = fileInfo.absoluteFilePath();
-        }
-        candidate.title = localCandidateTitle(fileInfo);
-        parseSeasonEpisodeHint(candidate.title, &candidate.seasonNumber,
-                               &candidate.episodeNumber);
+        candidate.targetId = indexed.path;
+        candidate.title = indexed.title;
+        candidate.seasonNumber = indexed.seasonNumber;
+        candidate.episodeNumber = indexed.episodeNumber;
         candidate.matchReason = QStringLiteral("local-file");
-        candidate.score = computeLocalCandidateScore(
-            context, candidate.title, candidate.seasonNumber,
-            candidate.episodeNumber, manualKeyword.trimmed());
-        if (candidate.isValid()) {
+        candidate.score = computeLocalCandidateScore(context, candidate.title, candidate.seasonNumber,
+                                                     candidate.episodeNumber, manualKeyword.trimmed());
+        if (candidate.isValid())
+        {
             candidates.append(candidate);
         }
     }
 
     std::sort(candidates.begin(), candidates.end(),
-              [](const DanmakuMatchCandidate &lhs,
-                 const DanmakuMatchCandidate &rhs) {
-                  if (!qFuzzyCompare(lhs.score, rhs.score)) {
+              [](const DanmakuMatchCandidate &lhs, const DanmakuMatchCandidate &rhs)
+              {
+                  if (!qFuzzyCompare(lhs.score, rhs.score))
+                  {
                       return lhs.score > rhs.score;
                   }
                   return lhs.title < rhs.title;
@@ -497,60 +684,68 @@ QList<DanmakuMatchCandidate> searchLocalDanmakuCandidates(
     return candidates;
 }
 
-bool parsePField(QString p,
-                 qint64 *timeMs,
-                 int *mode,
-                 QColor *color,
-                 int *fontLevel,
-                 QDateTime *createdAt)
+bool parsePField(QString p, qint64 *timeMs, int *mode, QColor *color, int *fontLevel, QDateTime *createdAt)
 {
-    if (!timeMs || !mode || !color || !fontLevel || !createdAt) {
+    if (!timeMs || !mode || !color || !fontLevel || !createdAt)
+    {
         return false;
     }
 
     const QStringList parts = p.split(',', Qt::KeepEmptyParts);
-    if (parts.isEmpty()) {
+    if (parts.isEmpty())
+    {
         return false;
     }
 
     *timeMs = static_cast<qint64>(parts[0].toDouble() * 1000.0);
-    if (parts.size() > 1) {
+    if (parts.size() > 1)
+    {
         bool ok = false;
         const int parsedMode = parts[1].toInt(&ok);
-        if (ok) {
+        if (ok)
+        {
             *mode = parsedMode;
         }
     }
 
     const bool looksLikeBilibiliLayout = parts.size() >= 8;
-    if (looksLikeBilibiliLayout) {
-        if (parts.size() > 2) {
+    if (looksLikeBilibiliLayout)
+    {
+        if (parts.size() > 2)
+        {
             bool ok = false;
             const int parsedFontLevel = parts[2].toInt(&ok);
-            if (ok) {
+            if (ok)
+            {
                 *fontLevel = parsedFontLevel;
             }
         }
-        if (parts.size() > 3) {
+        if (parts.size() > 3)
+        {
             *color = parseColor(parts[3]);
         }
-        if (parts.size() > 4) {
+        if (parts.size() > 4)
+        {
             bool ok = false;
             const qint64 timestamp = parts[4].toLongLong(&ok);
-            if (ok && timestamp > 0) {
-                *createdAt = QDateTime::fromSecsSinceEpoch(timestamp, Qt::UTC);
+            if (ok && timestamp > 0)
+            {
+                *createdAt = QDateTime::fromSecsSinceEpoch(timestamp, QTimeZone::UTC);
             }
         }
         return true;
     }
 
-    if (parts.size() > 2) {
+    if (parts.size() > 2)
+    {
         *color = parseColor(parts[2]);
     }
-    if (parts.size() > 3) {
+    if (parts.size() > 3)
+    {
         bool ok = false;
         const int parsedFontLevel = parts[3].toInt(&ok);
-        if (ok) {
+        if (ok)
+        {
             *fontLevel = parsedFontLevel;
         }
     }
@@ -560,48 +755,50 @@ bool parsePField(QString p,
 DanmakuComment commentFromJsonObject(const QJsonObject &obj)
 {
     DanmakuComment comment;
-    comment.text = firstNonEmpty(
-        {jsonStringField(obj, {"m", "text", "comment", "content"})});
+    comment.text = firstNonEmpty({jsonStringField(obj, {"m", "text", "comment", "content"})});
 
     const QString p = jsonStringField(obj, {"p"});
-    if (!p.isEmpty()) {
-        parsePField(p, &comment.timeMs, &comment.mode, &comment.color,
-                    &comment.fontLevel, &comment.createdAt);
-    } else {
+    if (!p.isEmpty())
+    {
+        parsePField(p, &comment.timeMs, &comment.mode, &comment.color, &comment.fontLevel, &comment.createdAt);
+    }
+    else
+    {
         comment.timeMs = jsonLongField(obj, {"timeMs", "time", "position"}, 0);
-        if (comment.timeMs > 0 && comment.timeMs < 1000) {
+        if (comment.timeMs > 0 && comment.timeMs < 1000)
+        {
             comment.timeMs *= 1000;
         }
         comment.mode = jsonIntField(obj, {"mode", "positionType"}, 1);
         comment.color = parseColor(obj.value(QStringLiteral("color")));
         comment.fontLevel = jsonIntField(obj, {"size", "fontLevel"}, 25);
 
-        const QString createdAtString = jsonStringField(
-            obj, {"dateTime", "createdAt", "date", "timeStamp"});
-        if (!createdAtString.isEmpty()) {
-            comment.createdAt =
-                QDateTime::fromString(createdAtString, Qt::ISODate);
-            if (!comment.createdAt.isValid()) {
+        const QString createdAtString = jsonStringField(obj, {"dateTime", "createdAt", "date", "timeStamp"});
+        if (!createdAtString.isEmpty())
+        {
+            comment.createdAt = QDateTime::fromString(createdAtString, Qt::ISODate);
+            if (!comment.createdAt.isValid())
+            {
                 bool ok = false;
                 const qint64 timestamp = createdAtString.toLongLong(&ok);
-                if (ok && timestamp > 0) {
-                    comment.createdAt =
-                        QDateTime::fromSecsSinceEpoch(timestamp, Qt::UTC);
+                if (ok && timestamp > 0)
+                {
+                    comment.createdAt = QDateTime::fromSecsSinceEpoch(timestamp, QTimeZone::UTC);
                 }
             }
-        } else {
-            const QJsonValue createdAtValue =
-                obj.value(QStringLiteral("timeStamp"));
+        }
+        else
+        {
+            const QJsonValue createdAtValue = obj.value(QStringLiteral("timeStamp"));
             const qint64 timestamp = createdAtValue.toVariant().toLongLong();
-            if (timestamp > 0) {
-                comment.createdAt =
-                    QDateTime::fromSecsSinceEpoch(timestamp, Qt::UTC);
+            if (timestamp > 0)
+            {
+                comment.createdAt = QDateTime::fromSecsSinceEpoch(timestamp, QTimeZone::UTC);
             }
         }
     }
 
-    comment.sender =
-        jsonStringField(obj, {"sender", "user", "author", "nickname"});
+    comment.sender = jsonStringField(obj, {"sender", "user", "author", "nickname"});
     return comment;
 }
 
@@ -609,28 +806,36 @@ QList<DanmakuComment> parseLocalJsonComments(const QByteArray &rawData)
 {
     QList<DanmakuComment> comments;
     const QJsonDocument document = QJsonDocument::fromJson(rawData);
-    if (document.isNull()) {
+    if (document.isNull())
+    {
         return comments;
     }
 
     QJsonArray array;
-    if (document.isArray()) {
+    if (document.isArray())
+    {
         array = document.array();
-    } else {
+    }
+    else
+    {
         const QJsonObject root = document.object();
         array = root.value(QStringLiteral("comments")).toArray();
-        if (array.isEmpty()) {
+        if (array.isEmpty())
+        {
             array = root.value(QStringLiteral("data")).toArray();
         }
-        if (array.isEmpty()) {
+        if (array.isEmpty())
+        {
             array = root.value(QStringLiteral("result")).toArray();
         }
     }
 
     comments.reserve(array.size());
-    for (const QJsonValue &value : array) {
+    for (const QJsonValue &value : array)
+    {
         const DanmakuComment comment = commentFromJsonObject(value.toObject());
-        if (comment.isValid()) {
+        if (comment.isValid())
+        {
             comments.append(comment);
         }
     }
@@ -641,18 +846,20 @@ QList<DanmakuComment> parseLocalXmlComments(const QByteArray &rawData)
 {
     QList<DanmakuComment> comments;
     QXmlStreamReader reader(rawData);
-    while (!reader.atEnd()) {
+    while (!reader.atEnd())
+    {
         reader.readNext();
-        if (!reader.isStartElement() || reader.name() != QLatin1String("d")) {
+        if (!reader.isStartElement() || reader.name() != QLatin1String("d"))
+        {
             continue;
         }
 
         DanmakuComment comment;
         const QString p = reader.attributes().value(QStringLiteral("p")).toString();
-        parsePField(p, &comment.timeMs, &comment.mode, &comment.color,
-                    &comment.fontLevel, &comment.createdAt);
+        parsePField(p, &comment.timeMs, &comment.mode, &comment.color, &comment.fontLevel, &comment.createdAt);
         comment.text = reader.readElementText().trimmed();
-        if (comment.isValid()) {
+        if (comment.isValid())
+        {
             comments.append(comment);
         }
     }
@@ -661,20 +868,17 @@ QList<DanmakuComment> parseLocalXmlComments(const QByteArray &rawData)
 
 } 
 
-DanmakuService::DanmakuService(NetworkManager *networkManager,
-                               ServerManager *serverManager,
-                               QObject *parent)
-    : QObject(parent),
-      m_networkManager(networkManager),
-      m_serverManager(serverManager),
+DanmakuService::DanmakuService(NetworkManager *networkManager, ServerManager *serverManager, QObject *parent)
+    : QObject(parent), m_networkManager(networkManager), m_serverManager(serverManager),
       m_dandanplayProvider(new DandanplayProvider(networkManager)),
-      m_cacheStore(new DanmakuCacheStore())
+      m_danmuApiProvider(new DanmuApiProvider(networkManager)), m_cacheStore(new DanmakuCacheStore())
 {
 }
 
 DanmakuService::~DanmakuService()
 {
     delete m_dandanplayProvider;
+    delete m_danmuApiProvider;
     delete m_cacheStore;
 }
 
@@ -682,68 +886,64 @@ DanmakuMatchCandidate DanmakuService::createLocalFileCandidate(QString filePath)
 {
     DanmakuMatchCandidate candidate;
     const QFileInfo fileInfo(filePath.trimmed());
-    if (!fileInfo.exists() || !fileInfo.isFile() ||
-        !isSupportedLocalDanmakuFile(fileInfo)) {
+    if (!fileInfo.exists() || !fileInfo.isFile() || !isSupportedLocalDanmakuFile(fileInfo))
+    {
         return candidate;
     }
 
     candidate.provider = QString::fromLatin1(kLocalDanmakuProvider);
     candidate.targetId = fileInfo.canonicalFilePath();
-    if (candidate.targetId.isEmpty()) {
+    if (candidate.targetId.isEmpty())
+    {
         candidate.targetId = fileInfo.absoluteFilePath();
     }
     candidate.cacheScope = QDir::fromNativeSeparators(fileInfo.absolutePath());
     candidate.title = localCandidateTitle(fileInfo);
     candidate.matchReason = QStringLiteral("manual-local-file");
-    parseSeasonEpisodeHint(candidate.title, &candidate.seasonNumber,
-                           &candidate.episodeNumber);
+    parseSeasonEpisodeHint(candidate.title, &candidate.seasonNumber, &candidate.episodeNumber);
     return candidate;
 }
 
 QString DanmakuService::localDanmakuDirectoryPath(QString serverId)
 {
-    return QDir(preferredLocalDanmakuRootPath())
-        .filePath(safeDirectoryComponent(serverId));
+    return QDir(preferredLocalDanmakuRootPath()).filePath(safeDirectoryComponent(serverId));
 }
 
 bool DanmakuService::ensureLocalDanmakuDirectory(QString serverId)
 {
     const QString targetPath = localDanmakuDirectoryPath(serverId);
-    if (QDir(targetPath).exists()) {
+    if (QDir(targetPath).exists())
+    {
         return true;
     }
 
     const QString legacyPath = legacyLocalDanmakuDirectoryPath(serverId);
-    if (QDir(legacyPath).exists()) {
+    if (QDir(legacyPath).exists())
+    {
         const QString targetParentPath = QFileInfo(targetPath).absolutePath();
-        if (QDir().mkpath(targetParentPath) &&
-            QDir().rename(legacyPath, targetPath)) {
-            qDebug().noquote()
-                << "[Danmaku][Service] Migrated local danmaku directory"
-                << "| from:" << legacyPath
-                << "| to:" << targetPath;
+        if (QDir().mkpath(targetParentPath) && QDir().rename(legacyPath, targetPath))
+        {
+            qDebug().noquote() << "[Danmaku][Service] Migrated local danmaku directory"
+                               << "| from:" << legacyPath << "| to:" << targetPath;
             return true;
         }
 
-        if (copyDirectoryRecursively(legacyPath, targetPath)) {
-            qDebug().noquote()
-                << "[Danmaku][Service] Copied legacy local danmaku directory"
-                << "| from:" << legacyPath
-                << "| to:" << targetPath;
+        if (copyDirectoryRecursively(legacyPath, targetPath))
+        {
+            qDebug().noquote() << "[Danmaku][Service] Copied legacy local danmaku directory"
+                               << "| from:" << legacyPath << "| to:" << targetPath;
             return true;
         }
 
-        qWarning().noquote()
-            << "[Danmaku][Service] Failed to migrate legacy local danmaku directory"
-            << "| from:" << legacyPath
-            << "| to:" << targetPath;
+        qWarning().noquote() << "[Danmaku][Service] Failed to migrate legacy local danmaku directory"
+                             << "| from:" << legacyPath << "| to:" << targetPath;
     }
 
     const bool created = QDir().mkpath(targetPath);
-    if (!created) {
-        qWarning().noquote()
-            << "[Danmaku][Service] Failed to create local danmaku directory"
-            << "| path:" << targetPath;
+    if (!created)
+    {
+        qWarning().noquote() << "[Danmaku][Service] Failed to create local danmaku directory"
+                             << "| path:" << targetPath;
     }
     return created;
 }
@@ -752,110 +952,82 @@ DanmakuRenderOptions DanmakuService::renderOptions() const
 {
     DanmakuRenderOptions options;
     auto *store = ConfigStore::instance();
-    options.enabled =
-        store->get<bool>(ConfigKeys::PlayerDanmakuEnabled, true);
-    options.opacity =
-        store->get<QString>(ConfigKeys::PlayerDanmakuOpacity, QStringLiteral("72"))
-            .toDouble() /
-        100.0;
+    options.enabled = store->get<bool>(ConfigKeys::PlayerDanmakuEnabled, true);
+    options.opacity = store->get<QString>(ConfigKeys::PlayerDanmakuOpacity, QStringLiteral("72")).toDouble() / 100.0;
     options.fontScale =
-        store->get<QString>(ConfigKeys::PlayerDanmakuFontScale,
-                            QStringLiteral("100"))
-            .toDouble() /
-        100.0;
-    options.fontWeight =
-        store->get<QString>(ConfigKeys::PlayerDanmakuFontWeight,
-                            QStringLiteral("400"))
-            .toInt();
+        store->get<QString>(ConfigKeys::PlayerDanmakuFontScale, QStringLiteral("100")).toDouble() / 100.0;
+    options.fontWeight = store->get<QString>(ConfigKeys::PlayerDanmakuFontWeight, QStringLiteral("400")).toInt();
     options.outlineSize =
-        store->get<QString>(ConfigKeys::PlayerDanmakuOutlineSize,
-                            QStringLiteral("30"))
-            .toDouble() /
-        10.0;
+        store->get<QString>(ConfigKeys::PlayerDanmakuOutlineSize, QStringLiteral("30")).toDouble() / 10.0;
     options.shadowOffset =
-        store->get<QString>(ConfigKeys::PlayerDanmakuShadowOffset,
-                            QStringLiteral("10"))
-            .toDouble() /
-        10.0;
-    options.areaPercent =
-        store->get<QString>(ConfigKeys::PlayerDanmakuAreaPercent,
-                            QStringLiteral("70"))
-            .toInt();
-    options.density =
-        store->get<QString>(ConfigKeys::PlayerDanmakuDensity,
-                            QStringLiteral("100"))
-            .toInt();
+        store->get<QString>(ConfigKeys::PlayerDanmakuShadowOffset, QStringLiteral("10")).toDouble() / 10.0;
+    options.areaPercent = store->get<QString>(ConfigKeys::PlayerDanmakuAreaPercent, QStringLiteral("70")).toInt();
+    options.density = store->get<QString>(ConfigKeys::PlayerDanmakuDensity, QStringLiteral("100")).toInt();
     options.speedScale =
-        store->get<QString>(ConfigKeys::PlayerDanmakuSpeedScale,
-                            QStringLiteral("50"))
-            .toDouble() /
-        100.0;
-    options.offsetMs =
-        store->get<QString>(ConfigKeys::PlayerDanmakuOffsetMs,
-                            QStringLiteral("0"))
-            .toInt();
-    options.hideScroll =
-        store->get<bool>(ConfigKeys::PlayerDanmakuHideScroll, false);
-    options.hideTop =
-        store->get<bool>(ConfigKeys::PlayerDanmakuHideTop, false);
-    options.hideBottom =
-        store->get<bool>(ConfigKeys::PlayerDanmakuHideBottom, false);
-    options.dualSubtitle =
-        store->get<bool>(ConfigKeys::PlayerDanmakuDualSubtitle, true);
-    options.blockedKeywords = parseBlockedKeywords(
-        store->get<QString>(ConfigKeys::PlayerDanmakuBlockedKeywords));
+        store->get<QString>(ConfigKeys::PlayerDanmakuSpeedScale, QStringLiteral("50")).toDouble() / 100.0;
+    options.offsetMs = store->get<QString>(ConfigKeys::PlayerDanmakuOffsetMs, QStringLiteral("0")).toInt();
+    options.hideScroll = store->get<bool>(ConfigKeys::PlayerDanmakuHideScroll, false);
+    options.hideTop = store->get<bool>(ConfigKeys::PlayerDanmakuHideTop, false);
+    options.hideBottom = store->get<bool>(ConfigKeys::PlayerDanmakuHideBottom, false);
+    options.dualSubtitle = store->get<bool>(ConfigKeys::PlayerDanmakuDualSubtitle, true);
+    options.blockedKeywords = parseBlockedKeywords(store->get<QString>(ConfigKeys::PlayerDanmakuBlockedKeywords));
     return options;
 }
 
 DanmakuProviderConfig DanmakuService::providerConfig(QString serverId) const
 {
     DanmakuProviderConfig config;
-    if (!m_serverManager) {
+    if (!m_serverManager)
+    {
         return config;
     }
 
-    if (serverId.trimmed().isEmpty()) {
+    if (serverId.trimmed().isEmpty())
+    {
         serverId = m_serverManager->activeProfile().id;
     }
-    const DanmakuServerDefinition selectedServer =
-        DanmakuSettings::selectedServer(serverId);
+    const DanmakuServerDefinition selectedServer = DanmakuSettings::selectedServer(serverId);
     return providerConfigFromServerDefinition(selectedServer, serverId, true);
 }
 
-QList<DanmakuProviderConfig> DanmakuService::enabledProviderConfigs(
-    QString serverId) const
+QList<DanmakuProviderConfig> DanmakuService::enabledProviderConfigs(QString serverId) const
 {
     QList<DanmakuProviderConfig> configs;
-    if (!m_serverManager) {
+    if (!m_serverManager)
+    {
         return configs;
     }
 
     serverId = serverId.trimmed();
-    if (serverId.isEmpty()) {
+    if (serverId.isEmpty())
+    {
         serverId = m_serverManager->activeProfile().id;
     }
 
-    const QList<DanmakuServerDefinition> servers =
-        DanmakuSettings::loadServers(serverId);
+    const QList<DanmakuServerDefinition> servers = DanmakuSettings::loadServers(serverId);
     const QString selectedId = DanmakuSettings::selectedServerId(serverId);
-    auto appendServerConfig =
-        [&configs, &serverId](const DanmakuServerDefinition &server) {
-            if (!server.enabled || !server.isValid()) {
-                return;
-            }
-            configs.append(providerConfigFromServerDefinition(
-                server, serverId, false));
-        };
+    auto appendServerConfig = [&configs, &serverId](const DanmakuServerDefinition &server)
+    {
+        if (!server.enabled || !server.isValid())
+        {
+            return;
+        }
+        configs.append(providerConfigFromServerDefinition(server, serverId, false));
+    };
 
-    for (const DanmakuServerDefinition &server : servers) {
-        if (!selectedId.isEmpty() && server.id == selectedId) {
+    for (const DanmakuServerDefinition &server : servers)
+    {
+        if (!selectedId.isEmpty() && server.id == selectedId)
+        {
             appendServerConfig(server);
             break;
         }
     }
 
-    for (const DanmakuServerDefinition &server : servers) {
-        if (!selectedId.isEmpty() && server.id == selectedId) {
+    for (const DanmakuServerDefinition &server : servers)
+    {
+        if (!selectedId.isEmpty() && server.id == selectedId)
+        {
             continue;
         }
         appendServerConfig(server);
@@ -863,14 +1035,14 @@ QList<DanmakuProviderConfig> DanmakuService::enabledProviderConfigs(
     return configs;
 }
 
-DanmakuProviderConfig DanmakuService::providerConfigForCandidate(
-    QString serverId,
-    const DanmakuMatchCandidate &candidate) const
+DanmakuProviderConfig DanmakuService::providerConfigForCandidate(QString serverId,
+                                                                 const DanmakuMatchCandidate &candidate) const
 {
-    const QList<DanmakuProviderConfig> configs =
-        enabledProviderConfigs(serverId);
-    for (const DanmakuProviderConfig &config : configs) {
-        if (candidateBelongsToConfig(candidate, config)) {
+    const QList<DanmakuProviderConfig> configs = enabledProviderConfigs(serverId);
+    for (const DanmakuProviderConfig &config : configs)
+    {
+        if (candidateBelongsToConfig(candidate, config))
+        {
             return config;
         }
     }
@@ -880,94 +1052,113 @@ DanmakuProviderConfig DanmakuService::providerConfigForCandidate(
 bool DanmakuService::autoMatchEnabled(const QString &serverId) const
 {
     QString resolvedServerId = serverId.trimmed();
-    if (resolvedServerId.isEmpty() && m_serverManager) {
+    if (resolvedServerId.isEmpty() && m_serverManager)
+    {
         resolvedServerId = m_serverManager->activeProfile().id;
     }
 
-    return ConfigStore::instance()->get<bool>(
-        providerKey(resolvedServerId, ConfigKeys::DanmakuAutoMatch), true);
+    return ConfigStore::instance()->get<bool>(providerKey(resolvedServerId, ConfigKeys::DanmakuAutoMatch), true);
 }
 
-QCoro::Task<DanmakuLoadResult> DanmakuService::prepareDanmaku(
-    DanmakuMediaContext context,
-    QString manualKeyword)
+QCoro::Task<DanmakuLoadResult> DanmakuService::prepareDanmaku(DanmakuMediaContext context, QString manualKeyword)
 {
     DanmakuLoadResult loadResult;
     const DanmakuRenderOptions options = renderOptions();
-    qDebug().noquote()
-        << "[Danmaku][Service] Prepare start"
-        << "| media:" << context.displayTitle()
-        << "| mediaId:" << context.mediaId
-        << "| sourceId:" << context.mediaSourceId
-        << "| serverId:" << context.serverId
-        << "| localDir:" << localDanmakuDirectoryPath(context.serverId)
-        << "| manualKeyword:" << manualKeyword.trimmed();
-    if (!options.enabled) {
+    qDebug().noquote() << "[Danmaku][Service] Prepare start"
+                       << "| media:" << context.displayTitle() << "| mediaId:" << context.mediaId
+                       << "| sourceId:" << context.mediaSourceId << "| serverId:" << context.serverId
+                       << "| localDir:" << localDanmakuDirectoryPath(context.serverId)
+                       << "| manualKeyword:" << manualKeyword.trimmed();
+    if (!options.enabled)
+    {
         qDebug() << "[Danmaku][Service] Danmaku disabled globally, skip prepare";
         co_return loadResult;
     }
 
     const DanmakuProviderConfig config = providerConfig(context.serverId);
-    const QList<DanmakuProviderConfig> enabledConfigs =
-        enabledProviderConfigs(context.serverId);
-    qDebug().noquote()
-        << "[Danmaku][Service] Provider config"
-        << "| provider:" << config.provider
-        << "| endpointId:" << config.endpointId
-        << "| endpointName:" << config.endpointName
-        << "| baseUrl:" << config.baseUrl
-        << "| enabled:" << config.enabled
-        << "| contentScope:" << config.contentScope
-        << "| withRelated:" << config.withRelated
-        << "| cacheHours:" << config.cacheHours
-        << "| enabledProviderCount:" << enabledConfigs.size()
-        << "| hasAppId:" << !config.appId.trimmed().isEmpty()
-        << "| hasAppSecret:" << !config.appSecret.trimmed().isEmpty();
+    const QList<DanmakuProviderConfig> enabledConfigs = enabledProviderConfigs(context.serverId);
+    qDebug().noquote() << "[Danmaku][Service] Provider config"
+                       << "| provider:" << config.provider << "| endpointId:" << config.endpointId
+                       << "| endpointName:" << config.endpointName << "| enabled:" << config.enabled
+                       << "| contentScope:" << config.contentScope << "| withRelated:" << config.withRelated
+                       << "| cacheHours:" << config.cacheHours << "| enabledProviderCount:" << enabledConfigs.size()
+                       << "| hasAppId:" << !config.appId.trimmed().isEmpty()
+                       << "| hasAppSecret:" << !config.appSecret.trimmed().isEmpty()
+                       << "| hasAccessToken:" << !config.accessToken.trimmed().isEmpty();
 
-    const DanmakuMatchResult matchResult =
-        co_await resolveMatch(context, manualKeyword);
+    DanmakuMatchResult matchResult = co_await resolveMatch(context, manualKeyword);
     loadResult.matchResult = matchResult;
     loadResult.needManualMatch = !matchResult.matched;
-    if (!matchResult.matched) {
-        qDebug().noquote()
-            << "[Danmaku][Service] No match resolved"
-            << "| mediaId:" << context.mediaId
-            << "| candidateCount:" << matchResult.candidates.size()
-            << "| manualKeyword:" << manualKeyword.trimmed();
+    if (!matchResult.matched)
+    {
+        qDebug().noquote() << "[Danmaku][Service] No match resolved"
+                           << "| mediaId:" << context.mediaId << "| candidateCount:" << matchResult.candidates.size()
+                           << "| manualKeyword:" << manualKeyword.trimmed();
         co_return loadResult;
     }
 
-    qDebug().noquote()
-        << "[Danmaku][Service] Match selected"
-        << "| provider:" << matchResult.selected.provider
-        << "| targetId:" << matchResult.selected.targetId
-        << "| title:" << preferredProviderTitle(matchResult.selected)
-        << "| score:" << matchResult.selected.score
-        << "| cacheHit:" << matchResult.cacheHit
-        << "| manualOverride:" << matchResult.manualOverride;
+    qDebug().noquote() << "[Danmaku][Service] Match selected"
+                       << "| provider:" << matchResult.selected.provider
+                       << "| targetId:" << matchResult.selected.targetId
+                       << "| title:" << preferredProviderTitle(matchResult.selected)
+                       << "| score:" << matchResult.selected.score << "| cacheHit:" << matchResult.cacheHit
+                       << "| manualOverride:" << matchResult.manualOverride;
 
-    loadResult = co_await prepareDanmakuForCandidate(context, matchResult.selected);
+    std::exception_ptr staleTargetException;
+    try
+    {
+        loadResult = co_await prepareDanmakuForCandidate(context, matchResult.selected);
+    }
+    catch (const std::exception &e)
+    {
+        const QString errorMessage = QString::fromUtf8(e.what());
+        const bool staleDanmuApiTarget = matchResult.selected.provider == QLatin1String("danmu_api") &&
+                                         errorMessage.contains(QStringLiteral("HTTP 404"), Qt::CaseInsensitive);
+        if (!staleDanmuApiTarget)
+        {
+            throw;
+        }
+        staleTargetException = std::current_exception();
+        qWarning().noquote() << "[Danmaku][Service] DanmuApi target expired, rematching once"
+                             << "| mediaId:" << context.mediaId << "| endpointId:" << matchResult.selected.endpointId
+                             << "| targetId:" << matchResult.selected.targetId;
+    }
+
+    
+    
+    if (staleTargetException)
+    {
+        m_cacheStore->removeMatch(context);
+        DanmakuMatchResult refreshedMatch = co_await resolveMatch(context, context.displayTitle());
+        if (!refreshedMatch.matched || !refreshedMatch.selected.isValid())
+        {
+            std::rethrow_exception(staleTargetException);
+        }
+        loadResult = co_await prepareDanmakuForCandidate(context, refreshedMatch.selected);
+        matchResult = refreshedMatch;
+    }
     loadResult.matchResult = matchResult;
     if (!loadResult.success && loadResult.commentCount <= 0 &&
-        matchResult.selected.provider != QLatin1String(kLocalDanmakuProvider)) {
+        matchResult.selected.provider != QLatin1String(kLocalDanmakuProvider))
+    {
         loadResult.needManualMatch = true;
     }
     co_return loadResult;
 }
 
-QCoro::Task<DanmakuLoadResult> DanmakuService::prepareDanmakuForCandidate(
-    DanmakuMediaContext context,
-    DanmakuMatchCandidate candidate)
+QCoro::Task<DanmakuLoadResult> DanmakuService::prepareDanmakuForCandidate(DanmakuMediaContext context,
+                                                                          DanmakuMatchCandidate candidate)
 {
     DanmakuLoadResult loadResult;
     const DanmakuRenderOptions options = renderOptions();
-    if (!candidate.isValid() || !options.enabled) {
+    if (!candidate.isValid() || !options.enabled)
+    {
         co_return loadResult;
     }
 
-    const DanmakuProviderConfig config =
-        providerConfigForCandidate(context.serverId, candidate);
-    if (candidate.provider != QLatin1String(kLocalDanmakuProvider)) {
+    const DanmakuProviderConfig config = providerConfigForCandidate(context.serverId, candidate);
+    if (candidate.provider != QLatin1String(kLocalDanmakuProvider))
+    {
         applyEndpointMetadata(&candidate, config);
     }
     loadResult.provider = candidate.provider;
@@ -975,152 +1166,143 @@ QCoro::Task<DanmakuLoadResult> DanmakuService::prepareDanmakuForCandidate(
     loadResult.sourceServerName = candidate.endpointName;
     loadResult.sourceTitle = preferredProviderTitle(candidate);
 
-    qDebug().noquote()
-        << "[Danmaku][Service] Prepare candidate start"
-        << "| mediaId:" << context.mediaId
-        << "| provider:" << candidate.provider
-        << "| endpointId:" << candidate.endpointId
-        << "| endpointName:" << candidate.endpointName
-        << "| targetId:" << candidate.targetId
-        << "| title:" << loadResult.sourceTitle;
+    qDebug().noquote() << "[Danmaku][Service] Prepare candidate start"
+                       << "| mediaId:" << context.mediaId << "| provider:" << candidate.provider
+                       << "| endpointId:" << candidate.endpointId << "| endpointName:" << candidate.endpointName
+                       << "| targetId:" << candidate.targetId << "| title:" << loadResult.sourceTitle;
 
-    if (candidate.provider == QLatin1String(kLocalDanmakuProvider)) {
+    if (candidate.provider == QLatin1String(kLocalDanmakuProvider))
+    {
         const QFileInfo localFileInfo(candidate.targetId);
-        if (!localFileInfo.exists() || !localFileInfo.isFile()) {
-            qWarning().noquote()
-                << "[Danmaku][Service] Local danmaku file missing"
-                << "| path:" << candidate.targetId;
+        if (!localFileInfo.exists() || !localFileInfo.isFile())
+        {
+            qWarning().noquote() << "[Danmaku][Service] Local danmaku file missing"
+                                 << "| path:" << candidate.targetId;
             co_return loadResult;
         }
 
-        const QString localFilePath =
-            localFileInfo.canonicalFilePath().isEmpty()
-                ? localFileInfo.absoluteFilePath()
-                : localFileInfo.canonicalFilePath();
+        const QString localFilePath = localFileInfo.canonicalFilePath().isEmpty() ? localFileInfo.absoluteFilePath()
+                                                                                  : localFileInfo.canonicalFilePath();
         const QString suffix = localFileInfo.suffix().trimmed().toLower();
-        if (suffix == QLatin1String("ass")) {
+        if (suffix == QLatin1String("ass"))
+        {
             loadResult.success = true;
             loadResult.assFilePath = localFilePath;
             updateCommentCountFromAss(&loadResult);
-            qDebug().noquote()
-                << "[Danmaku][Service] Using local ASS file directly"
-                << "| path:" << localFilePath
-                << "| commentCount:" << loadResult.commentCount;
+            qDebug().noquote() << "[Danmaku][Service] Using local ASS file directly"
+                               << "| path:" << localFilePath << "| commentCount:" << loadResult.commentCount;
             co_return loadResult;
         }
 
         const QString assKey = assCacheKey(candidate, options);
         QString cachedAssPath;
-        if (m_cacheStore->loadAssPath(assKey, &cachedAssPath, config.cacheHours)) {
+        if (m_cacheStore->loadAssPath(assKey, &cachedAssPath, config.cacheHours))
+        {
             loadResult.success = true;
             loadResult.assFilePath = cachedAssPath;
             updateCommentCountFromAss(&loadResult);
-            qDebug().noquote()
-                << "[Danmaku][Service] Local ASS cache hit"
-                << "| assKey:" << assKey
-                << "| path:" << cachedAssPath
-                << "| commentCount:" << loadResult.commentCount;
+            qDebug().noquote() << "[Danmaku][Service] Local ASS cache hit"
+                               << "| assKey:" << assKey << "| path:" << cachedAssPath
+                               << "| commentCount:" << loadResult.commentCount;
             co_return loadResult;
         }
 
         
-        struct LocalParseResult {
+        struct LocalParseResult
+        {
             QList<DanmakuComment> comments;
             QString assPath;
             QString errorMessage;
         };
 
-        LocalParseResult parseResult = co_await QtConcurrent::run(
-            [localFilePath, suffix, options, assKey]() -> LocalParseResult {
+        auto localParseFuture = QtConcurrent::run(
+            [localFilePath, suffix, options, assKey]() -> LocalParseResult
+            {
                 LocalParseResult result;
                 QFile localFile(localFilePath);
-                if (!localFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+                if (!localFile.open(QIODevice::ReadOnly | QIODevice::Text))
+                {
                     result.errorMessage = localFile.errorString();
                     return result;
                 }
 
                 const QByteArray rawData = localFile.readAll();
-                if (suffix == QLatin1String("json")) {
+                if (suffix == QLatin1String("json"))
+                {
                     result.comments = parseLocalJsonComments(rawData);
-                } else if (suffix == QLatin1String("xml")) {
+                }
+                else if (suffix == QLatin1String("xml"))
+                {
                     result.comments = parseLocalXmlComments(rawData);
                 }
 
-                if (!result.comments.isEmpty()) {
-                    const QString assContent =
-                        DanmakuAssComposer::composeAss(result.comments, options);
+                if (!result.comments.isEmpty())
+                {
+                    const QString assContent = DanmakuAssComposer::composeAss(result.comments, options);
                     DanmakuCacheStore store;
                     result.assPath = store.saveAssFile(assKey, assContent);
                 }
                 return result;
             });
+        LocalParseResult parseResult = co_await localParseFuture;
 
-        if (!parseResult.errorMessage.isEmpty()) {
-            qWarning().noquote()
-                << "[Danmaku][Service] Failed to open local danmaku file"
-                << "| path:" << localFilePath
-                << "| error:" << parseResult.errorMessage;
+        if (!parseResult.errorMessage.isEmpty())
+        {
+            qWarning().noquote() << "[Danmaku][Service] Failed to open local danmaku file"
+                                 << "| path:" << localFilePath << "| error:" << parseResult.errorMessage;
             throw std::runtime_error(parseResult.errorMessage.toStdString());
         }
 
-        qDebug().noquote()
-            << "[Danmaku][Service] Parsed local danmaku file"
-            << "| path:" << localFilePath
-            << "| suffix:" << suffix
-            << "| count:" << parseResult.comments.size();
+        qDebug().noquote() << "[Danmaku][Service] Parsed local danmaku file"
+                           << "| path:" << localFilePath << "| suffix:" << suffix
+                           << "| count:" << parseResult.comments.size();
 
-        if (parseResult.comments.isEmpty()) {
-            qWarning().noquote()
-                << "[Danmaku][Service] Local danmaku file contains no comments"
-                << "| path:" << localFilePath;
+        if (parseResult.comments.isEmpty())
+        {
+            qWarning().noquote() << "[Danmaku][Service] Local danmaku file contains no comments"
+                                 << "| path:" << localFilePath;
             co_return loadResult;
         }
 
         loadResult.comments = parseResult.comments;
         loadResult.commentCount = parseResult.comments.size();
-        if (!parseResult.assPath.isEmpty()) {
+        if (!parseResult.assPath.isEmpty())
+        {
             loadResult.assFilePath = parseResult.assPath;
             loadResult.success = true;
-            qDebug().noquote()
-                << "[Danmaku][Service] Generated ASS file from local danmaku"
-                << "| assKey:" << assKey
-                << "| commentCount:" << parseResult.comments.size()
-                << "| path:" << parseResult.assPath;
-        } else {
-            qWarning().noquote()
-                << "[Danmaku][Service] Failed to save ASS file for local danmaku"
-                << "| assKey:" << assKey
-                << "| path:" << localFilePath;
+            qDebug().noquote() << "[Danmaku][Service] Generated ASS file from local danmaku"
+                               << "| assKey:" << assKey << "| commentCount:" << parseResult.comments.size()
+                               << "| path:" << parseResult.assPath;
+        }
+        else
+        {
+            qWarning().noquote() << "[Danmaku][Service] Failed to save ASS file for local danmaku"
+                                 << "| assKey:" << assKey << "| path:" << localFilePath;
         }
 
-        qDebug().noquote()
-            << "[Danmaku][Service] Prepare candidate finished"
-            << "| mediaId:" << context.mediaId
-            << "| success:" << loadResult.success
-            << "| commentCount:" << loadResult.commentCount
-            << "| assPath:" << loadResult.assFilePath;
+        qDebug().noquote() << "[Danmaku][Service] Prepare candidate finished"
+                           << "| mediaId:" << context.mediaId << "| success:" << loadResult.success
+                           << "| commentCount:" << loadResult.commentCount << "| assPath:" << loadResult.assFilePath;
         co_return loadResult;
     }
 
-    if (!config.enabled) {
-        qDebug().noquote()
-            << "[Danmaku][Service] Online provider disabled, skip remote candidate"
-            << "| provider:" << candidate.provider
-            << "| targetId:" << candidate.targetId;
+    if (!config.enabled)
+    {
+        qDebug().noquote() << "[Danmaku][Service] Online provider disabled, skip remote candidate"
+                           << "| provider:" << candidate.provider << "| targetId:" << candidate.targetId;
         co_return loadResult;
     }
 
     const QString assKey = assCacheKey(candidate, options);
     QString cachedAssPath;
-    if (m_cacheStore->loadAssPath(assKey, &cachedAssPath, config.cacheHours)) {
+    if (m_cacheStore->loadAssPath(assKey, &cachedAssPath, config.cacheHours))
+    {
         loadResult.success = true;
         loadResult.assFilePath = cachedAssPath;
         updateCommentCountFromAss(&loadResult);
-        qDebug().noquote()
-            << "[Danmaku][Service] ASS cache hit"
-            << "| assKey:" << assKey
-            << "| path:" << cachedAssPath
-            << "| commentCount:" << loadResult.commentCount;
+        qDebug().noquote() << "[Danmaku][Service] ASS cache hit"
+                           << "| assKey:" << assKey << "| path:" << cachedAssPath
+                           << "| commentCount:" << loadResult.commentCount;
     }
 
     
@@ -1128,272 +1310,346 @@ QCoro::Task<DanmakuLoadResult> DanmakuService::prepareDanmakuForCandidate(
     const QString cCacheScope = candidate.cacheScope;
     const QString cTargetId = candidate.targetId;
     const int cCacheHours = config.cacheHours;
-    QList<DanmakuComment> comments = co_await QtConcurrent::run(
-        [cProvider, cCacheScope, cTargetId, cCacheHours]() {
+    auto commentCacheFuture = QtConcurrent::run(
+        [cProvider, cCacheScope, cTargetId, cCacheHours]()
+        {
             DanmakuCacheStore store;
-            return store.loadComments(cProvider, cCacheScope, cTargetId,
-                                     cCacheHours);
+            return store.loadComments(cProvider, cCacheScope, cTargetId, cCacheHours);
         });
-    qDebug().noquote()
-        << "[Danmaku][Service] Comment cache"
-        << "| provider:" << candidate.provider
-        << "| cacheScope:" << candidate.cacheScope
-        << "| targetId:" << candidate.targetId
-        << "| count:" << comments.size();
+    QList<DanmakuComment> comments = co_await commentCacheFuture;
+    qDebug().noquote() << "[Danmaku][Service] Comment cache"
+                       << "| provider:" << candidate.provider << "| cacheScope:" << candidate.cacheScope
+                       << "| targetId:" << candidate.targetId << "| count:" << comments.size();
 
-    if (comments.isEmpty()) {
-        try {
-            if (config.provider == QStringLiteral("dandanplay")) {
-                qDebug().noquote()
-                    << "[Danmaku][Service] Fetching comments from provider"
-                    << "| provider:" << config.provider
-                    << "| endpointId:" << config.endpointId
-                    << "| endpointName:" << config.endpointName
-                    << "| targetId:" << candidate.targetId;
-                comments = co_await m_dandanplayProvider->fetchComments(
-                    candidate, config);
+    if (comments.isEmpty())
+    {
+        try
+        {
+            if (config.provider == QStringLiteral("dandanplay"))
+            {
+                qDebug().noquote() << "[Danmaku][Service] Fetching comments from provider"
+                                   << "| provider:" << config.provider << "| endpointId:" << config.endpointId
+                                   << "| endpointName:" << config.endpointName << "| targetId:" << candidate.targetId;
+                comments = co_await m_dandanplayProvider->fetchComments(candidate, config);
             }
-            if (!comments.isEmpty()) {
+            else if (config.provider == QStringLiteral("danmu_api"))
+            {
+                qDebug().noquote() << "[Danmaku][Service] Fetching comments from provider"
+                                   << "| provider:" << config.provider << "| endpointId:" << config.endpointId
+                                   << "| endpointName:" << config.endpointName << "| targetId:" << candidate.targetId;
+                comments = co_await m_danmuApiProvider->fetchComments(candidate, config);
+            }
+            if (!comments.isEmpty())
+            {
                 
                 const QString sProvider = candidate.provider;
                 const QString sCacheScope = candidate.cacheScope;
                 const QString sTargetId = candidate.targetId;
                 const QString sSourceTitle = loadResult.sourceTitle;
                 (void)QtConcurrent::run(
-                    [sProvider, sCacheScope, sTargetId, sSourceTitle,
-                     savedComments = comments]() {
+                    [sProvider, sCacheScope, sTargetId, sSourceTitle, savedComments = comments]()
+                    {
                         DanmakuCacheStore store;
-                        store.saveComments(sProvider, sCacheScope, sTargetId,
-                                           sSourceTitle, savedComments);
+                        store.saveComments(sProvider, sCacheScope, sTargetId, sSourceTitle, savedComments);
                     });
-                qDebug().noquote()
-                    << "[Danmaku][Service] Saved comments to cache"
-                    << "| provider:" << candidate.provider
-                    << "| cacheScope:" << candidate.cacheScope
-                    << "| targetId:" << candidate.targetId
-                    << "| count:" << comments.size();
+                qDebug().noquote() << "[Danmaku][Service] Saved comments to cache"
+                                   << "| provider:" << candidate.provider << "| cacheScope:" << candidate.cacheScope
+                                   << "| targetId:" << candidate.targetId << "| count:" << comments.size();
             }
-        } catch (const std::exception &e) {
-            qWarning().noquote()
-                << "[Danmaku][Service] Fetch comments failed"
-                << "| provider:" << config.provider
-                << "| targetId:" << candidate.targetId
-                << "| error:" << e.what();
-            if (loadResult.hasRenderableTrack()) {
+        }
+        catch (const std::exception &e)
+        {
+            qWarning().noquote() << "[Danmaku][Service] Fetch comments failed"
+                                 << "| provider:" << config.provider << "| targetId:" << candidate.targetId
+                                 << "| error:" << e.what();
+            if (loadResult.hasRenderableTrack())
+            {
                 updateCommentCountFromAss(&loadResult);
-                qWarning().noquote()
-                    << "[Danmaku][Service] Reusing cached ASS after fetch failure"
-                    << "| path:" << loadResult.assFilePath
-                    << "| commentCount:" << loadResult.commentCount;
+                qWarning().noquote() << "[Danmaku][Service] Reusing cached ASS after fetch failure"
+                                     << "| path:" << loadResult.assFilePath
+                                     << "| commentCount:" << loadResult.commentCount;
                 co_return loadResult;
             }
             throw;
         }
     }
 
-    if (comments.isEmpty()) {
-        if (loadResult.hasRenderableTrack()) {
+    if (comments.isEmpty())
+    {
+        if (loadResult.hasRenderableTrack())
+        {
             updateCommentCountFromAss(&loadResult);
-            qDebug().noquote()
-                << "[Danmaku][Service] Reusing cached ASS without comment payload"
-                << "| path:" << loadResult.assFilePath
-                << "| commentCount:" << loadResult.commentCount;
+            qDebug().noquote() << "[Danmaku][Service] Reusing cached ASS without comment payload"
+                               << "| path:" << loadResult.assFilePath << "| commentCount:" << loadResult.commentCount;
             co_return loadResult;
         }
 
-        qDebug().noquote()
-            << "[Danmaku][Service] No comments available for selected candidate"
-            << "| provider:" << candidate.provider
-            << "| targetId:" << candidate.targetId;
+        qDebug().noquote() << "[Danmaku][Service] No comments available for selected candidate"
+                           << "| provider:" << candidate.provider << "| targetId:" << candidate.targetId;
         co_return loadResult;
     }
 
     loadResult.commentCount = comments.size();
     loadResult.comments = comments;
 
-    if (!loadResult.success) {
+    if (!loadResult.success)
+    {
         
-        const QString assPath = co_await QtConcurrent::run(
-            [comments = std::move(comments), options, assKey]() {
-                const QString assContent =
-                    DanmakuAssComposer::composeAss(comments, options);
+        auto assComposeFuture = QtConcurrent::run(
+            [comments = std::move(comments), options, assKey]()
+            {
+                const QString assContent = DanmakuAssComposer::composeAss(comments, options);
                 DanmakuCacheStore store;
                 return store.saveAssFile(assKey, assContent);
             });
-        if (assPath.isEmpty()) {
-            qWarning().noquote()
-                << "[Danmaku][Service] Failed to save ASS file"
-                << "| assKey:" << assKey;
+        const QString assPath = co_await assComposeFuture;
+        if (assPath.isEmpty())
+        {
+            qWarning().noquote() << "[Danmaku][Service] Failed to save ASS file"
+                                 << "| assKey:" << assKey;
             co_return loadResult;
         }
         loadResult.assFilePath = assPath;
         loadResult.success = true;
-        qDebug().noquote()
-            << "[Danmaku][Service] Generated ASS file"
-            << "| assKey:" << assKey
-            << "| commentCount:" << loadResult.commentCount
-            << "| path:" << assPath;
+        qDebug().noquote() << "[Danmaku][Service] Generated ASS file"
+                           << "| assKey:" << assKey << "| commentCount:" << loadResult.commentCount
+                           << "| path:" << assPath;
     }
 
-    qDebug().noquote()
-        << "[Danmaku][Service] Prepare candidate finished"
-        << "| mediaId:" << context.mediaId
-        << "| success:" << loadResult.success
-        << "| commentCount:" << loadResult.commentCount
-        << "| assPath:" << loadResult.assFilePath;
+    qDebug().noquote() << "[Danmaku][Service] Prepare candidate finished"
+                       << "| mediaId:" << context.mediaId << "| success:" << loadResult.success
+                       << "| commentCount:" << loadResult.commentCount << "| assPath:" << loadResult.assFilePath;
     co_return loadResult;
 }
 
-QCoro::Task<QList<DanmakuMatchCandidate>> DanmakuService::searchCandidates(
-    DanmakuMediaContext context,
-    QString manualKeyword)
+QCoro::Task<QList<DanmakuMatchCandidate>> DanmakuService::searchCandidates(DanmakuMediaContext context,
+                                                                           QString manualKeyword)
 {
     const QList<DanmakuMatchCandidate> candidates =
-        co_await searchCandidatesForConfig(
-            context, providerConfig(context.serverId), manualKeyword);
+        co_await searchCandidatesForConfig(context, providerConfig(context.serverId), manualKeyword);
     co_return candidates;
 }
 
-QCoro::Task<QList<DanmakuMatchCandidate>>
-DanmakuService::searchCandidatesForConfig(DanmakuMediaContext context,
-                                          DanmakuProviderConfig config,
-                                          QString manualKeyword)
+QCoro::Task<QList<DanmakuMatchCandidate>> DanmakuService::searchCandidatesForConfig(DanmakuMediaContext context,
+                                                                                    DanmakuProviderConfig config,
+                                                                                    QString manualKeyword)
 {
     QList<DanmakuMatchCandidate> candidates;
-    if (!config.enabled) {
-        qDebug().noquote()
-            << "[Danmaku][Service] Online provider disabled, skip search"
-            << "| mediaId:" << context.mediaId
-            << "| provider:" << config.provider
-            << "| endpointId:" << config.endpointId;
+    if (!config.enabled)
+    {
+        qDebug().noquote() << "[Danmaku][Service] Online provider disabled, skip search"
+                           << "| mediaId:" << context.mediaId << "| provider:" << config.provider
+                           << "| endpointId:" << config.endpointId;
         co_return candidates;
     }
 
-    if (config.provider == QStringLiteral("dandanplay")) {
-        candidates = co_await m_dandanplayProvider->searchCandidates(
-            context, config, manualKeyword);
+    if (manualKeyword.trimmed().isEmpty() && !contentScopeAllowsContext(config, context))
+    {
+        qDebug().noquote() << "[Danmaku][Service] Provider content scope rejected media"
+                           << "| mediaId:" << context.mediaId << "| itemType:" << context.itemType
+                           << "| contentScope:" << config.contentScope
+                           << "| genres:" << context.genres.join(QStringLiteral(", "));
+        co_return candidates;
+    }
+
+    if (config.provider == QStringLiteral("dandanplay"))
+    {
+        candidates = co_await m_dandanplayProvider->searchCandidates(context, config, manualKeyword);
+    }
+    else if (config.provider == QStringLiteral("danmu_api"))
+    {
+        candidates = co_await m_danmuApiProvider->searchCandidates(context, config, manualKeyword);
     }
     const QString cacheScope = cacheScopeForConfig(config);
-    for (DanmakuMatchCandidate &candidate : candidates) {
-        if (candidate.cacheScope.trimmed().isEmpty()) {
+    for (DanmakuMatchCandidate &candidate : candidates)
+    {
+        if (candidate.cacheScope.trimmed().isEmpty())
+        {
             candidate.cacheScope = cacheScope;
         }
         applyEndpointMetadata(&candidate, config);
     }
-    qDebug().noquote()
-        << "[Danmaku][Service] Search candidates"
-        << "| mediaId:" << context.mediaId
-        << "| provider:" << config.provider
-        << "| endpointId:" << config.endpointId
-        << "| endpointName:" << config.endpointName
-        << "| cacheScope:" << cacheScope
-        << "| manualKeyword:" << manualKeyword.trimmed()
-        << "| count:" << candidates.size();
+    qDebug().noquote() << "[Danmaku][Service] Search candidates"
+                       << "| mediaId:" << context.mediaId << "| provider:" << config.provider
+                       << "| endpointId:" << config.endpointId << "| endpointName:" << config.endpointName
+                       << "| cacheScope:" << cacheScope << "| manualKeyword:" << manualKeyword.trimmed()
+                       << "| count:" << candidates.size();
     co_return candidates;
 }
 
-QCoro::Task<QList<DanmakuMatchCandidate>> DanmakuService::searchAllCandidates(
-    DanmakuMediaContext context,
-    QString manualKeyword)
+QCoro::Task<QList<DanmakuService::ProviderSearchOutcome>>
+DanmakuService::searchProvidersInParallel(DanmakuMediaContext context, QList<DanmakuProviderConfig> configs,
+                                          QString manualKeyword)
+{
+    if (configs.isEmpty())
+    {
+        co_return QList<ProviderSearchOutcome>{};
+    }
+
+    const bool needsDandanFingerprint =
+        manualKeyword.trimmed().isEmpty() &&
+        std::any_of(configs.cbegin(), configs.cend(), [](const DanmakuProviderConfig &config)
+                    { return config.enabled && config.provider == QLatin1String("dandanplay"); });
+    if (needsDandanFingerprint && m_dandanplayProvider)
+    {
+        QString cachedFingerprint;
+        if (m_cacheStore && m_cacheStore->loadFingerprint(context, &cachedFingerprint))
+        {
+            context.fileHash = cachedFingerprint;
+            qDebug().noquote() << "[Danmaku][Service] Media fingerprint cache hit"
+                               << "| mediaId:" << context.mediaId << "| sourceId:" << context.mediaSourceId
+                               << "| fileSize:" << context.fileSize;
+        }
+        else
+        {
+            context = co_await m_dandanplayProvider->enrichMediaFingerprint(context);
+            if (m_cacheStore && !context.fileHash.isEmpty())
+            {
+                m_cacheStore->saveFingerprint(context, context.fileHash);
+            }
+        }
+    }
+
+    struct SharedSearchState
+    {
+        QPromise<QList<ProviderSearchOutcome>> promise;
+        QList<ProviderSearchOutcome> outcomes;
+        int remaining = 0;
+    };
+    const auto state = QSharedPointer<SharedSearchState>::create();
+    state->remaining = configs.size();
+    QFuture<QList<ProviderSearchOutcome>> completionFuture = state->promise.future();
+    state->promise.start();
+
+    for (const DanmakuProviderConfig &config : std::as_const(configs))
+    {
+        QCoro::connect(searchProviderSafely(context, config, manualKeyword), this,
+                       [state](ProviderSearchOutcome outcome)
+                       {
+                           state->outcomes.append(std::move(outcome));
+                           --state->remaining;
+                           if (state->remaining == 0)
+                           {
+                               state->promise.addResult(state->outcomes);
+                               state->promise.finish();
+                           }
+                       });
+    }
+
+    const QList<ProviderSearchOutcome> outcomes = co_await completionFuture;
+    co_return outcomes;
+}
+
+QCoro::Task<DanmakuService::ProviderSearchOutcome>
+DanmakuService::searchProviderSafely(DanmakuMediaContext context, DanmakuProviderConfig config, QString manualKeyword)
+{
+    ProviderSearchOutcome outcome;
+    outcome.config = config;
+    try
+    {
+        outcome.candidates = co_await searchCandidatesForConfig(context, config, manualKeyword);
+    }
+    catch (const std::exception &e)
+    {
+        outcome.errorMessage = QString::fromUtf8(e.what()).trimmed();
+    }
+    co_return outcome;
+}
+
+QCoro::Task<QList<DanmakuMatchCandidate>> DanmakuService::searchAllCandidates(DanmakuMediaContext context,
+                                                                              QString manualKeyword)
 {
     QList<DanmakuMatchCandidate> aggregatedCandidates;
     const QString trimmedManualKeyword = manualKeyword.trimmed();
-    const QList<DanmakuProviderConfig> onlineProviders =
-        enabledProviderConfigs(context.serverId);
+    const QList<DanmakuProviderConfig> onlineProviders = enabledProviderConfigs(context.serverId);
     const QString sourceMode = normalizedSourceMode(
-        ConfigStore::instance()->get<QString>(
-            providerKey(context.serverId, ConfigKeys::DanmakuSourceMode),
-            QString::fromLatin1(kDanmakuSourceModePreferLocal)));
-    const bool allowLocal =
-        sourceMode != QLatin1String(kDanmakuSourceModeOnlineOnly);
-    const bool allowOnline =
-        sourceMode != QLatin1String(kDanmakuSourceModeLocalOnly) &&
-        !onlineProviders.isEmpty();
-    const QStringList sourceOrder =
-        (sourceMode == QLatin1String(kDanmakuSourceModePreferLocal) ||
-         sourceMode == QLatin1String(kDanmakuSourceModeLocalOnly))
-            ? QStringList{QStringLiteral("local"), QStringLiteral("online")}
-            : QStringList{QStringLiteral("online"), QStringLiteral("local")};
+        ConfigStore::instance()->get<QString>(providerKey(context.serverId, ConfigKeys::DanmakuSourceMode),
+                                              QString::fromLatin1(kDanmakuSourceModePreferLocal)));
+    const bool allowLocal = sourceMode != QLatin1String(kDanmakuSourceModeOnlineOnly);
+    const bool allowOnline = sourceMode != QLatin1String(kDanmakuSourceModeLocalOnly) && !onlineProviders.isEmpty();
+    const QStringList sourceOrder = (sourceMode == QLatin1String(kDanmakuSourceModePreferLocal) ||
+                                     sourceMode == QLatin1String(kDanmakuSourceModeLocalOnly))
+                                        ? QStringList{QStringLiteral("local"), QStringLiteral("online")}
+                                        : QStringList{QStringLiteral("online"), QStringLiteral("local")};
 
     std::exception_ptr remoteSearchException;
     QString remoteSearchError;
 
-    qDebug().noquote()
-        << "[Danmaku][Service] Search all candidates"
-        << "| mediaId:" << context.mediaId
-        << "| sourceMode:" << sourceMode
-        << "| manualKeyword:" << trimmedManualKeyword
-        << "| allowLocal:" << allowLocal
-        << "| allowOnline:" << allowOnline
-        << "| enabledProviderCount:" << onlineProviders.size();
+    qDebug().noquote() << "[Danmaku][Service] Search all candidates"
+                       << "| mediaId:" << context.mediaId << "| sourceMode:" << sourceMode
+                       << "| manualKeyword:" << trimmedManualKeyword << "| allowLocal:" << allowLocal
+                       << "| allowOnline:" << allowOnline << "| enabledProviderCount:" << onlineProviders.size();
 
-    for (const QString &source : sourceOrder) {
-        if (source == QLatin1String("local")) {
-            if (!allowLocal) {
+    for (const QString &source : sourceOrder)
+    {
+        if (source == QLatin1String("local"))
+        {
+            if (!allowLocal)
+            {
                 continue;
             }
 
-            const QList<DanmakuMatchCandidate> localCandidates =
-                searchLocalDanmakuCandidates(
-                    localDanmakuDirectoryPath(context.serverId), context,
-                    trimmedManualKeyword);
+            const QString localDirectory = localDanmakuDirectoryPath(context.serverId);
+            auto localSearchFuture = QtConcurrent::run(
+                [localDirectory, context, trimmedManualKeyword]()
+                { return searchLocalDanmakuCandidates(localDirectory, context, trimmedManualKeyword); });
+            const QList<DanmakuMatchCandidate> localCandidates = co_await localSearchFuture;
             aggregatedCandidates.append(localCandidates);
-            qDebug().noquote()
-                << "[Danmaku][Service] Search all local candidates"
-                << "| mediaId:" << context.mediaId
-                << "| count:" << localCandidates.size();
+            qDebug().noquote() << "[Danmaku][Service] Search all local candidates"
+                               << "| mediaId:" << context.mediaId << "| count:" << localCandidates.size();
             continue;
         }
 
-        if (!allowOnline) {
+        if (!allowOnline)
+        {
             continue;
         }
 
-        for (const DanmakuProviderConfig &providerConfig : onlineProviders) {
-            const DanmakuProviderConfig onlineConfig = providerConfig;
-            try {
-                const QList<DanmakuMatchCandidate> onlineCandidates =
-                    co_await searchCandidatesForConfig(
-                        context, onlineConfig, trimmedManualKeyword);
-                aggregatedCandidates.append(onlineCandidates);
-                qDebug().noquote()
-                    << "[Danmaku][Service] Search all online candidates"
-                    << "| mediaId:" << context.mediaId
-                    << "| endpointId:" << onlineConfig.endpointId
-                    << "| endpointName:" << onlineConfig.endpointName
-                    << "| count:" << onlineCandidates.size();
-            } catch (const std::exception &e) {
-                remoteSearchException = std::current_exception();
-                remoteSearchError = QString::fromUtf8(e.what()).trimmed();
-                qWarning().noquote()
-                    << "[Danmaku][Service] Search all online candidates failed"
-                    << "| mediaId:" << context.mediaId
-                    << "| endpointId:" << onlineConfig.endpointId
-                    << "| endpointName:" << onlineConfig.endpointName
-                    << "| error:" << remoteSearchError;
+        const QList<ProviderSearchOutcome> outcomes =
+            co_await searchProvidersInParallel(context, onlineProviders, trimmedManualKeyword);
+        for (const ProviderSearchOutcome &outcome : outcomes)
+        {
+            if (outcome.errorMessage.isEmpty())
+            {
+                aggregatedCandidates.append(outcome.candidates);
+                qDebug().noquote() << "[Danmaku][Service] Search all online candidates"
+                                   << "| mediaId:" << context.mediaId << "| endpointId:" << outcome.config.endpointId
+                                   << "| endpointName:" << outcome.config.endpointName
+                                   << "| count:" << outcome.candidates.size();
+            }
+            else
+            {
+                remoteSearchError = outcome.errorMessage;
+                remoteSearchException = std::make_exception_ptr(std::runtime_error(remoteSearchError.toStdString()));
+                qWarning().noquote() << "[Danmaku][Service] Search all online candidates failed"
+                                     << "| mediaId:" << context.mediaId << "| endpointId:" << outcome.config.endpointId
+                                     << "| endpointName:" << outcome.config.endpointName
+                                     << "| error:" << remoteSearchError;
             }
         }
     }
 
-    if (aggregatedCandidates.isEmpty() && remoteSearchException) {
+    if (aggregatedCandidates.isEmpty() && remoteSearchException)
+    {
         std::rethrow_exception(remoteSearchException);
     }
 
-    if (!aggregatedCandidates.isEmpty() && remoteSearchException) {
-        qWarning().noquote()
-            << "[Danmaku][Service] Search all candidates keeping partial results"
-            << "| mediaId:" << context.mediaId
-            << "| candidateCount:" << aggregatedCandidates.size()
-            << "| error:" << remoteSearchError;
+    if (!aggregatedCandidates.isEmpty() && remoteSearchException)
+    {
+        qWarning().noquote() << "[Danmaku][Service] Search all candidates keeping partial results"
+                             << "| mediaId:" << context.mediaId << "| candidateCount:" << aggregatedCandidates.size()
+                             << "| error:" << remoteSearchError;
     }
     
     std::sort(aggregatedCandidates.begin(), aggregatedCandidates.end(),
-              [](const DanmakuMatchCandidate &lhs,
-                 const DanmakuMatchCandidate &rhs) {
-                  if (!qFuzzyCompare(lhs.score, rhs.score)) {
+              [](const DanmakuMatchCandidate &lhs, const DanmakuMatchCandidate &rhs)
+              {
+                  if (!qFuzzyCompare(lhs.score, rhs.score))
+                  {
                       return lhs.score > rhs.score;
                   }
-                  if (lhs.commentCount != rhs.commentCount) {
+                  if (lhs.commentCount != rhs.commentCount)
+                  {
                       return lhs.commentCount > rhs.commentCount;
                   }
                   return lhs.endpointName < rhs.endpointName;
@@ -1402,306 +1658,292 @@ QCoro::Task<QList<DanmakuMatchCandidate>> DanmakuService::searchAllCandidates(
     co_return aggregatedCandidates;
 }
 
-QCoro::Task<DanmakuMatchResult> DanmakuService::resolveMatch(
-    DanmakuMediaContext context,
-    QString manualKeyword)
+QCoro::Task<DanmakuMatchResult> DanmakuService::resolveMatch(DanmakuMediaContext context, QString manualKeyword)
 {
     DanmakuMatchResult result;
     const QString trimmedManualKeyword = manualKeyword.trimmed();
-    const QList<DanmakuProviderConfig> onlineProviders =
-        enabledProviderConfigs(context.serverId);
+    const QList<DanmakuProviderConfig> onlineProviders = enabledProviderConfigs(context.serverId);
     const QString sourceMode = normalizedSourceMode(
-        ConfigStore::instance()->get<QString>(
-            providerKey(context.serverId, ConfigKeys::DanmakuSourceMode),
-            QString::fromLatin1(kDanmakuSourceModePreferLocal)));
-    const auto cachedCandidateAvailable = [](const DanmakuMatchCandidate &candidate) {
-        if (!candidate.isValid()) {
+        ConfigStore::instance()->get<QString>(providerKey(context.serverId, ConfigKeys::DanmakuSourceMode),
+                                              QString::fromLatin1(kDanmakuSourceModePreferLocal)));
+    const auto cachedCandidateAvailable = [](const DanmakuMatchCandidate &candidate)
+    {
+        if (!candidate.isValid())
+        {
             return false;
         }
-        if (candidate.provider == QLatin1String(kLocalDanmakuProvider)) {
+        if (candidate.provider == QLatin1String(kLocalDanmakuProvider))
+        {
             return QFileInfo::exists(candidate.targetId);
         }
         return true;
     };
-    const auto sourceModeAllowsCandidate =
-        [sourceMode, onlineProviders](const DanmakuMatchCandidate &candidate) {
-            const bool isLocalCandidate =
-                candidate.provider == QLatin1String(kLocalDanmakuProvider);
-            if (isLocalCandidate) {
-                return sourceMode != QLatin1String(kDanmakuSourceModeOnlineOnly);
-            }
-            if (sourceMode == QLatin1String(kDanmakuSourceModeLocalOnly) ||
-                onlineProviders.isEmpty()) {
-                return false;
-            }
-            if (candidate.endpointId.trimmed().isEmpty() &&
-                candidate.cacheScope.trimmed().isEmpty()) {
+    const auto sourceModeAllowsCandidate = [sourceMode, onlineProviders](const DanmakuMatchCandidate &candidate)
+    {
+        const bool isLocalCandidate = candidate.provider == QLatin1String(kLocalDanmakuProvider);
+        if (isLocalCandidate)
+        {
+            return sourceMode != QLatin1String(kDanmakuSourceModeOnlineOnly);
+        }
+        if (sourceMode == QLatin1String(kDanmakuSourceModeLocalOnly) || onlineProviders.isEmpty())
+        {
+            return false;
+        }
+        if (candidate.endpointId.trimmed().isEmpty() && candidate.cacheScope.trimmed().isEmpty())
+        {
+            return true;
+        }
+        for (const DanmakuProviderConfig &config : onlineProviders)
+        {
+            if (candidateBelongsToConfig(candidate, config))
+            {
                 return true;
             }
-            for (const DanmakuProviderConfig &config : onlineProviders) {
-                if (candidateBelongsToConfig(candidate, config)) {
-                    return true;
-                }
-            }
-            return false;
-        };
+        }
+        return false;
+    };
 
     DanmakuMatchCandidate cachedCandidate;
     bool manualOverride = false;
-    const bool hasCachedMatch =
-        m_cacheStore->loadMatch(context, &cachedCandidate, &manualOverride);
-    if (trimmedManualKeyword.isEmpty() && hasCachedMatch &&
-        cachedCandidateAvailable(cachedCandidate) &&
-        sourceModeAllowsCandidate(cachedCandidate)) {
+    const bool hasCachedMatch = m_cacheStore->loadMatch(context, &cachedCandidate, &manualOverride);
+    const bool cachedCandidateTrusted = manualOverride || cachedCandidate.isHashMatch() ||
+                                        (isPlausibleOnlineCandidate(context, cachedCandidate) &&
+                                         cachedCandidate.score >= onlineConfidenceThreshold(context));
+    if (trimmedManualKeyword.isEmpty() && hasCachedMatch && cachedCandidateAvailable(cachedCandidate) &&
+        sourceModeAllowsCandidate(cachedCandidate) &&
+        (cachedCandidate.provider == QLatin1String(kLocalDanmakuProvider) || cachedCandidateTrusted))
+    {
         result.matched = true;
         result.cacheHit = true;
         result.manualOverride = manualOverride;
         result.selected = cachedCandidate;
-        qDebug().noquote()
-            << "[Danmaku][Service] Match cache hit"
-            << "| mediaId:" << context.mediaId
-            << "| matched:" << result.matched
-            << "| manualOverride:" << result.manualOverride
-            << "| endpointId:" << result.selected.endpointId
-            << "| endpointName:" << result.selected.endpointName
-            << "| targetId:" << result.selected.targetId;
-        if (result.matched) {
+        qDebug().noquote() << "[Danmaku][Service] Match cache hit"
+                           << "| mediaId:" << context.mediaId << "| matched:" << result.matched
+                           << "| manualOverride:" << result.manualOverride
+                           << "| endpointId:" << result.selected.endpointId
+                           << "| endpointName:" << result.selected.endpointName
+                           << "| targetId:" << result.selected.targetId;
+        if (result.matched)
+        {
             co_return result;
         }
     }
 
-    if (trimmedManualKeyword.isEmpty() && !autoMatchEnabled(context.serverId)) {
-        qDebug().noquote()
-            << "[Danmaku][Service] Auto match disabled"
-            << "| mediaId:" << context.mediaId
-            << "| serverId:" << context.serverId;
+    if (trimmedManualKeyword.isEmpty() && !autoMatchEnabled(context.serverId))
+    {
+        qDebug().noquote() << "[Danmaku][Service] Auto match disabled"
+                           << "| mediaId:" << context.mediaId << "| serverId:" << context.serverId;
         co_return result;
     }
 
     const bool allowLocal = sourceMode != QLatin1String(kDanmakuSourceModeOnlineOnly);
-    const bool allowOnline =
-        sourceMode != QLatin1String(kDanmakuSourceModeLocalOnly) &&
-        !onlineProviders.isEmpty();
-    const QStringList sourceOrder =
-        (sourceMode == QLatin1String(kDanmakuSourceModePreferLocal) ||
-         sourceMode == QLatin1String(kDanmakuSourceModeLocalOnly))
-            ? QStringList{QStringLiteral("local"), QStringLiteral("online")}
-            : QStringList{QStringLiteral("online"), QStringLiteral("local")};
+    const bool allowOnline = sourceMode != QLatin1String(kDanmakuSourceModeLocalOnly) && !onlineProviders.isEmpty();
+    const QStringList sourceOrder = (sourceMode == QLatin1String(kDanmakuSourceModePreferLocal) ||
+                                     sourceMode == QLatin1String(kDanmakuSourceModeLocalOnly))
+                                        ? QStringList{QStringLiteral("local"), QStringLiteral("online")}
+                                        : QStringList{QStringLiteral("online"), QStringLiteral("local")};
 
-    qDebug().noquote()
-        << "[Danmaku][Service] Resolve match"
-        << "| mediaId:" << context.mediaId
-        << "| sourceMode:" << sourceMode
-        << "| allowLocal:" << allowLocal
-        << "| allowOnline:" << allowOnline
-        << "| enabledProviderCount:" << onlineProviders.size();
+    qDebug().noquote() << "[Danmaku][Service] Resolve match"
+                       << "| mediaId:" << context.mediaId << "| sourceMode:" << sourceMode
+                       << "| allowLocal:" << allowLocal << "| allowOnline:" << allowOnline
+                       << "| enabledProviderCount:" << onlineProviders.size();
 
     QList<DanmakuMatchCandidate> aggregatedCandidates;
     std::exception_ptr remoteSearchException;
     QString remoteSearchError;
 
-    const auto appendCandidates =
-        [&aggregatedCandidates](const QList<DanmakuMatchCandidate> &candidates) {
-            aggregatedCandidates.append(candidates);
-        };
-    const auto trySelectLocalCandidate =
-        [this, &context, &result, &trimmedManualKeyword](
-            const QList<DanmakuMatchCandidate> &candidates) -> bool {
-            if (candidates.isEmpty()) {
-                return false;
-            }
-
-            const DanmakuMatchCandidate selected = candidates.first();
-            const double threshold = context.isEpisode() ? 44.0 : 36.0;
-            const bool allowSingleCandidateFallback =
-                candidates.size() == 1 && selected.score >= 24.0;
-            qDebug().noquote()
-                << "[Danmaku][Service] Local candidates discovered"
-                << "| mediaId:" << context.mediaId
-                << "| count:" << candidates.size()
-                << "| topTargetId:" << selected.targetId
-                << "| topScore:" << selected.score
-                << "| threshold:" << threshold;
-
-            if (!trimmedManualKeyword.isEmpty() ||
-                selected.score >= threshold || allowSingleCandidateFallback) {
-                result.matched = true;
-                result.selected = selected;
-                result.manualOverride = !trimmedManualKeyword.isEmpty();
-                m_cacheStore->saveMatch(context, selected, result.manualOverride);
-                qDebug().noquote()
-                    << "[Danmaku][Service] Local match selected"
-                    << "| mediaId:" << context.mediaId
-                    << "| targetId:" << selected.targetId
-                    << "| score:" << selected.score
-                    << "| manualOverride:" << result.manualOverride;
-                return true;
-            }
+    const auto appendCandidates = [&aggregatedCandidates](const QList<DanmakuMatchCandidate> &candidates)
+    { aggregatedCandidates.append(candidates); };
+    const auto trySelectLocalCandidate = [this, &context,
+                                          &result](const QList<DanmakuMatchCandidate> &candidates) -> bool
+    {
+        if (candidates.isEmpty())
+        {
             return false;
-        };
-    const auto trySelectOnlineCandidate =
-        [this, &context, &result, &trimmedManualKeyword](
-            const QList<DanmakuMatchCandidate> &candidates) -> bool {
-            if (candidates.isEmpty()) {
-                return false;
-            }
+        }
 
-            const DanmakuMatchCandidate selected = candidates.first();
-            if (!trimmedManualKeyword.isEmpty()) {
-                result.matched = true;
-                result.selected = selected;
-                result.manualOverride = true;
-                m_cacheStore->saveMatch(context, selected, true);
-                qDebug().noquote()
-                    << "[Danmaku][Service] Manual match selected"
-                    << "| mediaId:" << context.mediaId
-                    << "| keyword:" << trimmedManualKeyword
-                    << "| endpointId:" << selected.endpointId
-                    << "| endpointName:" << selected.endpointName
-                    << "| targetId:" << selected.targetId
-                    << "| score:" << selected.score;
-                return true;
+        DanmakuMatchCandidate selected;
+        for (const DanmakuMatchCandidate &candidate : candidates)
+        {
+            if (isPlausibleOnlineCandidate(context, candidate))
+            {
+                selected = candidate;
+                break;
             }
+        }
+        if (!selected.isValid())
+        {
+            qDebug().noquote() << "[Danmaku][Service] Local candidates rejected by metadata constraints"
+                               << "| mediaId:" << context.mediaId << "| candidateCount:" << candidates.size();
+            return false;
+        }
+        const double threshold = context.isEpisode() ? 44.0 : 36.0;
+        const bool allowSingleCandidateFallback = candidates.size() == 1 && selected.score >= 24.0;
+        qDebug().noquote() << "[Danmaku][Service] Local candidates discovered"
+                           << "| mediaId:" << context.mediaId << "| count:" << candidates.size()
+                           << "| topTargetId:" << selected.targetId << "| topScore:" << selected.score
+                           << "| threshold:" << threshold;
 
-            const double threshold = context.isEpisode() ? 52.0 : 44.0;
-            const bool fallback = selected.score < threshold;
-            if (fallback) {
-                qDebug().noquote()
-                    << "[Danmaku][Service] Best online match below threshold, falling back to highest-score candidate"
-                    << "| mediaId:" << context.mediaId
-                    << "| endpointId:" << selected.endpointId
-                    << "| endpointName:" << selected.endpointName
-                    << "| targetId:" << selected.targetId
-                    << "| score:" << selected.score
-                    << "| threshold:" << threshold;
-            }
-
+        if (selected.score >= threshold || allowSingleCandidateFallback)
+        {
             result.matched = true;
             result.selected = selected;
             result.manualOverride = false;
             m_cacheStore->saveMatch(context, selected, false);
-            qDebug().noquote()
-                << "[Danmaku][Service] Auto match selected"
-                << (fallback ? "| fallback: true" : "")
-                << "| mediaId:" << context.mediaId
-                << "| endpointId:" << selected.endpointId
-                << "| endpointName:" << selected.endpointName
-                << "| targetId:" << selected.targetId
-                << "| score:" << selected.score;
+            qDebug().noquote() << "[Danmaku][Service] Local match selected"
+                               << "| mediaId:" << context.mediaId << "| targetId:" << selected.targetId
+                               << "| score:" << selected.score << "| manualOverride:" << result.manualOverride;
             return true;
-        };
+        }
+        return false;
+    };
+    const auto trySelectOnlineCandidate = [this, &context,
+                                           &result](const QList<DanmakuMatchCandidate> &candidates) -> bool
+    {
+        if (candidates.isEmpty())
+        {
+            return false;
+        }
 
-    for (const QString &source : sourceOrder) {
-        if (source == QLatin1String("local")) {
-            if (!allowLocal) {
+        DanmakuMatchCandidate selected;
+        for (const DanmakuMatchCandidate &candidate : candidates)
+        {
+            if (isPlausibleOnlineCandidate(context, candidate))
+            {
+                selected = candidate;
+                break;
+            }
+        }
+        if (!selected.isValid())
+        {
+            qDebug().noquote() << "[Danmaku][Service] Online candidates rejected by metadata constraints"
+                               << "| mediaId:" << context.mediaId << "| candidateCount:" << candidates.size();
+            return false;
+        }
+
+        const double threshold = onlineConfidenceThreshold(context);
+        if (!selected.isHashMatch() && selected.score < threshold)
+        {
+            qDebug().noquote() << "[Danmaku][Service] Best plausible online match below confidence threshold"
+                               << "| mediaId:" << context.mediaId << "| endpointId:" << selected.endpointId
+                               << "| endpointName:" << selected.endpointName << "| targetId:" << selected.targetId
+                               << "| score:" << selected.score << "| threshold:" << threshold;
+            return false;
+        }
+
+        result.matched = true;
+        result.selected = selected;
+        result.manualOverride = false;
+        m_cacheStore->saveMatch(context, selected, false);
+        qDebug().noquote() << "[Danmaku][Service] Auto match selected"
+                           << "| hashVerified:" << selected.isHashMatch() << "| mediaId:" << context.mediaId
+                           << "| endpointId:" << selected.endpointId << "| endpointName:" << selected.endpointName
+                           << "| targetId:" << selected.targetId << "| score:" << selected.score;
+        return true;
+    };
+
+    for (const QString &source : sourceOrder)
+    {
+        if (source == QLatin1String("local"))
+        {
+            if (!allowLocal)
+            {
                 continue;
             }
 
-            const QList<DanmakuMatchCandidate> localCandidates =
-                searchLocalDanmakuCandidates(
-                    localDanmakuDirectoryPath(context.serverId), context,
-                    trimmedManualKeyword);
+            const QString localDirectory = localDanmakuDirectoryPath(context.serverId);
+            auto localSearchFuture = QtConcurrent::run(
+                [localDirectory, context, trimmedManualKeyword]()
+                { return searchLocalDanmakuCandidates(localDirectory, context, trimmedManualKeyword); });
+            const QList<DanmakuMatchCandidate> localCandidates = co_await localSearchFuture;
             appendCandidates(localCandidates);
-            if (trySelectLocalCandidate(localCandidates)) {
+            if (trySelectLocalCandidate(localCandidates))
+            {
                 result.candidates = aggregatedCandidates;
                 co_return result;
             }
             continue;
         }
 
-        if (!allowOnline) {
+        if (!allowOnline)
+        {
             continue;
         }
 
         QList<DanmakuMatchCandidate> onlineCandidates;
-        for (const DanmakuProviderConfig &providerConfig : onlineProviders) {
-            const DanmakuProviderConfig onlineConfig = providerConfig;
-            try {
-                const QList<DanmakuMatchCandidate> providerCandidates =
-                    co_await searchCandidatesForConfig(
-                        context, onlineConfig, trimmedManualKeyword);
-                onlineCandidates.append(providerCandidates);
-                qDebug().noquote()
-                    << "[Danmaku][Service] Resolve online candidates"
-                    << "| mediaId:" << context.mediaId
-                    << "| endpointId:" << onlineConfig.endpointId
-                    << "| endpointName:" << onlineConfig.endpointName
-                    << "| count:" << providerCandidates.size();
-            } catch (const std::exception &e) {
-                remoteSearchException = std::current_exception();
-                remoteSearchError = QString::fromUtf8(e.what()).trimmed();
-                qWarning().noquote()
-                    << "[Danmaku][Service] Search candidates failed"
-                    << "| mediaId:" << context.mediaId
-                    << "| endpointId:" << onlineConfig.endpointId
-                    << "| endpointName:" << onlineConfig.endpointName
-                    << "| sourceMode:" << sourceMode
-                    << "| manualKeyword:" << trimmedManualKeyword
-                    << "| error:" << remoteSearchError;
+        const QList<ProviderSearchOutcome> outcomes =
+            co_await searchProvidersInParallel(context, onlineProviders, trimmedManualKeyword);
+        for (const ProviderSearchOutcome &outcome : outcomes)
+        {
+            if (outcome.errorMessage.isEmpty())
+            {
+                onlineCandidates.append(outcome.candidates);
+                qDebug().noquote() << "[Danmaku][Service] Resolve online candidates"
+                                   << "| mediaId:" << context.mediaId << "| endpointId:" << outcome.config.endpointId
+                                   << "| endpointName:" << outcome.config.endpointName
+                                   << "| count:" << outcome.candidates.size();
+            }
+            else
+            {
+                remoteSearchError = outcome.errorMessage;
+                remoteSearchException = std::make_exception_ptr(std::runtime_error(remoteSearchError.toStdString()));
+                qWarning().noquote() << "[Danmaku][Service] Search candidates failed"
+                                     << "| mediaId:" << context.mediaId << "| endpointId:" << outcome.config.endpointId
+                                     << "| endpointName:" << outcome.config.endpointName
+                                     << "| sourceMode:" << sourceMode << "| manualKeyword:" << trimmedManualKeyword
+                                     << "| error:" << remoteSearchError;
             }
         }
 
         std::sort(onlineCandidates.begin(), onlineCandidates.end(),
-                  [](const DanmakuMatchCandidate &lhs,
-                     const DanmakuMatchCandidate &rhs) {
-                      if (!qFuzzyCompare(lhs.score, rhs.score)) {
+                  [](const DanmakuMatchCandidate &lhs, const DanmakuMatchCandidate &rhs)
+                  {
+                      if (!qFuzzyCompare(lhs.score, rhs.score))
+                      {
                           return lhs.score > rhs.score;
                       }
-                      if (lhs.commentCount != rhs.commentCount) {
+                      if (lhs.commentCount != rhs.commentCount)
+                      {
                           return lhs.commentCount > rhs.commentCount;
                       }
                       return lhs.endpointName < rhs.endpointName;
                   });
         appendCandidates(onlineCandidates);
-        if (trySelectOnlineCandidate(onlineCandidates)) {
+        if (trySelectOnlineCandidate(onlineCandidates))
+        {
             result.candidates = aggregatedCandidates;
             co_return result;
         }
     }
 
     result.candidates = aggregatedCandidates;
-    if (aggregatedCandidates.isEmpty()) {
-        if (!trimmedManualKeyword.isEmpty() && hasCachedMatch &&
-            cachedCandidateAvailable(cachedCandidate) &&
-            sourceModeAllowsCandidate(cachedCandidate)) {
-            result.matched = true;
-            result.cacheHit = true;
-            result.manualOverride = manualOverride;
-            result.selected = cachedCandidate;
-            qDebug().noquote()
-                << "[Danmaku][Service] Manual search empty, fallback to cached match"
-                << "| mediaId:" << context.mediaId
-                << "| targetId:" << cachedCandidate.targetId;
-            co_return result;
-        }
-
-        if (remoteSearchException) {
+    if (aggregatedCandidates.isEmpty())
+    {
+        if (remoteSearchException)
+        {
             std::rethrow_exception(remoteSearchException);
         }
-    } else if (remoteSearchException) {
-        qWarning().noquote()
-            << "[Danmaku][Service] Keep available candidates after remote search failure"
-            << "| mediaId:" << context.mediaId
-            << "| candidateCount:" << aggregatedCandidates.size()
-            << "| error:" << remoteSearchError;
+    }
+    else if (remoteSearchException)
+    {
+        qWarning().noquote() << "[Danmaku][Service] Keep available candidates after remote search failure"
+                             << "| mediaId:" << context.mediaId << "| candidateCount:" << aggregatedCandidates.size()
+                             << "| error:" << remoteSearchError;
     }
 
     co_return result;
 }
 
-void DanmakuService::saveManualMatch(const DanmakuMediaContext &context,
-                                     const DanmakuMatchCandidate &candidate)
+void DanmakuService::saveManualMatch(const DanmakuMediaContext &context, const DanmakuMatchCandidate &candidate)
 {
-    if (!candidate.isValid()) {
+    if (!candidate.isValid())
+    {
         return;
     }
     m_cacheStore->saveMatch(context, candidate, true);
-    qDebug().noquote()
-        << "[Danmaku][Service] Manual match saved"
-        << "| mediaId:" << context.mediaId
-        << "| endpointId:" << candidate.endpointId
-        << "| endpointName:" << candidate.endpointName
-        << "| targetId:" << candidate.targetId;
+    qDebug().noquote() << "[Danmaku][Service] Manual match saved"
+                       << "| mediaId:" << context.mediaId << "| endpointId:" << candidate.endpointId
+                       << "| endpointName:" << candidate.endpointName << "| targetId:" << candidate.targetId;
 }
 
 void DanmakuService::clearCache()
@@ -1710,8 +1952,7 @@ void DanmakuService::clearCache()
     qDebug() << "[Danmaku][Service] Cache cleared";
 }
 
-QString DanmakuService::assCacheKey(const DanmakuMatchCandidate &candidate,
-                                    const DanmakuRenderOptions &options) const
+QString DanmakuService::assCacheKey(const DanmakuMatchCandidate &candidate, const DanmakuRenderOptions &options) const
 {
     QJsonObject obj;
     obj["assRenderVersion"] = kDanmakuAssRenderVersion;
@@ -1728,23 +1969,21 @@ QString DanmakuService::assCacheKey(const DanmakuMatchCandidate &candidate,
     obj["hideScroll"] = options.hideScroll;
     obj["hideTop"] = options.hideTop;
     obj["hideBottom"] = options.hideBottom;
-    if (candidate.provider == QLatin1String(kLocalDanmakuProvider)) {
+    if (candidate.provider == QLatin1String(kLocalDanmakuProvider))
+    {
         const QFileInfo fileInfo(candidate.targetId);
         obj["localPath"] = QDir::fromNativeSeparators(
-            fileInfo.canonicalFilePath().isEmpty() ? fileInfo.absoluteFilePath()
-                                                   : fileInfo.canonicalFilePath());
+            fileInfo.canonicalFilePath().isEmpty() ? fileInfo.absoluteFilePath() : fileInfo.canonicalFilePath());
         obj["localSize"] = QString::number(fileInfo.size());
-        obj["localModifiedAt"] =
-            QString::number(fileInfo.lastModified().toMSecsSinceEpoch());
+        obj["localModifiedAt"] = QString::number(fileInfo.lastModified().toMSecsSinceEpoch());
     }
     QJsonArray blocked;
-    for (const QString &keyword : options.blockedKeywords) {
+    for (const QString &keyword : options.blockedKeywords)
+    {
         blocked.append(keyword);
     }
     obj["blockedKeywords"] = blocked;
 
     return QString::fromLatin1(
-        QCryptographicHash::hash(QJsonDocument(obj).toJson(QJsonDocument::Compact),
-                                 QCryptographicHash::Sha1)
-            .toHex());
+        QCryptographicHash::hash(QJsonDocument(obj).toJson(QJsonDocument::Compact), QCryptographicHash::Sha1).toHex());
 }

--- a/src/qEmbyCore/services/danmaku/danmakuservice.h
+++ b/src/qEmbyCore/services/danmaku/danmakuservice.h
@@ -9,6 +9,7 @@
 class NetworkManager;
 class ServerManager;
 class DandanplayProvider;
+class DanmuApiProvider;
 class DanmakuCacheStore;
 
 class QEMBYCORE_EXPORT DanmakuService : public QObject
@@ -52,6 +53,12 @@ public:
     void clearCache();
 
 private:
+    struct ProviderSearchOutcome {
+        DanmakuProviderConfig config;
+        QList<DanmakuMatchCandidate> candidates;
+        QString errorMessage;
+    };
+
     bool autoMatchEnabled(const QString &serverId) const;
     QList<DanmakuProviderConfig> enabledProviderConfigs(
         QString serverId = QString()) const;
@@ -62,12 +69,21 @@ private:
         DanmakuMediaContext context,
         DanmakuProviderConfig config,
         QString manualKeyword = QString());
+    QCoro::Task<QList<ProviderSearchOutcome>> searchProvidersInParallel(
+        DanmakuMediaContext context,
+        QList<DanmakuProviderConfig> configs,
+        QString manualKeyword = QString());
+    QCoro::Task<ProviderSearchOutcome> searchProviderSafely(
+        DanmakuMediaContext context,
+        DanmakuProviderConfig config,
+        QString manualKeyword = QString());
     QString assCacheKey(const DanmakuMatchCandidate &candidate,
                         const DanmakuRenderOptions &options) const;
 
     NetworkManager *m_networkManager;
     ServerManager *m_serverManager;
     DandanplayProvider *m_dandanplayProvider;
+    DanmuApiProvider *m_danmuApiProvider;
     DanmakuCacheStore *m_cacheStore;
 };
 

--- a/src/qEmbyCore/services/danmaku/danmakusettings.cpp
+++ b/src/qEmbyCore/services/danmaku/danmakusettings.cpp
@@ -182,17 +182,31 @@ QList<DanmakuServerDefinition> normalizedServers(QList<DanmakuServerDefinition> 
     {
         server.id = server.id.trimmed();
         server.name = server.name.trimmed();
-        server.provider = server.provider.trimmed();
+        server.provider = server.provider.trimmed().toLower();
         server.baseUrl = normalizeBaseUrl(server.baseUrl);
         server.description = server.description.trimmed();
         server.appId = server.appId.trimmed();
         server.appSecret = server.appSecret.trimmed();
+        server.accessToken = server.accessToken.trimmed();
         server.contentScope = server.contentScope.trimmed().toLower();
         server.builtIn = isBuiltInOfficialDandanplayServer(server);
 
         if (server.provider.isEmpty())
         {
             server.provider = QString::fromLatin1(kOfficialDandanplayProvider);
+        }
+        if (server.provider == QLatin1String("danmu_api"))
+        {
+            server.appId.clear();
+            server.appSecret.clear();
+            if (server.contentScope.isEmpty())
+            {
+                server.contentScope = QStringLiteral("general");
+            }
+        }
+        else
+        {
+            server.accessToken.clear();
         }
         if (server.id.isEmpty())
         {
@@ -250,6 +264,7 @@ QList<DanmakuServerDefinition> parseServers(const QString &json)
         server.description = object.value(QStringLiteral("description")).toString().trimmed();
         server.appId = object.value(QStringLiteral("appId")).toString().trimmed();
         server.appSecret = object.value(QStringLiteral("appSecret")).toString().trimmed();
+        server.accessToken = object.value(QStringLiteral("accessToken")).toString().trimmed();
         server.contentScope = object.value(QStringLiteral("contentScope")).toString().trimmed();
         server.builtIn = object.value(QStringLiteral("builtIn")).toBool(false);
         server.enabled = object.value(QStringLiteral("enabled")).toBool(true);
@@ -270,6 +285,7 @@ QJsonArray toJsonArray(const QList<DanmakuServerDefinition> &servers)
             savedServer.description.clear();
             savedServer.appId.clear();
             savedServer.appSecret.clear();
+            savedServer.accessToken.clear();
         }
 
         QJsonObject object;
@@ -280,6 +296,7 @@ QJsonArray toJsonArray(const QList<DanmakuServerDefinition> &servers)
         object.insert(QStringLiteral("description"), savedServer.description);
         object.insert(QStringLiteral("appId"), savedServer.appId);
         object.insert(QStringLiteral("appSecret"), savedServer.appSecret);
+        object.insert(QStringLiteral("accessToken"), savedServer.accessToken);
         object.insert(QStringLiteral("contentScope"), savedServer.contentScope);
         object.insert(QStringLiteral("builtIn"), savedServer.builtIn);
         object.insert(QStringLiteral("enabled"), savedServer.enabled);

--- a/src/qEmbyCore/services/danmaku/danmuapiprovider.cpp
+++ b/src/qEmbyCore/services/danmaku/danmuapiprovider.cpp
@@ -1,0 +1,597 @@
+#include "danmuapiprovider.h"
+
+#include <QColor>
+#include <QDateTime>
+#include <QDebug>
+#include <QFileInfo>
+#include <QHash>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QRegularExpression>
+#include <QSet>
+#include <QUrl>
+#include <QUrlQuery>
+#include <algorithm>
+#include <cmath>
+#include <exception>
+#include <stdexcept>
+#include <utility>
+
+namespace {
+
+constexpr int kDanmuApiRequestTimeoutMs = 20000;
+
+struct SearchHint {
+    QString subject;
+    int seasonNumber = -1;
+    int episodeNumber = -1;
+};
+
+NetworkRequestOptions requestOptions()
+{
+    NetworkRequestOptions options;
+    options.timeoutMs = kDanmuApiRequestTimeoutMs;
+    return options;
+}
+
+QMap<QString, QString> requestHeaders()
+{
+    return {{QStringLiteral("Accept"), QStringLiteral("application/json")},
+            {QStringLiteral("User-Agent"),
+             QStringLiteral("qEmby/1.0 (Danmaku)")}};
+}
+
+QString stringField(const QJsonObject &object,
+                    std::initializer_list<const char *> keys)
+{
+    for (const char *key : keys) {
+        const QString value =
+            object.value(QLatin1String(key)).toVariant().toString().trimmed();
+        if (!value.isEmpty()) {
+            return value;
+        }
+    }
+    return {};
+}
+
+int intField(const QJsonObject &object,
+             std::initializer_list<const char *> keys,
+             int fallback = -1)
+{
+    for (const char *key : keys) {
+        const QJsonValue value = object.value(QLatin1String(key));
+        if (!value.isUndefined() && !value.isNull()) {
+            bool ok = false;
+            const int parsed = value.toVariant().toString().toInt(&ok);
+            if (ok) {
+                return parsed;
+            }
+        }
+    }
+    return fallback;
+}
+
+void ensureSuccessfulResponse(const QJsonObject &response,
+                              const QString &operation)
+{
+    if (!response.contains(QStringLiteral("success")) ||
+        response.value(QStringLiteral("success")).toBool(true)) {
+        return;
+    }
+    const QString message = stringField(
+        response, {"errorMessage", "message", "error"});
+    throw std::runtime_error(
+        QStringLiteral("%1: %2")
+            .arg(operation,
+                 message.isEmpty() ? QStringLiteral("request rejected")
+                                   : message)
+            .toStdString());
+}
+
+QString buildUrl(const DanmakuProviderConfig &config,
+                 const QString &apiPath,
+                 const QList<QPair<QString, QString>> &queryItems = {})
+{
+    QUrl url = QUrl::fromUserInput(config.baseUrl.trimmed());
+    QString path = url.path();
+    while (path.endsWith('/') && path.size() > 1) {
+        path.chop(1);
+    }
+
+    const QString token = config.accessToken.trimmed();
+    if (!token.isEmpty()) {
+        const QString lastSegment = path.section('/', -1);
+        if (lastSegment != token) {
+            if (!path.endsWith('/')) {
+                path.append('/');
+            }
+            path.append(token);
+        }
+    }
+
+    if (!path.endsWith('/')) {
+        path.append('/');
+    }
+    path.append(apiPath.startsWith('/') ? apiPath.mid(1) : apiPath);
+    url.setPath(path);
+
+    QUrlQuery query;
+    for (const auto &item : queryItems) {
+        if (!item.second.trimmed().isEmpty()) {
+            query.addQueryItem(item.first, item.second.trimmed());
+        }
+    }
+    url.setQuery(query);
+    return url.toString();
+}
+
+QString normalizedTitle(QString value)
+{
+    value = value.trimmed().toLower();
+    value.remove(QRegularExpression(QStringLiteral(R"([^\p{L}\p{N}]+)")));
+    return value;
+}
+
+double titleScore(const QString &lhs, const QString &rhs)
+{
+    const QString left = normalizedTitle(lhs);
+    const QString right = normalizedTitle(rhs);
+    if (left.isEmpty() || right.isEmpty()) {
+        return 0.0;
+    }
+    if (left == right) {
+        return 1.0;
+    }
+    if (left.contains(right) || right.contains(left)) {
+        return 0.82;
+    }
+    if (left.size() < 2 || right.size() < 2) {
+        return 0.0;
+    }
+
+    QSet<QString> leftPairs;
+    QSet<QString> rightPairs;
+    for (int i = 0; i + 1 < left.size(); ++i) {
+        leftPairs.insert(left.mid(i, 2));
+    }
+    for (int i = 0; i + 1 < right.size(); ++i) {
+        rightPairs.insert(right.mid(i, 2));
+    }
+    int common = 0;
+    for (const QString &pair : std::as_const(leftPairs)) {
+        if (rightPairs.contains(pair)) {
+            ++common;
+        }
+    }
+    return (2.0 * common) / (leftPairs.size() + rightPairs.size());
+}
+
+int extractSeasonNumber(const QString &text)
+{
+    static const QList<QRegularExpression> patterns = {
+        QRegularExpression(
+            QStringLiteral(R"((?:^|[^A-Za-z0-9])S\s*0*(\d{1,2})(?:[^A-Za-z0-9]|$))"),
+            QRegularExpression::CaseInsensitiveOption),
+        QRegularExpression(
+            QStringLiteral(R"(第\s*0*(\d{1,2})\s*[季部期])")),
+        QRegularExpression(
+            QStringLiteral(R"((?:Season\s*|)(\d{1,2})(?:st|nd|rd|th)?\s*(?:Season|期))"),
+            QRegularExpression::CaseInsensitiveOption)};
+    for (const QRegularExpression &pattern : patterns) {
+        const QRegularExpressionMatch match = pattern.match(text);
+        if (match.hasMatch()) {
+            return match.captured(1).toInt();
+        }
+    }
+    return 0;
+}
+
+int extractEpisodeNumber(const QString &text)
+{
+    static const QList<QRegularExpression> patterns = {
+        QRegularExpression(
+            QStringLiteral(R"((?:^|[^A-Za-z0-9])S\s*0*\d{1,2}\s*E\s*0*(\d{1,4})(?:[^A-Za-z0-9]|$))"),
+            QRegularExpression::CaseInsensitiveOption),
+        QRegularExpression(
+            QStringLiteral(R"(第\s*0*(\d{1,4})\s*[话話集期])")),
+        QRegularExpression(
+            QStringLiteral(R"((?:^|[^A-Za-z0-9])(?:EP?|Episode)\s*[._-]?\s*0*(\d{1,4})(?:[^A-Za-z0-9]|$))"),
+            QRegularExpression::CaseInsensitiveOption)};
+    for (const QRegularExpression &pattern : patterns) {
+        const QRegularExpressionMatch match = pattern.match(text);
+        if (match.hasMatch()) {
+            return match.captured(1).toInt();
+        }
+    }
+    bool ok = false;
+    const int number = text.trimmed().toInt(&ok);
+    return ok ? number : 0;
+}
+
+SearchHint parseSearchHint(const QString &input,
+                           const DanmakuMediaContext &context)
+{
+    SearchHint hint;
+    hint.subject = input.trimmed();
+    hint.seasonNumber = context.seasonNumber;
+    hint.episodeNumber = context.episodeNumber;
+
+    static const QList<QRegularExpression> patterns = {
+        QRegularExpression(
+            QStringLiteral(R"((?:^|[\s._-])S\s*0*(\d{1,2})\s*E\s*0*(\d{1,4})(?=$|[\s._-]))"),
+            QRegularExpression::CaseInsensitiveOption),
+        QRegularExpression(
+            QStringLiteral(R"(第\s*0*(\d{1,2})\s*季\s*第?\s*0*(\d{1,4})\s*[话話集期])"))};
+    for (const QRegularExpression &pattern : patterns) {
+        const QRegularExpressionMatch match = pattern.match(hint.subject);
+        if (!match.hasMatch()) {
+            continue;
+        }
+        hint.seasonNumber = match.captured(1).toInt();
+        hint.episodeNumber = match.captured(2).toInt();
+        hint.subject.remove(match.capturedStart(), match.capturedLength());
+        hint.subject = hint.subject.trimmed();
+        break;
+    }
+    if (hint.subject.isEmpty()) {
+        hint.subject = context.isEpisode() ? context.seriesName.trimmed()
+                                           : context.title.trimmed();
+    }
+    return hint;
+}
+
+double candidateScore(const DanmakuMediaContext &context,
+                      const DanmakuMatchCandidate &candidate,
+                      const QString &query)
+{
+    const QString subject =
+        context.isEpisode() ? context.seriesName : context.title;
+    const QString candidateSubject = candidate.subtitle.isEmpty()
+                                         ? candidate.title
+                                         : candidate.subtitle;
+    double score = titleScore(subject, candidateSubject) * 55.0;
+    score += titleScore(query, candidateSubject) * 20.0;
+    score += titleScore(context.title, candidate.title) * 8.0;
+    if (context.isEpisode() && context.episodeNumber > 0 &&
+        candidate.episodeNumber == context.episodeNumber) {
+        score += 24.0;
+    }
+    if (context.isEpisode() && context.seasonNumber > 0) {
+        if (candidate.seasonNumber == context.seasonNumber) {
+            score += 24.0;
+        } else if (candidate.seasonNumber > 0) {
+            score -= 35.0;
+        } else if (context.seasonNumber == 1) {
+            score += 5.0;
+        }
+    }
+    return score;
+}
+
+QList<DanmakuMatchCandidate> parseEpisodeSearchResponse(
+    const QJsonObject &response,
+    const DanmakuMediaContext &context,
+    const QString &query,
+    int requestedEpisode)
+{
+    QList<DanmakuMatchCandidate> candidates;
+    const QJsonArray animes = response.value(QStringLiteral("animes")).toArray();
+    for (const QJsonValue &animeValue : animes) {
+        const QJsonObject anime = animeValue.toObject();
+        const QString animeTitle =
+            stringField(anime, {"animeTitle", "title", "name"});
+        const int animeSeason = extractSeasonNumber(animeTitle);
+        const QJsonArray episodes =
+            anime.value(QStringLiteral("episodes")).toArray();
+        for (const QJsonValue &episodeValue : episodes) {
+            const QJsonObject episode = episodeValue.toObject();
+            DanmakuMatchCandidate candidate;
+            candidate.provider = QStringLiteral("danmu_api");
+            candidate.targetId =
+                stringField(episode, {"episodeId", "id", "episodeID"});
+            candidate.title = stringField(
+                episode, {"episodeTitle", "title", "name"});
+            candidate.subtitle = animeTitle;
+            candidate.seasonNumber = animeSeason;
+            candidate.episodeNumber = intField(
+                episode, {"episodeNumber", "episode", "sort"}, -1);
+            if (candidate.episodeNumber <= 0) {
+                candidate.episodeNumber = extractEpisodeNumber(candidate.title);
+            }
+            if (candidate.episodeNumber <= 0 && requestedEpisode > 0) {
+                candidate.episodeNumber = requestedEpisode;
+            }
+            candidate.matchReason = QStringLiteral("search");
+            candidate.score = candidateScore(context, candidate, query);
+            if (candidate.isValid()) {
+                candidates.append(candidate);
+            }
+        }
+    }
+    return candidates;
+}
+
+QList<DanmakuMatchCandidate> parseMatchResponse(
+    const QJsonObject &response,
+    const DanmakuMediaContext &context,
+    const QString &fileName)
+{
+    QList<DanmakuMatchCandidate> candidates;
+    const bool matched = response.value(QStringLiteral("isMatched")).toBool();
+    const QJsonArray matches = response.value(QStringLiteral("matches")).toArray();
+    for (const QJsonValue &value : matches) {
+        const QJsonObject match = value.toObject();
+        DanmakuMatchCandidate candidate;
+        candidate.provider = QStringLiteral("danmu_api");
+        candidate.targetId =
+            stringField(match, {"episodeId", "id", "episodeID"});
+        candidate.title = stringField(
+            match, {"episodeTitle", "title", "name"});
+        candidate.subtitle = stringField(
+            match, {"animeTitle", "animeName"});
+        candidate.seasonNumber = extractSeasonNumber(candidate.subtitle);
+        candidate.episodeNumber = extractEpisodeNumber(candidate.title);
+        candidate.matchReason = matched ? QStringLiteral("filename")
+                                        : QStringLiteral("match-candidate");
+        candidate.score = candidateScore(context, candidate, fileName);
+        if (matched) {
+            candidate.score += 10.0;
+        }
+        if (candidate.isValid()) {
+            candidates.append(candidate);
+        }
+    }
+    return candidates;
+}
+
+QList<DanmakuMatchCandidate> deduplicate(
+    const QList<DanmakuMatchCandidate> &input)
+{
+    QHash<QString, DanmakuMatchCandidate> best;
+    for (const DanmakuMatchCandidate &candidate : input) {
+        const auto existing = best.constFind(candidate.targetId);
+        if (existing == best.constEnd() || candidate.score > existing->score) {
+            best.insert(candidate.targetId, candidate);
+        }
+    }
+    QList<DanmakuMatchCandidate> result = best.values();
+    std::sort(result.begin(), result.end(),
+              [](const DanmakuMatchCandidate &left,
+                 const DanmakuMatchCandidate &right) {
+                  return left.score > right.score;
+              });
+    return result;
+}
+
+QColor parseColor(const QString &value)
+{
+    bool ok = false;
+    const uint rgb = value.toUInt(&ok, 10);
+    if (ok) {
+        return QColor::fromRgb(rgb);
+    }
+    const QColor color(value);
+    return color.isValid() ? color : QColor(Qt::white);
+}
+
+QList<DanmakuComment> parseComments(const QJsonObject &response)
+{
+    QList<DanmakuComment> comments;
+    const QJsonArray array = response.value(QStringLiteral("comments")).toArray();
+    comments.reserve(array.size());
+    for (const QJsonValue &value : array) {
+        const QJsonObject object = value.toObject();
+        DanmakuComment comment;
+        comment.text = stringField(object, {"m", "text", "content"});
+        const QString p = stringField(object, {"p"});
+        if (!p.isEmpty()) {
+            const QStringList parts = p.split(',', Qt::KeepEmptyParts);
+            if (!parts.isEmpty()) {
+                comment.timeMs =
+                    static_cast<qint64>(parts.at(0).toDouble() * 1000.0);
+            }
+            if (parts.size() > 1) {
+                comment.mode = parts.at(1).toInt();
+            }
+            if (parts.size() > 2) {
+                comment.color = parseColor(parts.at(2));
+            }
+            if (parts.size() > 3) {
+                comment.sender = parts.at(3).trimmed();
+            }
+        } else {
+            const double rawTime =
+                object.value(QStringLiteral("time")).toVariant().toDouble();
+            if (rawTime > 0.0 && rawTime < 1000.0) {
+                comment.timeMs = static_cast<qint64>(rawTime * 1000.0);
+            } else {
+                comment.timeMs = static_cast<qint64>(rawTime);
+            }
+            comment.mode = intField(object, {"mode", "positionType"}, 1);
+            comment.color = parseColor(
+                object.value(QStringLiteral("color")).toVariant().toString());
+        }
+        if (comment.isValid()) {
+            comments.append(comment);
+        }
+    }
+    return comments;
+}
+
+} 
+
+DanmuApiProvider::DanmuApiProvider(NetworkManager *networkManager)
+    : m_networkManager(networkManager)
+{
+}
+
+QCoro::Task<QList<DanmakuMatchCandidate>> DanmuApiProvider::searchCandidates(
+    DanmakuMediaContext context,
+    DanmakuProviderConfig config,
+    QString manualKeyword) const
+{
+    QList<DanmakuMatchCandidate> allCandidates;
+    if (!m_networkManager || config.baseUrl.trimmed().isEmpty()) {
+        co_return allCandidates;
+    }
+
+    const bool manual = !manualKeyword.trimmed().isEmpty();
+    const SearchHint hint = parseSearchHint(
+        manual ? manualKeyword
+               : (context.isEpisode() ? context.seriesName : context.title),
+        context);
+    DanmakuMediaContext searchContext = context;
+    if (searchContext.isEpisode()) {
+        searchContext.seriesName = hint.subject;
+        searchContext.seasonNumber = hint.seasonNumber;
+        searchContext.episodeNumber = hint.episodeNumber;
+    } else if (manual) {
+        searchContext.title = hint.subject;
+        searchContext.originalTitle.clear();
+    }
+
+    QString fileName = context.fileName.trimmed();
+    if (fileName.isEmpty() && !context.path.trimmed().isEmpty()) {
+        fileName = QFileInfo(context.path.trimmed()).completeBaseName().trimmed();
+    }
+    if (!manual && !fileName.isEmpty()) {
+        try {
+            const QString path = QStringLiteral("/api/v2/match");
+            const QString url = buildUrl(config, path);
+            const QMap<QString, QString> headers = requestHeaders();
+            const QJsonObject payload{
+                {QStringLiteral("fileName"), fileName}};
+            const NetworkRequestOptions options = requestOptions();
+            const QJsonObject response = co_await m_networkManager->post(
+                url, headers, payload, options);
+            ensureSuccessfulResponse(response, QStringLiteral("match"));
+            const QList<DanmakuMatchCandidate> matchCandidates =
+                parseMatchResponse(response, context, fileName);
+            allCandidates.append(matchCandidates);
+            qDebug().noquote()
+                << "[Danmaku][DanmuApi] Filename match"
+                << "| endpointId:" << config.endpointId
+                << "| mediaId:" << context.mediaId
+                << "| matched:"
+                << response.value(QStringLiteral("isMatched")).toBool()
+                << "| count:" << matchCandidates.size();
+            const double directMatchThreshold =
+                context.isEpisode() ? 72.0 : 62.0;
+            if (response.value(QStringLiteral("isMatched")).toBool() &&
+                !matchCandidates.isEmpty() &&
+                matchCandidates.first().score >= directMatchThreshold) {
+                co_return deduplicate(allCandidates);
+            }
+        } catch (const std::exception &e) {
+            qWarning().noquote()
+                << "[Danmaku][DanmuApi] Filename match failed"
+                << "| endpointId:" << config.endpointId
+                << "| mediaId:" << context.mediaId
+                << "| error:" << e.what();
+        }
+    }
+
+    QString querySubject = hint.subject;
+    if (searchContext.isEpisode() &&
+        (hint.seasonNumber == 0 || hint.seasonNumber > 1) &&
+        extractSeasonNumber(querySubject) <= 0) {
+        querySubject += QStringLiteral(" S%1").arg(hint.seasonNumber, 2, 10,
+                                                   QChar('0'));
+    }
+    QString episodeParameter;
+    if (searchContext.isEpisode() && hint.episodeNumber > 0) {
+        episodeParameter = QString::number(hint.episodeNumber);
+    } else if (!searchContext.isEpisode()) {
+        episodeParameter = QStringLiteral("movie");
+    }
+
+    const QString path = QStringLiteral("/api/v2/search/episodes");
+    QJsonObject response;
+    try {
+        const QList<QPair<QString, QString>> queryItems{
+            {QStringLiteral("anime"), querySubject},
+            {QStringLiteral("episode"), episodeParameter}};
+        const QString url = buildUrl(config, path, queryItems);
+        const QMap<QString, QString> headers = requestHeaders();
+        const NetworkRequestOptions options = requestOptions();
+        response = co_await m_networkManager->get(
+            url, headers, options);
+        ensureSuccessfulResponse(response, QStringLiteral("episode search"));
+    } catch (const std::exception &e) {
+        if (allCandidates.isEmpty()) {
+            throw;
+        }
+        qWarning().noquote()
+            << "[Danmaku][DanmuApi] Metadata search failed, keeping filename candidates"
+            << "| endpointId:" << config.endpointId
+            << "| mediaId:" << context.mediaId
+            << "| error:" << e.what();
+        co_return deduplicate(allCandidates);
+    }
+    QList<DanmakuMatchCandidate> searchCandidates = parseEpisodeSearchResponse(
+        response, searchContext, hint.subject, hint.episodeNumber);
+    searchCandidates.erase(
+        std::remove_if(
+            searchCandidates.begin(), searchCandidates.end(),
+            [&searchContext](const DanmakuMatchCandidate &candidate) {
+                if (!searchContext.isEpisode()) {
+                    return false;
+                }
+                if (searchContext.episodeNumber > 0 &&
+                    candidate.episodeNumber > 0 &&
+                    candidate.episodeNumber != searchContext.episodeNumber) {
+                    return true;
+                }
+                if (searchContext.seasonNumber > 0 &&
+                    candidate.seasonNumber > 0 &&
+                    candidate.seasonNumber != searchContext.seasonNumber) {
+                    return true;
+                }
+                
+                
+                
+                return false;
+            }),
+        searchCandidates.end());
+    allCandidates.append(searchCandidates);
+
+    qDebug().noquote()
+        << "[Danmaku][DanmuApi] Metadata search"
+        << "| endpointId:" << config.endpointId
+        << "| mediaId:" << context.mediaId
+        << "| season:" << hint.seasonNumber
+        << "| episode:" << hint.episodeNumber
+        << "| movieMode:" << !searchContext.isEpisode()
+        << "| count:" << searchCandidates.size();
+    co_return deduplicate(allCandidates);
+}
+
+QCoro::Task<QList<DanmakuComment>> DanmuApiProvider::fetchComments(
+    DanmakuMatchCandidate candidate,
+    DanmakuProviderConfig config) const
+{
+    if (!m_networkManager || !candidate.isValid()) {
+        co_return QList<DanmakuComment>{};
+    }
+
+    const QString path =
+        QStringLiteral("/api/v2/comment/%1").arg(candidate.targetId);
+    const QList<QPair<QString, QString>> queryItems{
+        {QStringLiteral("format"), QStringLiteral("json")},
+        {QStringLiteral("duration"), QStringLiteral("true")}};
+    const QString url = buildUrl(config, path, queryItems);
+    const QMap<QString, QString> headers = requestHeaders();
+    const NetworkRequestOptions options = requestOptions();
+    const QJsonObject response = co_await m_networkManager->get(
+        url, headers, options);
+    ensureSuccessfulResponse(response, QStringLiteral("comments"));
+    const QList<DanmakuComment> comments = parseComments(response);
+    qDebug().noquote()
+        << "[Danmaku][DanmuApi] Comments fetched"
+        << "| endpointId:" << config.endpointId
+        << "| targetId:" << candidate.targetId
+        << "| videoDuration:"
+        << response.value(QStringLiteral("videoDuration")).toVariant().toLongLong()
+        << "| count:" << comments.size();
+    co_return comments;
+}

--- a/src/qEmbyCore/services/danmaku/danmuapiprovider.h
+++ b/src/qEmbyCore/services/danmaku/danmuapiprovider.h
@@ -1,0 +1,25 @@
+#ifndef DANMUAPIPROVIDER_H
+#define DANMUAPIPROVIDER_H
+
+#include "../../api/networkmanager.h"
+#include "../../models/danmaku/danmakumodels.h"
+
+class DanmuApiProvider
+{
+public:
+    explicit DanmuApiProvider(NetworkManager *networkManager);
+
+    QCoro::Task<QList<DanmakuMatchCandidate>> searchCandidates(
+        DanmakuMediaContext context,
+        DanmakuProviderConfig config,
+        QString manualKeyword = QString()) const;
+
+    QCoro::Task<QList<DanmakuComment>> fetchComments(
+        DanmakuMatchCandidate candidate,
+        DanmakuProviderConfig config) const;
+
+private:
+    NetworkManager *m_networkManager;
+};
+
+#endif 

--- a/src/qEmbyCore/services/media/mediaservice.cpp
+++ b/src/qEmbyCore/services/media/mediaservice.cpp
@@ -8,6 +8,7 @@
 #include <QDateTime>
 #include <QDebug>
 #include <QDir>
+#include <QElapsedTimer>
 #include <QFile>
 #include <QHash>
 #include <QImage>
@@ -16,10 +17,13 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QNetworkAccessManager>
+#include <QAbstractNetworkCache>
 #include <QNetworkDiskCache>
 #include <QNetworkReply>
 #include <QPointer>
+#include <QPromise>
 #include <QSettings>
+#include <QScopeGuard>
 #include <QSet>
 #include <QStandardPaths>
 #include <QUrl>
@@ -34,50 +38,56 @@
 
 namespace
 {
-template <typename T> QList<T> parseJsonArray(const QJsonArray &array)
-{
-    QList<T> list;
-    for (const auto &val : array)
+    constexpr int kDecodedImageCacheCostKb = 128 * 1024;
+    constexpr int kImageTransferTimeoutMs = 30 * 1000;
+    constexpr int kMaxGlobalImageNetworkRequests = 8;
+    constexpr qint64 kSlowImageRequestThresholdMs = 500;
+    constexpr int kImageWidthBuckets[] = {
+        160, 240, 320, 480, 640, 768, 1024, 1280, 1920};
+
+    int bucketImageWidth(int width)
     {
-        list.append(T::fromJson(val.toObject()));
-    }
-    return list;
-}
+        if (width <= 0)
+        {
+            return width;
+        }
 
-MediaQueryPage parseMediaQueryPage(const QJsonObject& response, int startIndex,
-                                   int limit)
-{
-    MediaQueryPage page;
-    page.items = parseJsonArray<MediaItem>(response.value("Items").toArray());
-    page.startIndex = qMax(0, startIndex);
-    page.limit = limit;
-    page.hasTotalRecordCount =
-        response.contains(QStringLiteral("TotalRecordCount"));
-    page.totalRecordCount =
-        response.value(QStringLiteral("TotalRecordCount"))
-            .toInt(page.startIndex + page.items.size());
-    return page;
-}
-
-
-
-
-
-
-
-
-constexpr int kRecommendCacheFormatVersion = 7;
-constexpr int kDefaultRecommendFetchLimit = 1000;
-
-QString appendMediaCardTooltipFields(QString fieldsCsv)
-{
-    QStringList fields =
-        fieldsCsv.split(QLatin1Char(','), Qt::SkipEmptyParts);
-
-    for (QString& field : fields) {
-        field = field.trimmed();
+        for (const int bucket : kImageWidthBuckets)
+        {
+            if (width <= bucket)
+            {
+                return bucket;
+            }
+        }
+        return width;
     }
 
+    template <typename T>
+    QList<T> parseJsonArray(const QJsonArray &array)
+    {
+        QList<T> list;
+        for (const auto &val : array)
+        {
+            list.append(T::fromJson(val.toObject()));
+        }
+        return list;
+    }
+
+    MediaQueryPage parseMediaQueryPage(const QJsonObject &response, int startIndex,
+                                       int limit)
+    {
+        MediaQueryPage page;
+        page.items = parseJsonArray<MediaItem>(response.value("Items").toArray());
+        page.startIndex = qMax(0, startIndex);
+        page.limit = limit;
+        page.hasTotalRecordCount =
+            response.contains(QStringLiteral("TotalRecordCount"));
+        page.totalRecordCount =
+            response.value(QStringLiteral("TotalRecordCount"))
+                .toInt(page.startIndex + page.items.size());
+        return page;
+    }
+
     
     
     
@@ -85,293 +95,367 @@ QString appendMediaCardTooltipFields(QString fieldsCsv)
     
     
     
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    const QStringList tooltipFields = {
-        QStringLiteral("PremiereDate"),
-        QStringLiteral("RunTimeTicks"),
-        QStringLiteral("Overview"),
-        QStringLiteral("Genres"),
-        QStringLiteral("OfficialRating"),
-        QStringLiteral("Taglines"),
-        QStringLiteral("MediaSources"),
-        QStringLiteral("MediaStreams"),
-        QStringLiteral("Tags"),
-        QStringLiteral("Studios"),
-        QStringLiteral("ExternalUrls"),
+    constexpr int kRecommendCacheFormatVersion = 7;
+    constexpr int kDefaultRecommendFetchLimit = 1000;
+
+    QString appendMediaCardTooltipFields(QString fieldsCsv)
+    {
+        QStringList fields =
+            fieldsCsv.split(QLatin1Char(','), Qt::SkipEmptyParts);
+
+        for (QString &field : fields)
+        {
+            field = field.trimmed();
+        }
+
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        const QStringList tooltipFields = {
+            QStringLiteral("PremiereDate"),
+            QStringLiteral("RunTimeTicks"),
+            QStringLiteral("Overview"),
+            QStringLiteral("Genres"),
+            QStringLiteral("OfficialRating"),
+            QStringLiteral("Taglines"),
+            QStringLiteral("MediaSources"),
+            QStringLiteral("MediaStreams"),
+            QStringLiteral("Tags"),
+            QStringLiteral("Studios"),
+            QStringLiteral("ExternalUrls"),
+        };
+
+        for (const QString &field : tooltipFields)
+        {
+            if (!fields.contains(field, Qt::CaseInsensitive))
+            {
+                fields.append(field);
+            }
+        }
+
+        return fields.join(QLatin1Char(','));
+    }
+
+    struct PlayedItemEntry
+    {
+        MediaItem item;
+        QDateTime playedAt;
+        int sequence = 0;
     };
 
-    for (const QString& field : tooltipFields) {
-        if (!fields.contains(field, Qt::CaseInsensitive)) {
-            fields.append(field);
+    QDateTime parseServerDateTime(const QString &rawValue)
+    {
+        const QString trimmed = rawValue.trimmed();
+        if (trimmed.isEmpty())
+        {
+            return {};
         }
+
+        QDateTime parsed = QDateTime::fromString(trimmed, Qt::ISODateWithMs);
+        if (!parsed.isValid())
+        {
+            parsed = QDateTime::fromString(trimmed, Qt::ISODate);
+        }
+        return parsed.isValid() ? parsed.toUTC() : QDateTime();
     }
 
-    return fields.join(QLatin1Char(','));
-}
-
-struct PlayedItemEntry
-{
-    MediaItem item;
-    QDateTime playedAt;
-    int sequence = 0;
-};
-
-QDateTime parseServerDateTime(const QString& rawValue)
-{
-    const QString trimmed = rawValue.trimmed();
-    if (trimmed.isEmpty()) {
-        return {};
+    QDateTime mediaDateCreated(const MediaItem &item)
+    {
+        const QDateTime rawDate = parseServerDateTime(item.dateCreatedRaw);
+        if (rawDate.isValid())
+        {
+            return rawDate;
+        }
+        return parseServerDateTime(item.dateCreated);
     }
 
-    QDateTime parsed = QDateTime::fromString(trimmed, Qt::ISODateWithMs);
-    if (!parsed.isValid()) {
-        parsed = QDateTime::fromString(trimmed, Qt::ISODate);
+    QDateTime mediaPlayedAt(const MediaItem &item)
+    {
+        return parseServerDateTime(item.userData.lastPlayedDate);
     }
-    return parsed.isValid() ? parsed.toUTC() : QDateTime();
-}
 
-QDateTime mediaDateCreated(const MediaItem& item)
-{
-    const QDateTime rawDate = parseServerDateTime(item.dateCreatedRaw);
-    if (rawDate.isValid()) {
-        return rawDate;
+    QString mediaSortTitle(const MediaItem &item)
+    {
+        const QString sortTitle = item.sortName.trimmed();
+        return sortTitle.isEmpty() ? item.name.trimmed() : sortTitle;
     }
-    return parseServerDateTime(item.dateCreated);
-}
 
-QDateTime mediaPlayedAt(const MediaItem& item)
-{
-    return parseServerDateTime(item.userData.lastPlayedDate);
-}
-
-QString mediaSortTitle(const MediaItem& item)
-{
-    const QString sortTitle = item.sortName.trimmed();
-    return sortTitle.isEmpty() ? item.name.trimmed() : sortTitle;
-}
-
-int compareDateTime(const QDateTime& lhs, const QDateTime& rhs)
-{
-    const qint64 lhsValue = lhs.isValid() ? lhs.toMSecsSinceEpoch() : 0;
-    const qint64 rhsValue = rhs.isValid() ? rhs.toMSecsSinceEpoch() : 0;
-    if (lhsValue == rhsValue) {
-        return 0;
-    }
-    return lhsValue < rhsValue ? -1 : 1;
-}
-
-int comparePlayedEntries(const PlayedItemEntry& lhs,
-                         const PlayedItemEntry& rhs,
-                         const QString& sortBy)
-{
-    if (sortBy.compare(QStringLiteral("DateCreated"), Qt::CaseInsensitive) == 0) {
-        return compareDateTime(mediaDateCreated(lhs.item),
-                               mediaDateCreated(rhs.item));
-    }
-    if (sortBy.compare(QStringLiteral("Runtime"), Qt::CaseInsensitive) == 0) {
-        if (lhs.item.runTimeTicks == rhs.item.runTimeTicks) {
+    int compareDateTime(const QDateTime &lhs, const QDateTime &rhs)
+    {
+        const qint64 lhsValue = lhs.isValid() ? lhs.toMSecsSinceEpoch() : 0;
+        const qint64 rhsValue = rhs.isValid() ? rhs.toMSecsSinceEpoch() : 0;
+        if (lhsValue == rhsValue)
+        {
             return 0;
         }
-        return lhs.item.runTimeTicks < rhs.item.runTimeTicks ? -1 : 1;
-    }
-    if (sortBy.compare(QStringLiteral("PremiereDate"), Qt::CaseInsensitive) == 0) {
-        const int result =
-            QString::compare(lhs.item.premiereDate, rhs.item.premiereDate,
-                             Qt::CaseInsensitive);
-        return result == 0 ? 0 : (result < 0 ? -1 : 1);
-    }
-    if (sortBy.compare(QStringLiteral("SortName"), Qt::CaseInsensitive) == 0 ||
-        sortBy.compare(QStringLiteral("Title"), Qt::CaseInsensitive) == 0) {
-        const int result =
-            QString::localeAwareCompare(mediaSortTitle(lhs.item),
-                                        mediaSortTitle(rhs.item));
-        return result == 0 ? 0 : (result < 0 ? -1 : 1);
+        return lhsValue < rhsValue ? -1 : 1;
     }
 
-    return compareDateTime(lhs.playedAt, rhs.playedAt);
-}
-
-QString mediaPageFingerprint(const QList<MediaItem>& items)
-{
-    QString fingerprint;
-    for (const MediaItem& item : items) {
-        if (item.id.isEmpty()) {
-            continue;
-        }
-        fingerprint += item.id;
-        fingerprint += QLatin1Char('|');
-    }
-    return fingerprint;
-}
-
-QString findUserViewIdByCollectionType(const QList<MediaItem> &views,
-                                       QString collectionType)
-{
-    collectionType = collectionType.trimmed();
-    if (collectionType.isEmpty())
+    int comparePlayedEntries(const PlayedItemEntry &lhs,
+                             const PlayedItemEntry &rhs,
+                             const QString &sortBy)
     {
+        if (sortBy.compare(QStringLiteral("DateCreated"), Qt::CaseInsensitive) == 0)
+        {
+            return compareDateTime(mediaDateCreated(lhs.item),
+                                   mediaDateCreated(rhs.item));
+        }
+        if (sortBy.compare(QStringLiteral("Runtime"), Qt::CaseInsensitive) == 0)
+        {
+            if (lhs.item.runTimeTicks == rhs.item.runTimeTicks)
+            {
+                return 0;
+            }
+            return lhs.item.runTimeTicks < rhs.item.runTimeTicks ? -1 : 1;
+        }
+        if (sortBy.compare(QStringLiteral("PremiereDate"), Qt::CaseInsensitive) == 0)
+        {
+            const int result =
+                QString::compare(lhs.item.premiereDate, rhs.item.premiereDate,
+                                 Qt::CaseInsensitive);
+            return result == 0 ? 0 : (result < 0 ? -1 : 1);
+        }
+        if (sortBy.compare(QStringLiteral("SortName"), Qt::CaseInsensitive) == 0 ||
+            sortBy.compare(QStringLiteral("Title"), Qt::CaseInsensitive) == 0)
+        {
+            const int result =
+                QString::localeAwareCompare(mediaSortTitle(lhs.item),
+                                            mediaSortTitle(rhs.item));
+            return result == 0 ? 0 : (result < 0 ? -1 : 1);
+        }
+
+        return compareDateTime(lhs.playedAt, rhs.playedAt);
+    }
+
+    QString mediaPageFingerprint(const QList<MediaItem> &items)
+    {
+        QString fingerprint;
+        for (const MediaItem &item : items)
+        {
+            if (item.id.isEmpty())
+            {
+                continue;
+            }
+            fingerprint += item.id;
+            fingerprint += QLatin1Char('|');
+        }
+        return fingerprint;
+    }
+
+    QString findUserViewIdByCollectionType(const QList<MediaItem> &views,
+                                           QString collectionType)
+    {
+        collectionType = collectionType.trimmed();
+        if (collectionType.isEmpty())
+        {
+            return {};
+        }
+
+        for (const MediaItem &view : views)
+        {
+            if (view.collectionType.compare(collectionType, Qt::CaseInsensitive) == 0 && !view.id.isEmpty())
+            {
+                return view.id;
+            }
+        }
+
         return {};
     }
 
-    for (const MediaItem &view : views)
+    int effectivePort(const QUrl &url)
     {
-        if (view.collectionType.compare(collectionType, Qt::CaseInsensitive) == 0
-            && !view.id.isEmpty())
+        if (url.port() > 0)
         {
-            return view.id;
+            return url.port();
         }
+
+        if (url.scheme().compare(QStringLiteral("https"), Qt::CaseInsensitive) == 0)
+        {
+            return 443;
+        }
+        if (url.scheme().compare(QStringLiteral("http"), Qt::CaseInsensitive) == 0)
+        {
+            return 80;
+        }
+        return -1;
     }
 
-    return {};
-}
-
-int effectivePort(const QUrl& url)
-{
-    if (url.port() > 0) {
-        return url.port();
+    bool isSameOrigin(const QUrl &left, const QUrl &right)
+    {
+        return left.scheme().compare(right.scheme(), Qt::CaseInsensitive) == 0 &&
+               left.host().compare(right.host(), Qt::CaseInsensitive) == 0 &&
+               effectivePort(left) == effectivePort(right);
     }
 
-    if (url.scheme().compare(QStringLiteral("https"), Qt::CaseInsensitive) == 0) {
-        return 443;
-    }
-    if (url.scheme().compare(QStringLiteral("http"), Qt::CaseInsensitive) == 0) {
-        return 80;
-    }
-    return -1;
-}
+    NetworkRequestOptions buildImageRequestOptions(const ServerProfile &profile,
+                                                   const QUrl &requestUrl)
+    {
+        NetworkRequestOptions options;
+        if (!profile.isValid() || !requestUrl.isValid())
+        {
+            return options;
+        }
 
-bool isSameOrigin(const QUrl& left, const QUrl& right)
-{
-    return left.scheme().compare(right.scheme(), Qt::CaseInsensitive) == 0 &&
-           left.host().compare(right.host(), Qt::CaseInsensitive) == 0 &&
-           effectivePort(left) == effectivePort(right);
-}
+        const QUrl profileUrl(profile.url);
+        if (profile.ignoreSslVerification &&
+            isSameOrigin(requestUrl, profileUrl))
+        {
+            options.ignoreSslErrors = true;
+        }
 
-NetworkRequestOptions buildImageRequestOptions(const ServerProfile& profile,
-                                               const QUrl& requestUrl)
-{
-    NetworkRequestOptions options;
-    if (!profile.isValid() || !requestUrl.isValid()) {
         return options;
     }
 
-    const QUrl profileUrl(profile.url);
-    if (profile.ignoreSslVerification &&
-        isSameOrigin(requestUrl, profileUrl)) {
-        options.ignoreSslErrors = true;
-    }
-
-    return options;
-}
-
-struct ResolvedImageRequest {
-    QUrl url;
-
-    bool isValid() const
+    struct ResolvedImageRequest
     {
-        return url.isValid() && !url.scheme().trimmed().isEmpty();
-    }
-};
+        QUrl url;
 
-QString sanitizeMimeType(QString mimeType)
-{
-    const int separatorIndex = mimeType.indexOf(QLatin1Char(';'));
-    if (separatorIndex >= 0) {
-        mimeType = mimeType.left(separatorIndex);
-    }
+        bool isValid() const
+        {
+            return url.isValid() && !url.scheme().trimmed().isEmpty();
+        }
+    };
 
-    return mimeType.trimmed().toLower();
-}
+    QString sanitizeMimeType(QString mimeType)
+    {
+        const int separatorIndex = mimeType.indexOf(QLatin1Char(';'));
+        if (separatorIndex >= 0)
+        {
+            mimeType = mimeType.left(separatorIndex);
+        }
 
-QString detectImageMimeType(const QByteArray& data)
-{
-    if (data.isEmpty()) {
-        return {};
-    }
-
-    QBuffer buffer;
-    buffer.setData(data);
-    if (!buffer.open(QIODevice::ReadOnly)) {
-        return {};
+        return mimeType.trimmed().toLower();
     }
 
-    QImageReader reader(&buffer);
-    const QString format = QString::fromLatin1(reader.format()).trimmed().toLower();
-    if (format.isEmpty()) {
-        return {};
+    QString detectImageMimeType(const QByteArray &data)
+    {
+        if (data.isEmpty())
+        {
+            return {};
+        }
+
+        QBuffer buffer;
+        buffer.setData(data);
+        if (!buffer.open(QIODevice::ReadOnly))
+        {
+            return {};
+        }
+
+        QImageReader reader(&buffer);
+        const QString format = QString::fromLatin1(reader.format()).trimmed().toLower();
+        if (format.isEmpty())
+        {
+            return {};
+        }
+
+        return QStringLiteral("image/%1").arg(format);
     }
 
-    return QStringLiteral("image/%1").arg(format);
-}
+    QString buildItemImagePath(QString itemId, QString imageType, int imageIndex)
+    {
+        itemId = itemId.trimmed();
+        imageType = imageType.trimmed();
 
-QString buildItemImagePath(QString itemId, QString imageType, int imageIndex)
-{
-    itemId = itemId.trimmed();
-    imageType = imageType.trimmed();
+        QString path = QStringLiteral("/Items/%1/Images/%2").arg(itemId, imageType);
+        if (imageIndex >= 0)
+        {
+            path += QStringLiteral("/%1").arg(imageIndex);
+        }
 
-    QString path = QStringLiteral("/Items/%1/Images/%2").arg(itemId, imageType);
-    if (imageIndex >= 0) {
-        path += QStringLiteral("/%1").arg(imageIndex);
+        return path;
     }
 
-    return path;
-}
+    QString buildImageCacheKey(QString itemId, QString imageType, int imageIndex)
+    {
+        return QStringLiteral("%1|%2|%3")
+            .arg(itemId.trimmed(), imageType.trimmed())
+            .arg(imageIndex);
+    }
 
-QString buildImageCacheKey(QString itemId, QString imageType, int imageIndex)
-{
-    return QStringLiteral("%1|%2|%3")
-        .arg(itemId.trimmed(), imageType.trimmed())
-        .arg(imageIndex);
-}
+    QString buildDecodedImageCacheKey(const ServerProfile &profile,
+                                      const QString &itemId,
+                                      const QString &imageType,
+                                      const QString &imageTag, int imageIndex,
+                                      int maxWidth, quint64 cacheVersion)
+    {
+        return profile.id + QLatin1Char('|') + profile.url +
+               QLatin1Char('|') + profile.userId + QLatin1Char('|') + itemId +
+               QLatin1Char('|') + imageType + QLatin1Char('|') + imageTag +
+               QLatin1Char('|') + QString::number(imageIndex) +
+               QLatin1Char('|') + QString::number(maxWidth) +
+               QLatin1Char('|') + QString::number(cacheVersion);
+    }
 
-ResolvedImageRequest resolveImageRequest(const ServerManager* serverManager,
-                                        QString imageUrl)
-{
-    ResolvedImageRequest result;
+    int decodedImageCostKb(const QImage &image)
+    {
+        if (image.isNull())
+        {
+            return 1;
+        }
 
-    imageUrl = imageUrl.trimmed();
-    if (imageUrl.isEmpty()) {
+        const qint64 bytes = image.sizeInBytes();
+        return qMax(1, static_cast<int>(bytes / 1024));
+    }
+
+    ResolvedImageRequest resolveImageRequest(const ServerManager *serverManager,
+                                             QString imageUrl)
+    {
+        ResolvedImageRequest result;
+
+        imageUrl = imageUrl.trimmed();
+        if (imageUrl.isEmpty())
+        {
+            return result;
+        }
+
+        const ServerProfile profile =
+            serverManager ? serverManager->activeProfile() : ServerProfile{};
+        QUrl resolvedUrl(imageUrl);
+
+        if (resolvedUrl.isRelative() && profile.isValid())
+        {
+            QUrl baseUrl(profile.url);
+            if (baseUrl.isValid() && baseUrl.path().isEmpty())
+            {
+                baseUrl.setPath(QStringLiteral("/"));
+            }
+            resolvedUrl = baseUrl.resolved(QUrl(imageUrl));
+        }
+
+        if (!resolvedUrl.isValid() || resolvedUrl.scheme().trimmed().isEmpty())
+        {
+            return result;
+        }
+
+        if (profile.isValid() && !profile.accessToken.isEmpty() &&
+            isSameOrigin(resolvedUrl, QUrl(profile.url)))
+        {
+            QUrlQuery query(resolvedUrl);
+            if (!query.hasQueryItem(QStringLiteral("api_key")))
+            {
+                query.addQueryItem(QStringLiteral("api_key"), profile.accessToken);
+                resolvedUrl.setQuery(query);
+            }
+        }
+
+        result.url = resolvedUrl;
         return result;
     }
-
-    const ServerProfile profile =
-        serverManager ? serverManager->activeProfile() : ServerProfile{};
-    QUrl resolvedUrl(imageUrl);
-
-    if (resolvedUrl.isRelative() && profile.isValid()) {
-        QUrl baseUrl(profile.url);
-        if (baseUrl.isValid() && baseUrl.path().isEmpty()) {
-            baseUrl.setPath(QStringLiteral("/"));
-        }
-        resolvedUrl = baseUrl.resolved(QUrl(imageUrl));
-    }
-
-    if (!resolvedUrl.isValid() || resolvedUrl.scheme().trimmed().isEmpty()) {
-        return result;
-    }
-
-    if (profile.isValid() && !profile.accessToken.isEmpty() &&
-        isSameOrigin(resolvedUrl, QUrl(profile.url))) {
-        QUrlQuery query(resolvedUrl);
-        if (!query.hasQueryItem(QStringLiteral("api_key"))) {
-            query.addQueryItem(QStringLiteral("api_key"), profile.accessToken);
-            resolvedUrl.setQuery(query);
-        }
-    }
-
-    result.url = resolvedUrl;
-    return result;
-}
 } 
 
 MediaService::MediaService(ServerManager *serverManager, QObject *parent)
@@ -384,6 +468,7 @@ MediaService::MediaService(ServerManager *serverManager, QObject *parent)
     diskCache->setCacheDirectory(cachePath);
     diskCache->setMaximumCacheSize(500 * 1024 * 1024);
     m_imageManager->setCache(diskCache);
+    m_decodedImageCache.setMaxCost(kDecodedImageCacheCostKb);
 }
 
 void MediaService::ensureValidProfile() const
@@ -451,10 +536,10 @@ QCoro::Task<MediaQueryPage> MediaService::getLibraryItemsPage(const QString &par
     ensureValidProfile();
     ServerProfile profile = m_serverManager->activeProfile();
 
-    QStringList fields = {QStringLiteral("BasicSyncInfo"),  QStringLiteral("CanDelete"),
-                          QStringLiteral("CanDownload"),    QStringLiteral("PrimaryImageAspectRatio"),
+    QStringList fields = {QStringLiteral("BasicSyncInfo"), QStringLiteral("CanDelete"),
+                          QStringLiteral("CanDownload"), QStringLiteral("PrimaryImageAspectRatio"),
                           QStringLiteral("ProductionYear"), QStringLiteral("Status"),
-                          QStringLiteral("EndDate"),        QStringLiteral("RecursiveItemCount"),
+                          QStringLiteral("EndDate"), QStringLiteral("RecursiveItemCount"),
                           QStringLiteral("MediaType"),
                           QStringLiteral("DateCreated")};
     if (includeChildCount)
@@ -592,14 +677,24 @@ QCoro::Task<QList<MediaItem>> MediaService::getNextUp(const QString &seriesId)
     co_return parseJsonArray<MediaItem>(response["Items"].toArray());
 }
 
-QCoro::Task<QPixmap> MediaService::fetchImage(const QString &itemId,
-                                              const QString &imageType,
-                                              const QString &imageTag,
-                                              int maxWidth, int imageIndex)
+QCoro::Task<QPixmap> MediaService::fetchImage(QString itemId,
+                                              QString imageType,
+                                              QString imageTag,
+                                              int maxWidth, int imageIndex,
+                                              ImageRequestPriority priority,
+                                              QObject *requestContext,
+                                              ImageFetchPolicy fetchPolicy)
 {
     ServerProfile profile = m_serverManager->activeProfile();
     if (!profile.isValid())
+    {
+        qWarning() << "[MediaService] fetchImage skipped: invalid active profile"
+                   << "| itemId=" << itemId
+                   << "| imageType=" << imageType;
         co_return QPixmap();
+    }
+    const bool hasRequestContext = requestContext != nullptr;
+    QPointer<QObject> requestContextGuard(requestContext);
 
     
     QString quality = ConfigStore::instance()->get<QString>(ConfigKeys::ImageQuality, "high");
@@ -610,6 +705,7 @@ QCoro::Task<QPixmap> MediaService::fetchImage(const QString &itemId,
         effectiveMaxWidth = maxWidth * 3 / 4;
     else if (quality == "original")
         effectiveMaxWidth = 0; 
+    effectiveMaxWidth = bucketImageWidth(effectiveMaxWidth);
 
     const QString trimmedItemId = itemId.trimmed();
     const QString trimmedImageType = imageType.trimmed();
@@ -619,6 +715,184 @@ QCoro::Task<QPixmap> MediaService::fetchImage(const QString &itemId,
         buildImageCacheKey(trimmedItemId, trimmedImageType, imageIndex);
     const quint64 cacheVersion =
         m_invalidatedImageRequestVersions.value(imageCacheKey, 0);
+    const QString decodedCacheKey = buildDecodedImageCacheKey(
+        profile, trimmedItemId, trimmedImageType, imageTag, imageIndex,
+        effectiveMaxWidth, cacheVersion);
+    const bool networkOnly = fetchPolicy == ImageFetchPolicy::NetworkOnly;
+
+    if (!networkOnly)
+    {
+        if (QImage *cached = m_decodedImageCache.object(decodedCacheKey))
+        {
+            
+            
+            
+            const QImage cachedImage = *cached;
+            QPixmap cachedPixmap = QPixmap::fromImage(cachedImage);
+            qDebug() << "[MediaService] decoded image cache hit"
+                     << "| itemId=" << trimmedItemId
+                     << "| imageType=" << trimmedImageType
+                     << "| maxWidth=" << effectiveMaxWidth
+                     << "| imageSize=" << cachedImage.size()
+                     << "| pixmapNull=" << cachedPixmap.isNull();
+            if (!cachedPixmap.isNull())
+            {
+                co_return std::move(cachedPixmap);
+            }
+
+            
+            
+            
+            qWarning() << "[MediaService] removing unusable decoded image "
+                          "cache entry"
+                       << "| itemId=" << trimmedItemId
+                       << "| imageType=" << trimmedImageType
+                       << "| imageSize=" << cachedImage.size();
+            m_decodedImageCache.remove(decodedCacheKey);
+        }
+    }
+
+    QPointer<MediaService> serviceGuard(this);
+    
+    
+    
+    
+    
+    const bool shareInFlightRequest =
+        !networkOnly && !hasRequestContext;
+    const auto inFlightIt = shareInFlightRequest
+                                ? m_inFlightImageRequests.constFind(decodedCacheKey)
+                                : m_inFlightImageRequests.constEnd();
+    if (shareInFlightRequest && inFlightIt != m_inFlightImageRequests.constEnd())
+    {
+        const InFlightImageRequest sharedRequest = inFlightIt.value();
+        if (!sharedRequest.future.isCanceled())
+        {
+            try
+            {
+                QFuture<QImage> inFlightFuture = sharedRequest.future;
+                const QImage sharedImage = co_await inFlightFuture;
+                if (!serviceGuard)
+                {
+                    co_return QPixmap();
+                }
+
+                QPixmap sharedPixmap;
+                if (!inFlightFuture.isCanceled() && !sharedImage.isNull())
+                {
+                    sharedPixmap = QPixmap::fromImage(sharedImage);
+                }
+                if (!sharedPixmap.isNull())
+                {
+                    qDebug() << "[MediaService] reused in-flight image request"
+                             << "| itemId=" << trimmedItemId
+                             << "| imageType=" << trimmedImageType
+                             << "| requestId=" << sharedRequest.requestId
+                             << "| imageSize=" << sharedImage.size();
+                    co_return std::move(sharedPixmap);
+                }
+
+                qWarning() << "[MediaService] joined image request became "
+                              "cancelled or empty; starting a replacement"
+                           << "| itemId=" << trimmedItemId
+                           << "| imageType=" << trimmedImageType
+                           << "| requestId=" << sharedRequest.requestId;
+            }
+            catch (...)
+            {
+                if (!serviceGuard)
+                {
+                    co_return QPixmap();
+                }
+                qWarning() << "[MediaService] in-flight image request was "
+                              "cancelled; starting a replacement"
+                           << "| itemId=" << trimmedItemId
+                           << "| imageType=" << trimmedImageType
+                           << "| requestId=" << sharedRequest.requestId;
+            }
+        }
+
+        removeInFlightImageRequest(decodedCacheKey,
+                                   sharedRequest.requestId);
+    }
+
+    if (hasRequestContext && !requestContextGuard)
+    {
+        qDebug() << "[MediaService] fetchImage cancelled before scheduling"
+                 << "| itemId=" << trimmedItemId
+                 << "| imageType=" << trimmedImageType;
+        co_return QPixmap();
+    }
+
+    QPromise<QImage> sharedPromise;
+    sharedPromise.start();
+    QFuture<QImage> sharedFuture = sharedPromise.future();
+    const quint64 inFlightRequestId = ++m_nextInFlightImageRequestId;
+    if (shareInFlightRequest)
+    {
+        m_inFlightImageRequests.insert(
+            decodedCacheKey,
+            InFlightImageRequest {inFlightRequestId, sharedFuture});
+    }
+    auto inFlightCleanup = qScopeGuard(
+        [serviceGuard, decodedCacheKey, inFlightRequestId,
+         shareInFlightRequest]()
+        {
+            if (serviceGuard && shareInFlightRequest)
+            {
+                serviceGuard->removeInFlightImageRequest(
+                    decodedCacheKey, inFlightRequestId);
+            }
+        });
+    const quint64 memoryCacheGeneration = m_imageCacheGeneration;
+
+    quint64 networkSlotRequestId = 0;
+    bool networkSlotAcquired = true;
+    
+    
+    
+    
+    if (!networkOnly && !hasRequestContext)
+    {
+        QFuture<bool> networkSlotFuture = acquireImageNetworkSlot(
+            priority, requestContextGuard, hasRequestContext,
+            &networkSlotRequestId);
+        networkSlotAcquired = co_await networkSlotFuture;
+    }
+    auto networkSlotCleanup = qScopeGuard(
+        [serviceGuard, networkSlotRequestId]()
+        {
+            if (serviceGuard && networkSlotRequestId > 0)
+            {
+                serviceGuard->releaseImageNetworkSlot(
+                    networkSlotRequestId);
+            }
+        });
+    if (!serviceGuard || !networkSlotAcquired)
+    {
+        if (serviceGuard)
+        {
+            qDebug() << "[MediaService] fetchImage cancelled by global scheduler"
+                     << "| itemId=" << trimmedItemId
+                     << "| imageType=" << trimmedImageType
+                     << "| requestId=" << networkSlotRequestId
+                     << "| contextAlive=" << bool(requestContextGuard);
+        }
+        sharedPromise.addResult(QImage());
+        sharedPromise.finish();
+        co_return QPixmap();
+    }
+
+    if (hasRequestContext && !requestContextGuard)
+    {
+        qDebug() << "[MediaService] fetchImage cancelled after scheduling"
+                 << "| itemId=" << trimmedItemId
+                 << "| imageType=" << trimmedImageType
+                 << "| requestId=" << networkSlotRequestId;
+        sharedPromise.addResult(QImage());
+        sharedPromise.finish();
+        co_return QPixmap();
+    }
 
     QString urlStr;
     if (effectiveMaxWidth > 0)
@@ -654,7 +928,8 @@ QCoro::Task<QPixmap> MediaService::fetchImage(const QString &itemId,
         }
     }
 
-    if (cacheVersion > 0) {
+    if (cacheVersion > 0)
+    {
         urlStr += QStringLiteral("&qemby_image_rev=%1").arg(cacheVersion);
         qDebug() << "[MediaService] fetchImage using invalidated cache version"
                  << "| itemId=" << trimmedItemId
@@ -662,40 +937,120 @@ QCoro::Task<QPixmap> MediaService::fetchImage(const QString &itemId,
                  << "| imageIndex=" << imageIndex
                  << "| version=" << cacheVersion;
     }
+    if (networkOnly)
+    {
+        
+        
+        
+        urlStr += QStringLiteral("&qemby_network_only=%1_%2")
+                      .arg(QDateTime::currentMSecsSinceEpoch())
+                      .arg(inFlightRequestId);
+        qDebug() << "[MediaService] network-only image request"
+                 << "| itemId=" << trimmedItemId
+                 << "| imageType=" << trimmedImageType
+                 << "| maxWidth=" << effectiveMaxWidth;
+    }
 
     QNetworkRequest request((QUrl(urlStr)));
     const NetworkRequestOptions requestOptions =
         buildImageRequestOptions(profile, request.url());
     NetworkManager::applyRequestOptions(request, requestOptions);
-    request.setAttribute(QNetworkRequest::CacheLoadControlAttribute,
-                         cacheVersion > 0 ? QNetworkRequest::PreferNetwork
-                                          : QNetworkRequest::PreferCache);
+    request.setAttribute(
+        QNetworkRequest::CacheLoadControlAttribute,
+        networkOnly
+            ? QNetworkRequest::AlwaysNetwork
+            : (cacheVersion > 0 ? QNetworkRequest::PreferNetwork
+                                : QNetworkRequest::PreferCache));
+    if (networkOnly)
+    {
+        request.setAttribute(QNetworkRequest::CacheSaveControlAttribute,
+                             false);
+    }
     request.setAttribute(QNetworkRequest::Http2AllowedAttribute, true);
+    request.setTransferTimeout(kImageTransferTimeoutMs);
+    switch (priority)
+    {
+    case ImageRequestPriority::High:
+        request.setPriority(QNetworkRequest::HighPriority);
+        break;
+    case ImageRequestPriority::Low:
+        request.setPriority(QNetworkRequest::LowPriority);
+        break;
+    case ImageRequestPriority::Normal:
+        request.setPriority(QNetworkRequest::NormalPriority);
+        break;
+    }
 
+    QElapsedTimer totalTimer;
+    totalTimer.start();
+    QElapsedTimer networkTimer;
+    networkTimer.start();
     QNetworkReply *reply = m_imageManager->get(request);
+    QPointer<QNetworkReply> replyGuard(reply);
+    if (requestContextGuard)
+    {
+        QObject::connect(
+            requestContextGuard.data(), &QObject::destroyed, reply,
+            [replyGuard]()
+            {
+                if (replyGuard && !replyGuard->isFinished())
+                {
+                    replyGuard->abort();
+                }
+            });
+    }
+    auto replyCleanup = qScopeGuard(
+        [replyGuard]()
+        {
+            if (!replyGuard)
+            {
+                return;
+            }
+            if (!replyGuard->isFinished())
+            {
+                replyGuard->abort();
+            }
+            replyGuard->deleteLater();
+        });
     NetworkManager::attachReplyHandlers(reply, requestOptions,
                                         QStringLiteral("GET_IMAGE"));
     co_await reply;
+    if (!serviceGuard || !replyGuard)
+    {
+        sharedPromise.addResult(QImage());
+        sharedPromise.finish();
+        co_return QPixmap();
+    }
+    const qint64 networkElapsedMs = networkTimer.elapsed();
+    const bool loadedFromDiskCache =
+        reply->attribute(QNetworkRequest::SourceIsFromCacheAttribute).toBool();
 
     QPixmap result;
+    QImage decodedImage;
+    qint64 decodeElapsedMs = 0;
+    int imageBytes = 0;
     if (reply->error() == QNetworkReply::NoError)
     {
         QByteArray data = reply->readAll();
-        const int imageBytes = data.size();
+        imageBytes = data.size();
         
         
         
         
+        QElapsedTimer decodeTimer;
+        decodeTimer.start();
         auto future = QtConcurrent::run(
-            [data = std::move(data)]() mutable {
+            [data = std::move(data)]() mutable
+            {
                 QImage decoded;
                 decoded.loadFromData(data);
                 return decoded;
             });
-        QImage image = co_await future;
-        if (!image.isNull())
+        decodedImage = co_await future;
+        decodeElapsedMs = decodeTimer.elapsed();
+        if (!decodedImage.isNull())
         {
-            result = QPixmap::fromImage(std::move(image));
+            result = QPixmap::fromImage(decodedImage);
         }
         else
         {
@@ -719,7 +1074,53 @@ QCoro::Task<QPixmap> MediaService::fetchImage(const QString &itemId,
                    << NetworkManager::buildReplyErrorMessage(reply, httpStatus);
     }
 
-    reply->deleteLater();
+    if (!serviceGuard)
+    {
+        sharedPromise.addResult(decodedImage);
+        sharedPromise.finish();
+        co_return result;
+    }
+
+    if (!networkOnly && !result.isNull() && !decodedImage.isNull() &&
+        memoryCacheGeneration == m_imageCacheGeneration)
+    {
+        m_decodedImageCache.insert(
+            decodedCacheKey, new QImage(decodedImage),
+            decodedImageCostKb(decodedImage));
+    }
+
+    sharedPromise.addResult(decodedImage);
+    sharedPromise.finish();
+    if (shareInFlightRequest)
+    {
+        removeInFlightImageRequest(decodedCacheKey, inFlightRequestId);
+    }
+
+    const qint64 totalElapsedMs = totalTimer.elapsed();
+    if (!result.isNull())
+    {
+        qDebug() << "[MediaService] image request completed"
+                 << "| itemId=" << trimmedItemId
+                 << "| imageType=" << trimmedImageType
+                 << "| maxWidth=" << effectiveMaxWidth
+                 << "| bytes=" << imageBytes
+                 << "| fromDiskCache=" << loadedFromDiskCache
+                 << "| totalMs=" << totalElapsedMs;
+    }
+    if (totalElapsedMs >= kSlowImageRequestThresholdMs)
+    {
+        qWarning() << "[MediaService] slow image request"
+                   << "| itemId=" << trimmedItemId
+                   << "| imageType=" << trimmedImageType
+                   << "| imageIndex=" << imageIndex
+                   << "| maxWidth=" << effectiveMaxWidth
+                   << "| bytes=" << imageBytes
+                   << "| fromDiskCache=" << loadedFromDiskCache
+                   << "| networkMs=" << networkElapsedMs
+                   << "| decodeMs=" << decodeElapsedMs
+                   << "| totalMs=" << totalElapsedMs;
+    }
+
     co_return result;
 }
 
@@ -728,7 +1129,8 @@ void MediaService::invalidateImageCache(QString itemId, QString imageType,
 {
     itemId = itemId.trimmed();
     imageType = imageType.trimmed();
-    if (itemId.isEmpty() || imageType.isEmpty()) {
+    if (itemId.isEmpty() || imageType.isEmpty())
+    {
         qWarning() << "[MediaService] invalidateImageCache skipped"
                    << "| itemId=" << itemId
                    << "| imageType=" << imageType
@@ -739,7 +1141,8 @@ void MediaService::invalidateImageCache(QString itemId, QString imageType,
     const quint64 nextVersion = ++m_nextImageRequestVersion;
     m_invalidatedImageRequestVersions.insert(
         buildImageCacheKey(itemId, imageType, imageIndex), nextVersion);
-    if (imageIndex >= 0) {
+    if (imageIndex >= 0)
+    {
         m_invalidatedImageRequestVersions.insert(
             buildImageCacheKey(itemId, imageType, -1), nextVersion);
     }
@@ -751,9 +1154,225 @@ void MediaService::invalidateImageCache(QString itemId, QString imageType,
              << "| version=" << nextVersion;
 }
 
+void MediaService::clearImageCaches()
+{
+    const int decodedEntries = m_decodedImageCache.size();
+    const int inFlightEntries = m_inFlightImageRequests.size();
+    ++m_imageCacheGeneration;
+    m_decodedImageCache.clear();
+    m_inFlightImageRequests.clear();
+    const QList<PendingImageNetworkSlot> pendingSlots =
+        std::exchange(m_pendingImageNetworkSlots, {});
+    for (const PendingImageNetworkSlot &slot : pendingSlots)
+    {
+        if (slot.promise)
+        {
+            slot.promise->addResult(false);
+            slot.promise->finish();
+        }
+    }
+    if (m_imageManager && m_imageManager->cache())
+    {
+        m_imageManager->cache()->clear();
+    }
+
+    qDebug() << "[MediaService] image caches cleared"
+             << "| decodedEntries=" << decodedEntries
+             << "| detachedInFlight=" << inFlightEntries;
+}
+
+void MediaService::removeInFlightImageRequest(const QString &cacheKey,
+                                              quint64 requestId)
+{
+    const auto it = m_inFlightImageRequests.find(cacheKey);
+    if (it == m_inFlightImageRequests.end() ||
+        it->requestId != requestId)
+    {
+        return;
+    }
+    m_inFlightImageRequests.erase(it);
+}
+
+QFuture<bool> MediaService::acquireImageNetworkSlot(
+    ImageRequestPriority priority,
+    QPointer<QObject> requestContext,
+    bool hasRequestContext,
+    quint64 *outRequestId)
+{
+    auto promise = QSharedPointer<QPromise<bool>>::create();
+    promise->start();
+    QFuture<bool> future = promise->future();
+
+    if (outRequestId)
+    {
+        *outRequestId = 0;
+    }
+
+    if (hasRequestContext && !requestContext)
+    {
+        promise->addResult(false);
+        promise->finish();
+        return future;
+    }
+
+    const quint64 slotRequestId = ++m_nextImageNetworkSlotRequestId;
+    if (outRequestId)
+    {
+        *outRequestId = slotRequestId;
+    }
+    PendingImageNetworkSlot slot;
+    slot.requestId = slotRequestId;
+    slot.priority = priority;
+    slot.hasRequestContext = hasRequestContext;
+    slot.requestContext = requestContext;
+    slot.promise = promise;
+    m_pendingImageNetworkSlots.append(std::move(slot));
+
+    if (requestContext)
+    {
+        QObject::connect(
+            requestContext.data(), &QObject::destroyed, this,
+            [this, slotRequestId]()
+            {
+                releaseImageNetworkSlot(slotRequestId);
+            });
+    }
+
+    const bool hadToWait =
+        m_activeImageNetworkRequests >= kMaxGlobalImageNetworkRequests;
+    dispatchPendingImageNetworkSlots();
+
+    if (hadToWait)
+    {
+        qDebug() << "[MediaService] image request queued by global scheduler"
+                 << "| requestId=" << slotRequestId
+                 << "| priority=" << static_cast<int>(priority)
+                 << "| active=" << m_activeImageNetworkRequests
+                 << "| pending=" << m_pendingImageNetworkSlots.size();
+    }
+
+    return future;
+}
+
+void MediaService::releaseImageNetworkSlot(quint64 requestId)
+{
+    for (int i = 0; i < m_pendingImageNetworkSlots.size(); ++i)
+    {
+        if (m_pendingImageNetworkSlots.at(i).requestId != requestId)
+        {
+            continue;
+        }
+
+        const PendingImageNetworkSlot slot =
+            m_pendingImageNetworkSlots.takeAt(i);
+        if (slot.promise)
+        {
+            slot.promise->addResult(false);
+            slot.promise->finish();
+        }
+
+        qDebug() << "[MediaService] cancelled pending image request"
+                 << "| requestId=" << requestId
+                 << "| active=" << m_activeImageNetworkRequests
+                 << "| pending=" << m_pendingImageNetworkSlots.size();
+        dispatchPendingImageNetworkSlots();
+        return;
+    }
+
+    if (!m_grantedImageNetworkSlots.remove(requestId))
+    {
+        return;
+    }
+    m_activeImageNetworkRequests =
+        qMax(0, m_activeImageNetworkRequests - 1);
+    dispatchPendingImageNetworkSlots();
+}
+
+void MediaService::dispatchPendingImageNetworkSlots()
+{
+    if (m_dispatchingImageNetworkSlots)
+    {
+        return;
+    }
+
+    m_dispatchingImageNetworkSlots = true;
+    auto dispatchGuard = qScopeGuard(
+        [this]()
+        {
+            m_dispatchingImageNetworkSlots = false;
+        });
+
+    while (m_activeImageNetworkRequests < kMaxGlobalImageNetworkRequests &&
+           !m_pendingImageNetworkSlots.isEmpty())
+    {
+        int selectedIndex = -1;
+        int selectedRank = 3;
+
+        for (int i = 0; i < m_pendingImageNetworkSlots.size(); ++i)
+        {
+            const PendingImageNetworkSlot &candidate =
+                m_pendingImageNetworkSlots.at(i);
+            if (candidate.hasRequestContext && !candidate.requestContext)
+            {
+                continue;
+            }
+
+            int rank = 1;
+            switch (candidate.priority)
+            {
+            case ImageRequestPriority::High:
+                rank = 0;
+                break;
+            case ImageRequestPriority::Normal:
+                rank = 1;
+                break;
+            case ImageRequestPriority::Low:
+                rank = 2;
+                break;
+            }
+
+            if (rank < selectedRank)
+            {
+                selectedRank = rank;
+                selectedIndex = i;
+                if (rank == 0)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (selectedIndex < 0)
+        {
+            const QList<PendingImageNetworkSlot> cancelledSlots =
+                std::exchange(m_pendingImageNetworkSlots, {});
+            for (const PendingImageNetworkSlot &slot : cancelledSlots)
+            {
+                if (slot.promise)
+                {
+                    slot.promise->addResult(false);
+                    slot.promise->finish();
+                }
+            }
+            return;
+        }
+
+        PendingImageNetworkSlot slot =
+            m_pendingImageNetworkSlots.takeAt(selectedIndex);
+        ++m_activeImageNetworkRequests;
+        m_grantedImageNetworkSlots.insert(slot.requestId);
+        if (slot.promise)
+        {
+            slot.promise->addResult(true);
+            slot.promise->finish();
+        }
+    }
+}
+
 QCoro::Task<QPixmap> MediaService::fetchImageByUrl(QString imageUrl)
 {
-    try {
+    try
+    {
         const DownloadedImageData downloadedImage =
             co_await downloadImageByUrl(std::move(imageUrl));
 
@@ -762,20 +1381,24 @@ QCoro::Task<QPixmap> MediaService::fetchImageByUrl(QString imageUrl)
         
         
         auto future = QtConcurrent::run(
-            [data = downloadedImage.data]() mutable {
+            [data = downloadedImage.data]() mutable
+            {
                 QImage decoded;
                 decoded.loadFromData(data);
                 return decoded;
             });
         QImage image = co_await future;
-        if (image.isNull()) {
+        if (image.isNull())
+        {
             qWarning() << "[MediaService] fetchImageByUrl returned invalid image"
                        << "| bytes=" << downloadedImage.data.size();
             co_return QPixmap();
         }
 
         co_return QPixmap::fromImage(std::move(image));
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception &e)
+    {
         qWarning() << "[MediaService] fetchImageByUrl failed"
                    << "| error=" << e.what();
         co_return QPixmap();
@@ -786,7 +1409,8 @@ QCoro::Task<DownloadedImageData> MediaService::downloadImageByUrl(QString imageU
 {
     const ResolvedImageRequest resolvedRequest =
         resolveImageRequest(m_serverManager, imageUrl);
-    if (!resolvedRequest.isValid()) {
+    if (!resolvedRequest.isValid())
+    {
         qWarning() << "[MediaService] downloadImageByUrl skipped invalid url"
                    << "| imageUrl=" << imageUrl;
         throw std::runtime_error(tr("Invalid image URL").toStdString());
@@ -801,16 +1425,18 @@ QCoro::Task<DownloadedImageData> MediaService::downloadImageByUrl(QString imageU
     request.setAttribute(QNetworkRequest::CacheLoadControlAttribute,
                          QNetworkRequest::PreferCache);
     request.setAttribute(QNetworkRequest::Http2AllowedAttribute, true);
+    request.setTransferTimeout(kImageTransferTimeoutMs);
 
     qDebug() << "[MediaService] downloadImageByUrl"
              << "| url=" << resolvedRequest.url.toString(QUrl::RemoveQuery);
 
-    QNetworkReply* reply = m_imageManager->get(request);
+    QNetworkReply *reply = m_imageManager->get(request);
     NetworkManager::attachReplyHandlers(reply, requestOptions,
                                         QStringLiteral("GET_IMAGE_URL"));
     co_await reply;
 
-    if (reply->error() != QNetworkReply::NoError) {
+    if (reply->error() != QNetworkReply::NoError)
+    {
         const int httpStatus =
             reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         const QString errorString =
@@ -828,12 +1454,14 @@ QCoro::Task<DownloadedImageData> MediaService::downloadImageByUrl(QString imageU
         sanitizeMimeType(reply->header(QNetworkRequest::ContentTypeHeader).toString());
     reply->deleteLater();
 
-    if (!result.mimeType.startsWith(QStringLiteral("image/"))) {
+    if (!result.mimeType.startsWith(QStringLiteral("image/")))
+    {
         result.mimeType = detectImageMimeType(result.data);
     }
 
     if (result.data.isEmpty() ||
-        !result.mimeType.startsWith(QStringLiteral("image/"))) {
+        !result.mimeType.startsWith(QStringLiteral("image/")))
+    {
         qWarning() << "[MediaService] downloadImageByUrl returned invalid image"
                    << "| url=" << resolvedRequest.url.toString(QUrl::RemoveQuery)
                    << "| bytes=" << result.data.size()
@@ -851,10 +1479,12 @@ QCoro::Task<MediaQueryPage> MediaService::fetchItemPage(
     ensureValidProfile();
 
     QString path = basePath;
-    if (startIndex > 0) {
+    if (startIndex > 0)
+    {
         path += QStringLiteral("&StartIndex=%1").arg(startIndex);
     }
-    if (limit > 0) {
+    if (limit > 0)
+    {
         path += QStringLiteral("&Limit=%1").arg(limit);
     }
 
@@ -881,7 +1511,8 @@ QCoro::Task<QList<MediaItem>> MediaService::fetchPagedItemList(
     int totalRecordCount = 0;
     int pageSize = 0;
 
-    if (normalizedLimit > 0) {
+    if (normalizedLimit > 0)
+    {
         const MediaQueryPage initialPage =
             co_await fetchItemPage(basePath, 0, normalizedLimit, context);
         ++requestCount;
@@ -890,7 +1521,9 @@ QCoro::Task<QList<MediaItem>> MediaService::fetchPagedItemList(
             qMin(normalizedLimit,
                  qMax(initialPage.totalRecordCount, rawItems.size()));
         pageSize = initialPage.items.size();
-    } else {
+    }
+    else
+    {
         const MediaQueryPage unboundedPage =
             co_await fetchItemPage(basePath, 0, 0, context);
         ++requestCount;
@@ -906,30 +1539,35 @@ QCoro::Task<QList<MediaItem>> MediaService::fetchPagedItemList(
 
     QSet<QString> pageFingerprints;
     const QString initialFingerprint = mediaPageFingerprint(rawItems);
-    if (!initialFingerprint.isEmpty()) {
+    if (!initialFingerprint.isEmpty())
+    {
         pageFingerprints.insert(initialFingerprint);
     }
 
     if (normalizedLimit > 0 && rawItems.size() < totalRecordCount &&
-        pageSize > 0) {
+        pageSize > 0)
+    {
         qDebug() << "[MediaService] paged fetch server-side page cap detected"
                  << "| context=" << context
                  << "| pageSize=" << pageSize
                  << "| loaded=" << rawItems.size()
                  << "| total=" << totalRecordCount;
 
-        while (rawItems.size() < totalRecordCount) {
+        while (rawItems.size() < totalRecordCount)
+        {
             const int startIndex = rawItems.size();
             const int remainingCount = totalRecordCount - startIndex;
             const int pageLimit = qMin(pageSize, remainingCount);
-            if (pageLimit <= 0) {
+            if (pageLimit <= 0)
+            {
                 break;
             }
 
             const MediaQueryPage page =
                 co_await fetchItemPage(basePath, startIndex, pageLimit, context);
             ++requestCount;
-            if (page.items.isEmpty()) {
+            if (page.items.isEmpty())
+            {
                 qWarning() << "[MediaService] paged fetch returned empty page"
                            << "| context=" << context
                            << "| startIndex=" << startIndex
@@ -939,8 +1577,10 @@ QCoro::Task<QList<MediaItem>> MediaService::fetchPagedItemList(
             }
 
             const QString fingerprint = mediaPageFingerprint(page.items);
-            if (!fingerprint.isEmpty()) {
-                if (pageFingerprints.contains(fingerprint)) {
+            if (!fingerprint.isEmpty())
+            {
+                if (pageFingerprints.contains(fingerprint))
+                {
                     qWarning()
                         << "[MediaService] paged fetch repeated page detected"
                         << "| context=" << context
@@ -959,7 +1599,9 @@ QCoro::Task<QList<MediaItem>> MediaService::fetchPagedItemList(
                            qMax(totalRecordCount, page.totalRecordCount))
                     : qMax(totalRecordCount, page.totalRecordCount);
         }
-    } else if (normalizedLimit > 0 && rawItems.size() < totalRecordCount) {
+    }
+    else if (normalizedLimit > 0 && rawItems.size() < totalRecordCount)
+    {
         qWarning() << "[MediaService] paged fetch cannot continue"
                    << "| context=" << context
                    << "| loaded=" << rawItems.size()
@@ -968,23 +1610,30 @@ QCoro::Task<QList<MediaItem>> MediaService::fetchPagedItemList(
     }
 
     QList<MediaItem> items;
-    if (deduplicateItems) {
+    if (deduplicateItems)
+    {
         QSet<QString> itemIds;
-        for (const MediaItem& item : std::as_const(rawItems)) {
+        for (const MediaItem &item : std::as_const(rawItems))
+        {
             const QString id = item.id.trimmed();
-            if (!id.isEmpty()) {
-                if (itemIds.contains(id)) {
+            if (!id.isEmpty())
+            {
+                if (itemIds.contains(id))
+                {
                     continue;
                 }
                 itemIds.insert(id);
             }
             items.append(item);
         }
-    } else {
+    }
+    else
+    {
         items = std::move(rawItems);
     }
 
-    if (normalizedLimit > 0 && items.size() > normalizedLimit) {
+    if (normalizedLimit > 0 && items.size() > normalizedLimit)
+    {
         items = items.mid(0, normalizedLimit);
     }
 
@@ -1003,7 +1652,9 @@ QCoro::Task<QList<MediaItem>> MediaService::getResumeItems(int limit, const QStr
     const QString fieldQuery = appendMediaCardTooltipFields(
         QStringLiteral("ProductionYear,RecursiveItemCount,CanDownload"));
     QString path = QString("/Users/%1/Items/"
-                           "Resume?Recursive=true&Fields=%2&MediaTypes=Video")
+                           "Resume?Recursive=true&Fields=%2&MediaTypes=Video"
+                           "&EnableImageTypes=Primary,Backdrop,Thumb"
+                           "&ImageTypeLimit=1")
                        .arg(m_serverManager->activeProfile().userId, fieldQuery);
     if (!sortBy.isEmpty())
         path += QString("&SortBy=%1").arg(sortBy);
@@ -1038,7 +1689,9 @@ QCoro::Task<MediaQueryPage> MediaService::getResumeItemsPage(
     const QString fieldQuery = appendMediaCardTooltipFields(
         QStringLiteral("ProductionYear,RecursiveItemCount,CanDownload"));
     QString path = QString("/Users/%1/Items/"
-                           "Resume?Recursive=true&Fields=%2&MediaTypes=Video")
+                           "Resume?Recursive=true&Fields=%2&MediaTypes=Video"
+                           "&EnableImageTypes=Primary,Backdrop,Thumb"
+                           "&ImageTypeLimit=1")
                        .arg(m_serverManager->activeProfile().userId, fieldQuery);
     if (!sortBy.isEmpty())
         path += QString("&SortBy=%1").arg(sortBy);
@@ -1081,7 +1734,8 @@ QCoro::Task<QList<MediaItem>> MediaService::getPlayedItems(int limit, const QStr
         [this, fieldQuery, userId](QString includeItemTypes, int requestLimit,
                                    QString requestSortBy,
                                    QString requestSortOrder)
-            -> QCoro::Task<QList<MediaItem>> {
+        -> QCoro::Task<QList<MediaItem>>
+    {
         QString path =
             QString("/Users/%1/"
                     "Items?Recursive=true&Fields=%2&IncludeItemTypes=%3&Filters=IsPlayed")
@@ -1101,7 +1755,8 @@ QCoro::Task<QList<MediaItem>> MediaService::getPlayedItems(int limit, const QStr
     QHash<QString, bool> seriesCompletedCache;
     int sequence = 0;
 
-    const auto appendEntry = [&entries, &sequence](MediaItem item) {
+    const auto appendEntry = [&entries, &sequence](MediaItem item)
+    {
         PlayedItemEntry entry;
         entry.playedAt = mediaPlayedAt(item);
         entry.sequence = sequence++;
@@ -1112,16 +1767,19 @@ QCoro::Task<QList<MediaItem>> MediaService::getPlayedItems(int limit, const QStr
     const QList<MediaItem> movies =
         co_await fetchPlayedItems(QStringLiteral("Movie"), queryLimit,
                                   requestSortBy, requestSortOrder);
-    for (MediaItem movie : movies) {
+    for (MediaItem movie : movies)
+    {
         appendEntry(std::move(movie));
     }
 
     const QList<MediaItem> directSeries =
         co_await fetchPlayedItems(QStringLiteral("Series"), queryLimit,
                                   requestSortBy, requestSortOrder);
-    for (MediaItem series : directSeries) {
+    for (MediaItem series : directSeries)
+    {
         const QString seriesId = series.id.trimmed();
-        if (seriesId.isEmpty() || seriesEntryIndexes.contains(seriesId)) {
+        if (seriesId.isEmpty() || seriesEntryIndexes.contains(seriesId))
+        {
             continue;
         }
         seriesEntryIndexes.insert(seriesId, entries.size());
@@ -1131,17 +1789,21 @@ QCoro::Task<QList<MediaItem>> MediaService::getPlayedItems(int limit, const QStr
     const QList<MediaItem> episodes =
         co_await fetchPlayedItems(QStringLiteral("Episode"), queryLimit,
                                   requestSortBy, requestSortOrder);
-    for (const MediaItem& episode : episodes) {
+    for (const MediaItem &episode : episodes)
+    {
         const QString seriesId = episode.seriesId.trimmed();
-        if (seriesId.isEmpty()) {
+        if (seriesId.isEmpty())
+        {
             continue;
         }
 
         const QDateTime episodePlayedAt = mediaPlayedAt(episode);
-        if (seriesEntryIndexes.contains(seriesId)) {
-            PlayedItemEntry& entry = entries[seriesEntryIndexes.value(seriesId)];
+        if (seriesEntryIndexes.contains(seriesId))
+        {
+            PlayedItemEntry &entry = entries[seriesEntryIndexes.value(seriesId)];
             if (!entry.playedAt.isValid() ||
-                compareDateTime(entry.playedAt, episodePlayedAt) < 0) {
+                compareDateTime(entry.playedAt, episodePlayedAt) < 0)
+            {
                 entry.playedAt = episodePlayedAt;
                 entry.item.userData.lastPlayedDate =
                     episode.userData.lastPlayedDate;
@@ -1149,12 +1811,15 @@ QCoro::Task<QList<MediaItem>> MediaService::getPlayedItems(int limit, const QStr
             continue;
         }
 
-        if (!seriesCompletedCache.contains(seriesId)) {
-            try {
+        if (!seriesCompletedCache.contains(seriesId))
+        {
+            try
+            {
                 MediaItem series = co_await getItemDetail(seriesId);
                 const bool seriesCompleted = series.userData.played;
                 seriesCompletedCache.insert(seriesId, seriesCompleted);
-                if (seriesCompleted) {
+                if (seriesCompleted)
+                {
                     series.userData.played = true;
                     series.userData.playbackPositionTicks = 0;
                     series.userData.playedPercentage = 100.0;
@@ -1163,7 +1828,9 @@ QCoro::Task<QList<MediaItem>> MediaService::getPlayedItems(int limit, const QStr
                     appendEntry(std::move(series));
                     continue;
                 }
-            } catch (const std::exception& e) {
+            }
+            catch (const std::exception &e)
+            {
                 seriesCompletedCache.insert(seriesId, false);
                 qWarning() << "[MediaService] failed to resolve played series"
                            << "| seriesId=" << seriesId
@@ -1176,11 +1843,13 @@ QCoro::Task<QList<MediaItem>> MediaService::getPlayedItems(int limit, const QStr
         requestSortOrder.compare(QStringLiteral("Descending"),
                                  Qt::CaseInsensitive) == 0;
     std::stable_sort(entries.begin(), entries.end(),
-                     [requestSortBy, descending](const PlayedItemEntry& lhs,
-                                                 const PlayedItemEntry& rhs) {
+                     [requestSortBy, descending](const PlayedItemEntry &lhs,
+                                                 const PlayedItemEntry &rhs)
+                     {
                          const int result =
                              comparePlayedEntries(lhs, rhs, requestSortBy);
-                         if (result == 0) {
+                         if (result == 0)
+                         {
                              return lhs.sequence < rhs.sequence;
                          }
                          return descending ? result > 0 : result < 0;
@@ -1188,8 +1857,10 @@ QCoro::Task<QList<MediaItem>> MediaService::getPlayedItems(int limit, const QStr
 
     QList<MediaItem> result;
     result.reserve(limit > 0 ? qMin(limit, entries.size()) : entries.size());
-    for (const PlayedItemEntry& entry : std::as_const(entries)) {
-        if (limit > 0 && result.size() >= limit) {
+    for (const PlayedItemEntry &entry : std::as_const(entries))
+    {
+        if (limit > 0 && result.size() >= limit)
+        {
             break;
         }
         result.append(entry.item);
@@ -1222,9 +1893,12 @@ QCoro::Task<MediaQueryPage> MediaService::getPlayedItemsPage(
     MediaQueryPage page;
     page.startIndex = normalizedStartIndex;
     page.limit = limit;
-    if (normalizedLimit > 0) {
+    if (normalizedLimit > 0)
+    {
         page.items = items.mid(page.startIndex, normalizedLimit);
-    } else {
+    }
+    else
+    {
         page.items = items.mid(page.startIndex);
     }
 
@@ -1517,7 +2191,9 @@ QCoro::Task<QList<MediaItem>> MediaService::getSimilarItems(const QString &itemI
     const QString fieldQuery = appendMediaCardTooltipFields(
         QStringLiteral("PrimaryImageAspectRatio,ProductionYear,CanDownload"));
     QString path = QString("/Items/%1/"
-                           "Similar?UserId=%2&Limit=%3&Fields=%4")
+                           "Similar?UserId=%2&Limit=%3&Fields=%4"
+                           "&EnableImageTypes=Primary,Backdrop,Thumb"
+                           "&ImageTypeLimit=1")
                        .arg(itemId, m_serverManager->activeProfile().userId)
                        .arg(limit)
                        .arg(fieldQuery);
@@ -1533,7 +2209,9 @@ QCoro::Task<QList<MediaItem>> MediaService::getItemCollections(const QString &it
         QStringLiteral("PrimaryImageAspectRatio,CanDownload"));
     QString path = QString("/Users/%1/"
                            "Items?IncludeItemTypes=Playlist,BoxSet&Recursive="
-                           "true&ListItemIds=%2&Fields=%3")
+                           "true&ListItemIds=%2&Fields=%3"
+                           "&EnableImageTypes=Primary,Backdrop,Thumb"
+                           "&ImageTypeLimit=1")
                        .arg(m_serverManager->activeProfile().userId, itemId,
                             fieldQuery);
 
@@ -1547,7 +2225,9 @@ QCoro::Task<QList<MediaItem>> MediaService::getCollectionItems(const QString &co
     const QString fieldQuery = appendMediaCardTooltipFields(
         QStringLiteral("PrimaryImageAspectRatio,ProductionYear,RecursiveItemCount,CanDownload"));
     QString path = QString("/Users/%1/"
-                           "Items?ParentId=%2&Fields=%3&SortBy=SortName")
+                           "Items?ParentId=%2&Fields=%3&SortBy=SortName"
+                           "&EnableImageTypes=Primary,Backdrop,Thumb"
+                           "&ImageTypeLimit=1")
                        .arg(m_serverManager->activeProfile().userId, collectionId,
                             fieldQuery);
 
@@ -1896,11 +2576,12 @@ void MediaService::clearRecommendCache()
     Q_EMIT recommendCacheCleared();
 }
 
-void MediaService::removeRecommendCacheItem(const QString& itemId)
+void MediaService::removeRecommendCacheItem(const QString &itemId)
 {
     const QString trimmedItemId = itemId.trimmed();
     if (trimmedItemId.isEmpty() || !m_serverManager ||
-        !m_serverManager->activeProfile().isValid()) {
+        !m_serverManager->activeProfile().isValid())
+    {
         return;
     }
 
@@ -1909,19 +2590,22 @@ void MediaService::removeRecommendCacheItem(const QString& itemId)
         ConfigStore::instance()
             ->get<QString>(ConfigKeys::DataCacheDuration, "24")
             .toInt();
-    if (cacheDurationHours <= 0) {
+    if (cacheDurationHours <= 0)
+    {
         cacheDurationHours = 24;
     }
 
     bool hasUsableCache =
         m_recommendCache.isValid(profile.id, profile.userId, cacheDurationHours);
-    if (!hasUsableCache) {
+    if (!hasUsableCache)
+    {
         hasUsableCache =
             m_recommendCache.loadFromDisk(profile.id, profile.userId,
                                           cacheDurationHours);
     }
 
-    if (!hasUsableCache) {
+    if (!hasUsableCache)
+    {
         qDebug() << "[MediaService] Skip recommend cache item removal"
                  << "| reason=no-usable-cache"
                  << "| itemId=" << trimmedItemId;
@@ -1929,13 +2613,16 @@ void MediaService::removeRecommendCacheItem(const QString& itemId)
     }
 
     const int previousCount = m_recommendCache.items.size();
-    for (int i = m_recommendCache.items.size() - 1; i >= 0; --i) {
-        if (m_recommendCache.items.at(i).id == trimmedItemId) {
+    for (int i = m_recommendCache.items.size() - 1; i >= 0; --i)
+    {
+        if (m_recommendCache.items.at(i).id == trimmedItemId)
+        {
             m_recommendCache.items.removeAt(i);
         }
     }
 
-    if (m_recommendCache.items.size() == previousCount) {
+    if (m_recommendCache.items.size() == previousCount)
+    {
         qDebug() << "[MediaService] Skip recommend cache item removal"
                  << "| reason=item-not-found"
                  << "| itemId=" << trimmedItemId
@@ -1943,9 +2630,12 @@ void MediaService::removeRecommendCacheItem(const QString& itemId)
         return;
     }
 
-    if (m_recommendCache.items.isEmpty()) {
+    if (m_recommendCache.items.isEmpty())
+    {
         m_recommendCache.clear();
-    } else {
+    }
+    else
+    {
         m_recommendCache.saveToDisk();
     }
 
@@ -1976,8 +2666,7 @@ void MediaService::updateUserViewsCache(MediaItem view, QString serverId,
         return;
     }
 
-    if (!m_userViewsCache.isValid(serverId, userId, false)
-        || m_userViewsCache.views.isEmpty())
+    if (!m_userViewsCache.isValid(serverId, userId, false) || m_userViewsCache.views.isEmpty())
     {
         qDebug() << "[MediaService] Skipping partial user view cache update"
                  << "| reason=base-cache-missing"

--- a/src/qEmbyCore/services/media/mediaservice.h
+++ b/src/qEmbyCore/services/media/mediaservice.h
@@ -5,10 +5,17 @@
 #include "../../models/media/mediaitem.h"
 #include "../../models/media/playbackinfo.h"
 #include <QHash>
+#include <QCache>
+#include <QImage>
 #include <QObject>
 #include <QList>
 #include <QPixmap>
+#include <QPointer>
 #include <QDateTime>
+#include <QFuture>
+#include <QPromise>
+#include <QSharedPointer>
+#include <QSet>
 #include <qcorotask.h>
 
 
@@ -89,6 +96,19 @@ struct QEMBYCORE_EXPORT MediaQueryPage {
 class ServerManager;
 class QNetworkAccessManager;
 
+enum class ImageRequestPriority
+{
+    High,
+    Normal,
+    Low
+};
+
+enum class ImageFetchPolicy
+{
+    CachePreferred,
+    NetworkOnly
+};
+
 class QEMBYCORE_EXPORT MediaService : public QObject
 {
     Q_OBJECT
@@ -150,11 +170,17 @@ public:
     QCoro::Task<MediaQueryPage> getItemsByFilterPage(const QString& genreFilter = "", const QString& tagFilter = "", const QString& studioFilter = "", const QString& sortBy = "SortName", const QString& sortOrder = "Ascending", int startIndex = 0, int limit = 0);
     QCoro::Task<QList<MediaItem>> getItemsByFilter(const QString& genreFilter = "", const QString& tagFilter = "", const QString& studioFilter = "", const QString& sortBy = "SortName", const QString& sortOrder = "Ascending", int limit = 0);
 
-    QCoro::Task<QPixmap> fetchImage(const QString& itemId, const QString& imageType,
-                                    const QString& imageTag, int maxWidth,
-                                    int imageIndex = -1);
+    QCoro::Task<QPixmap> fetchImage(QString itemId, QString imageType,
+                                    QString imageTag, int maxWidth,
+                                    int imageIndex = -1,
+                                    ImageRequestPriority priority =
+                                        ImageRequestPriority::Normal,
+                                    QObject* requestContext = nullptr,
+                                    ImageFetchPolicy fetchPolicy =
+                                        ImageFetchPolicy::CachePreferred);
     QCoro::Task<QPixmap> fetchImageByUrl(QString imageUrl);
     QCoro::Task<DownloadedImageData> downloadImageByUrl(QString imageUrl);
+    void clearImageCaches();
     void invalidateImageCache(QString itemId, QString imageType,
                               int imageIndex = -1);
     
@@ -180,12 +206,39 @@ Q_SIGNALS:
     void recommendCacheCleared();
 
 private:
+    struct InFlightImageRequest {
+        quint64 requestId = 0;
+        
+        
+        QFuture<QImage> future;
+    };
+
+    struct PendingImageNetworkSlot {
+        quint64 requestId = 0;
+        ImageRequestPriority priority = ImageRequestPriority::Normal;
+        bool hasRequestContext = false;
+        QPointer<QObject> requestContext;
+        QSharedPointer<QPromise<bool>> promise;
+    };
+
     ServerManager* m_serverManager;
     QNetworkAccessManager* m_imageManager;
     RecommendCache m_recommendCache; 
     UserViewsCache m_userViewsCache;
     QHash<QString, quint64> m_invalidatedImageRequestVersions;
+    
+    
+    
+    QCache<QString, QImage> m_decodedImageCache;
+    QHash<QString, InFlightImageRequest> m_inFlightImageRequests;
+    quint64 m_imageCacheGeneration = 0;
+    quint64 m_nextInFlightImageRequestId = 0;
+    quint64 m_nextImageNetworkSlotRequestId = 0;
     quint64 m_nextImageRequestVersion = 0;
+    QList<PendingImageNetworkSlot> m_pendingImageNetworkSlots;
+    QSet<quint64> m_grantedImageNetworkSlots;
+    int m_activeImageNetworkRequests = 0;
+    bool m_dispatchingImageNetworkSlots = false;
     
     
     void ensureValidProfile() const;
@@ -200,6 +253,15 @@ private:
                               QString userId, bool includesHidden);
     void updateUserViewsCache(MediaItem view, QString serverId,
                               QString userId);
+    void removeInFlightImageRequest(const QString& cacheKey,
+                                    quint64 requestId);
+    QFuture<bool> acquireImageNetworkSlot(
+        ImageRequestPriority priority,
+        QPointer<QObject> requestContext,
+        bool hasRequestContext,
+        quint64* outRequestId);
+    void releaseImageNetworkSlot(quint64 requestId);
+    void dispatchPendingImageNetworkSlots();
 };
 
 #endif 

--- a/src/qEmbyCore/services/sync/webdavsyncservice.cpp
+++ b/src/qEmbyCore/services/sync/webdavsyncservice.cpp
@@ -39,8 +39,7 @@ QString sanitizeNameSegment(const QString &s, const QString &fallback)
     out.reserve(trimmed.size());
     for (QChar c : trimmed)
     {
-        if (c.isLetterOrNumber() || c == QLatin1Char('_') ||
-            c == QLatin1Char('-') || c == QLatin1Char('.'))
+        if (c.isLetterOrNumber() || c == QLatin1Char('_') || c == QLatin1Char('-') || c == QLatin1Char('.'))
         {
             out.append(c);
         }
@@ -101,8 +100,7 @@ bool writeServersJson(const QJsonArray &arr)
         QFile out(tmpPath);
         if (!out.open(QIODevice::WriteOnly | QIODevice::Truncate))
         {
-            qWarning() << "[WebdavSyncService] failed to open" << tmpPath
-                       << "|" << out.errorString();
+            qWarning() << "[WebdavSyncService] failed to open" << tmpPath << "|" << out.errorString();
             return false;
         }
         if (out.write(payload) != payload.size())
@@ -150,7 +148,8 @@ QVariant jsonValueToVariant(const QJsonValue &v)
     {
     case QJsonValue::Bool:
         return v.toBool();
-    case QJsonValue::Double: {
+    case QJsonValue::Double:
+    {
         const double d = v.toDouble();
         const qlonglong i = static_cast<qlonglong>(d);
         if (static_cast<double>(i) == d)
@@ -190,10 +189,7 @@ bool keyMatchesIncludedNamespace(const QString &key)
 
 
 
-WebdavSyncService::WebdavSyncService(WebdavProfileStore *store, QObject *parent)
-    : QObject(parent), m_store(store)
-{
-}
+WebdavSyncService::WebdavSyncService(WebdavProfileStore *store, QObject *parent) : QObject(parent), m_store(store) {}
 
 WebdavSyncService::~WebdavSyncService() = default;
 
@@ -201,40 +197,31 @@ WebdavSyncService::~WebdavSyncService() = default;
 
 
 
-QString WebdavSyncService::proposedSnapshotFileName(const ConfigBundleMetadata &metadata,
-                                                    QString customTag)
+QString WebdavSyncService::proposedSnapshotFileName(const ConfigBundleMetadata &metadata, QString customTag)
 {
-    const qint64 exportedAt = metadata.exportedAt > 0
-                                  ? metadata.exportedAt
-                                  : QDateTime::currentMSecsSinceEpoch();
+    const qint64 exportedAt = metadata.exportedAt > 0 ? metadata.exportedAt : QDateTime::currentMSecsSinceEpoch();
     const QString version = sanitizeNameSegment(metadata.appVersion, QStringLiteral("dev"));
     const QString osName = sanitizeNameSegment(metadata.osName, QStringLiteral("OS"));
     const QString device = sanitizeNameSegment(metadata.deviceName, QStringLiteral("device"));
     const QString tag = sanitizeNameSegment(customTag, QString::fromLatin1(kDefaultSnapshotTag));
-    const QString ts = QDateTime::fromMSecsSinceEpoch(exportedAt, Qt::LocalTime)
+    const QString ts = QDateTime::fromMSecsSinceEpoch(exportedAt, QTimeZone::LocalTime)
                            .toString(QStringLiteral("yyyy-MM-dd-HH-mm-ss"));
 
-    return QString::fromLatin1(kSnapshotPrefix) + version + QLatin1Char('-') + osName +
-           QLatin1Char('-') + device + QLatin1Char('-') + ts + QLatin1Char('-') + tag +
-           QString::fromLatin1(kSnapshotSuffix);
+    return QString::fromLatin1(kSnapshotPrefix) + version + QLatin1Char('-') + osName + QLatin1Char('-') + device +
+           QLatin1Char('-') + ts + QLatin1Char('-') + tag + QString::fromLatin1(kSnapshotSuffix);
 }
 
 bool WebdavSyncService::isQEmbySnapshotName(const QString &fileName)
 {
     const bool isNewName = fileName.startsWith(QString::fromLatin1(kSnapshotPrefix)) &&
                            fileName.endsWith(QString::fromLatin1(kSnapshotSuffix));
-    const bool isLegacyName =
-        fileName.startsWith(QString::fromLatin1(kLegacySnapshotPrefix)) &&
-        fileName.endsWith(QString::fromLatin1(kLegacySnapshotSuffix));
+    const bool isLegacyName = fileName.startsWith(QString::fromLatin1(kLegacySnapshotPrefix)) &&
+                              fileName.endsWith(QString::fromLatin1(kLegacySnapshotSuffix));
     return isNewName || isLegacyName;
 }
 
-void WebdavSyncService::parseSnapshotName(const QString &fileName,
-                                          QString &appVersionOut,
-                                          QString &osNameOut,
-                                          QString &deviceHintOut,
-                                          QString &customTagOut,
-                                          QDateTime &createdAtOut)
+void WebdavSyncService::parseSnapshotName(const QString &fileName, QString &appVersionOut, QString &osNameOut,
+                                          QString &deviceHintOut, QString &customTagOut, QDateTime &createdAtOut)
 {
     appVersionOut.clear();
     osNameOut.clear();
@@ -254,8 +241,8 @@ void WebdavSyncService::parseSnapshotName(const QString &fileName,
         const int suffixLen = static_cast<int>(sizeof(kSnapshotSuffix)) - 1;
         const QString core = fileName.mid(prefixLen, fileName.size() - prefixLen - suffixLen);
 
-        static const QRegularExpression tsPattern(QStringLiteral(
-            "-(\\d{4}-\\d{2}-\\d{2}(?: \\d{2}:\\d{2}:\\d{2}|-\\d{2}-\\d{2}-\\d{2}))-"));
+        static const QRegularExpression tsPattern(
+            QStringLiteral("-(\\d{4}-\\d{2}-\\d{2}(?: \\d{2}:\\d{2}:\\d{2}|-\\d{2}-\\d{2}-\\d{2}))-"));
         const QRegularExpressionMatch match = tsPattern.match(core);
         if (!match.hasMatch())
         {
@@ -266,9 +253,7 @@ void WebdavSyncService::parseSnapshotName(const QString &fileName,
         const QString beforeTs = core.left(match.capturedStart(0));
         customTagOut = core.mid(match.capturedEnd(0));
         const int firstDash = beforeTs.indexOf(QLatin1Char('-'));
-        const int secondDash = firstDash >= 0
-                                   ? beforeTs.indexOf(QLatin1Char('-'), firstDash + 1)
-                                   : -1;
+        const int secondDash = firstDash >= 0 ? beforeTs.indexOf(QLatin1Char('-'), firstDash + 1) : -1;
         if (firstDash >= 0)
         {
             appVersionOut = beforeTs.left(firstDash);
@@ -290,8 +275,7 @@ void WebdavSyncService::parseSnapshotName(const QString &fileName,
         const QDateTime parsed = QDateTime::fromString(timestampText, timestampFormat);
         if (parsed.isValid())
         {
-            createdAtOut = QDateTime(parsed.date(), parsed.time(),
-                                     QTimeZone::systemTimeZone());
+            createdAtOut = QDateTime(parsed.date(), parsed.time(), QTimeZone::systemTimeZone());
         }
         return;
     }
@@ -302,9 +286,7 @@ void WebdavSyncService::parseSnapshotName(const QString &fileName,
 
     
     const int lastDash = core.lastIndexOf(QLatin1Char('-'));
-    const int secondLastDash = lastDash >= 0
-                                   ? core.lastIndexOf(QLatin1Char('-'), lastDash - 1)
-                                   : -1;
+    const int secondLastDash = lastDash >= 0 ? core.lastIndexOf(QLatin1Char('-'), lastDash - 1) : -1;
     if (secondLastDash < 0)
     {
         deviceHintOut = core;
@@ -326,26 +308,19 @@ WebdavClient *WebdavSyncService::buildClient()
 {
     if (!m_store)
     {
-        throw std::runtime_error(
-            tr("Internal error: WebDAV profile store is unavailable.")
-                .toUtf8()
-                .toStdString());
+        throw std::runtime_error(tr("Internal error: WebDAV profile store is unavailable.").toUtf8().toStdString());
     }
     if (!m_store->hasProfile())
     {
         throw std::runtime_error(
-            tr("WebDAV profile is not configured. Please save a profile first.")
-                .toUtf8()
-                .toStdString());
+            tr("WebDAV profile is not configured. Please save a profile first.").toUtf8().toStdString());
     }
 
     WebdavProfile profile = m_store->profile();
     if (!profile.isValid())
     {
         throw std::runtime_error(
-            tr("WebDAV profile is incomplete. Please fill in URL, username and password.")
-                .toUtf8()
-                .toStdString());
+            tr("WebDAV profile is incomplete. Please fill in URL, username and password.").toUtf8().toStdString());
     }
 
     
@@ -367,16 +342,13 @@ QCoro::Task<bool> WebdavSyncService::testConnection()
     co_return ok;
 }
 
-QCoro::Task<QString> WebdavSyncService::uploadSnapshot(QString customTag, bool encrypt,
-                                                       QString passphrase)
+QCoro::Task<QString> WebdavSyncService::uploadSnapshot(QString customTag, bool encrypt, QString passphrase)
 {
     qDebug() << "[WebdavSyncService] uploadSnapshot START"
-             << "| encrypt:" << encrypt
-             << "| customTag:" << customTag;
+             << "| encrypt:" << encrypt << "| customTag:" << customTag;
     if (encrypt && passphrase.isEmpty())
     {
-        throw std::runtime_error(
-            tr("Passphrase cannot be empty.").toUtf8().toStdString());
+        throw std::runtime_error(tr("Passphrase cannot be empty.").toUtf8().toStdString());
     }
 
     std::unique_ptr<WebdavClient> client(buildClient());
@@ -386,10 +358,7 @@ QCoro::Task<QString> WebdavSyncService::uploadSnapshot(QString customTag, bool e
     QByteArray plain = bundle.serialize(false);
     if (plain.isEmpty())
     {
-        throw std::runtime_error(
-            tr("There is no local configuration to upload.")
-                .toUtf8()
-                .toStdString());
+        throw std::runtime_error(tr("There is no local configuration to upload.").toUtf8().toStdString());
     }
 
     QByteArray payload;
@@ -399,10 +368,7 @@ QCoro::Task<QString> WebdavSyncService::uploadSnapshot(QString customTag, bool e
         SecureSecretBox::secureZero(plain);
         if (payload.isEmpty())
         {
-            throw std::runtime_error(
-                tr("Failed to encrypt the snapshot.")
-                    .toUtf8()
-                    .toStdString());
+            throw std::runtime_error(tr("Failed to encrypt the snapshot.").toUtf8().toStdString());
         }
     }
     else
@@ -412,12 +378,9 @@ QCoro::Task<QString> WebdavSyncService::uploadSnapshot(QString customTag, bool e
 
     const QString fileName = proposedSnapshotFileName(bundle.metadata, customTag);
     qDebug() << "[WebdavSyncService] uploadSnapshot uploading"
-             << "| fileName:" << fileName
-             << "| encrypted:" << encrypt
-             << "| size:" << payload.size();
+             << "| fileName:" << fileName << "| encrypted:" << encrypt << "| size:" << payload.size();
 
-    co_await client->putFile(fileName, payload,
-                             QStringLiteral("application/octet-stream"));
+    co_await client->putFile(fileName, payload, QStringLiteral("application/octet-stream"));
     SecureSecretBox::secureZero(payload);
 
     if (m_store)
@@ -454,8 +417,7 @@ QCoro::Task<QList<WebdavSnapshot>> WebdavSyncService::listSnapshots()
         s.fileName = e.displayName;
         s.mtime = e.lastModified;
         s.size = e.contentLength;
-        parseSnapshotName(s.fileName, s.appVersion, s.osName, s.deviceHint,
-                          s.customTag, s.createdAt);
+        parseSnapshotName(s.fileName, s.appVersion, s.osName, s.deviceHint, s.customTag, s.createdAt);
         if (!s.createdAt.isValid())
         {
             s.createdAt = s.mtime;
@@ -464,12 +426,10 @@ QCoro::Task<QList<WebdavSnapshot>> WebdavSyncService::listSnapshots()
     }
 
     std::sort(snapshots.begin(), snapshots.end(),
-              [](const WebdavSnapshot &a, const WebdavSnapshot &b)
-              { return a.createdAt > b.createdAt; });
+              [](const WebdavSnapshot &a, const WebdavSnapshot &b) { return a.createdAt > b.createdAt; });
 
     qDebug() << "[WebdavSyncService] listSnapshots DONE"
-             << "| total:" << entries.size()
-             << "| matched:" << snapshots.size();
+             << "| total:" << entries.size() << "| matched:" << snapshots.size();
     co_return snapshots;
 }
 
@@ -478,10 +438,7 @@ QCoro::Task<ConfigBundle> WebdavSyncService::downloadSnapshot(QString fileName, 
     qDebug() << "[WebdavSyncService] downloadSnapshot START | fileName:" << fileName;
     if (!isQEmbySnapshotName(fileName))
     {
-        throw std::runtime_error(
-            tr("Selected file is not a valid qEmby snapshot.")
-                .toUtf8()
-                .toStdString());
+        throw std::runtime_error(tr("Selected file is not a valid qEmby snapshot.").toUtf8().toStdString());
     }
 
     std::unique_ptr<WebdavClient> client(buildClient());
@@ -493,16 +450,12 @@ QCoro::Task<ConfigBundle> WebdavSyncService::downloadSnapshot(QString fileName, 
         if (!plainBundleOpt.has_value())
         {
             SecureSecretBox::secureZero(payload);
-            throw std::runtime_error(
-                tr("Snapshot is not a valid qEmby configuration bundle.")
-                    .toUtf8()
-                    .toStdString());
+            throw std::runtime_error(tr("Snapshot is not a valid qEmby configuration bundle.").toUtf8().toStdString());
         }
 
         SecureSecretBox::secureZero(payload);
         qDebug() << "[WebdavSyncService] downloadSnapshot DONE"
-                 << "| encrypted:" << false
-                 << "| servers:" << plainBundleOpt->servers.size()
+                 << "| encrypted:" << false << "| servers:" << plainBundleOpt->servers.size()
                  << "| entries:" << plainBundleOpt->configEntries.size()
                  << "| fromHost:" << plainBundleOpt->metadata.deviceName
                  << "| fromOs:" << plainBundleOpt->metadata.osPretty
@@ -514,9 +467,7 @@ QCoro::Task<ConfigBundle> WebdavSyncService::downloadSnapshot(QString fileName, 
     {
         SecureSecretBox::secureZero(payload);
         throw WebdavPassphraseRequiredError(
-            tr("Passphrase is required for encrypted snapshots.")
-                .toUtf8()
-                .toStdString());
+            tr("Passphrase is required for encrypted snapshots.").toUtf8().toStdString());
     }
 
     auto plainOpt = SecureSecretBox::decryptWithPassphrase(payload, passphrase);
@@ -534,19 +485,13 @@ QCoro::Task<ConfigBundle> WebdavSyncService::downloadSnapshot(QString fileName, 
     SecureSecretBox::secureZero(plain);
     if (!bundleOpt.has_value())
     {
-        throw std::runtime_error(
-            tr("Snapshot is not a valid qEmby configuration bundle.")
-                .toUtf8()
-                .toStdString());
+        throw std::runtime_error(tr("Snapshot is not a valid qEmby configuration bundle.").toUtf8().toStdString());
     }
 
     qDebug() << "[WebdavSyncService] downloadSnapshot DONE"
-             << "| encrypted:" << true
-             << "| servers:" << bundleOpt->servers.size()
-             << "| entries:" << bundleOpt->configEntries.size()
-             << "| fromHost:" << bundleOpt->metadata.deviceName
-             << "| fromOs:" << bundleOpt->metadata.osPretty
-             << "| fromApp:" << bundleOpt->metadata.appVersion;
+             << "| encrypted:" << true << "| servers:" << bundleOpt->servers.size()
+             << "| entries:" << bundleOpt->configEntries.size() << "| fromHost:" << bundleOpt->metadata.deviceName
+             << "| fromOs:" << bundleOpt->metadata.osPretty << "| fromApp:" << bundleOpt->metadata.appVersion;
     co_return bundleOpt.value();
 }
 
@@ -555,10 +500,7 @@ QCoro::Task<bool> WebdavSyncService::deleteSnapshot(QString fileName)
     qDebug() << "[WebdavSyncService] deleteSnapshot START | fileName:" << fileName;
     if (!isQEmbySnapshotName(fileName))
     {
-        throw std::runtime_error(
-            tr("Refused to delete a file that is not a qEmby snapshot.")
-                .toUtf8()
-                .toStdString());
+        throw std::runtime_error(tr("Refused to delete a file that is not a qEmby snapshot.").toUtf8().toStdString());
     }
 
     std::unique_ptr<WebdavClient> client(buildClient());
@@ -578,10 +520,8 @@ QCoro::Task<bool> WebdavSyncService::deleteSnapshot(QString fileName)
 bool WebdavSyncService::applyBundle(const ConfigBundle &bundle, MergeStrategy strategy)
 {
     qDebug() << "[WebdavSyncService] applyBundle START"
-             << "| strategy:" << static_cast<int>(strategy)
-             << "| bundleServers:" << bundle.servers.size()
-             << "| bundleEntries:" << bundle.configEntries.size()
-             << "| fromHost:" << bundle.metadata.deviceName;
+             << "| strategy:" << static_cast<int>(strategy) << "| bundleServers:" << bundle.servers.size()
+             << "| bundleEntries:" << bundle.configEntries.size() << "| fromHost:" << bundle.metadata.deviceName;
 
     
     QJsonArray finalServers;
@@ -590,7 +530,8 @@ bool WebdavSyncService::applyBundle(const ConfigBundle &bundle, MergeStrategy st
     case MergeStrategy::Replace:
         finalServers = bundle.servers;
         break;
-    case MergeStrategy::Merge: {
+    case MergeStrategy::Merge:
+    {
         const QJsonArray local = readServersJson();
         const QSet<QString> bundleIds = idSetOfArray(bundle.servers);
         finalServers = bundle.servers;
@@ -604,7 +545,8 @@ bool WebdavSyncService::applyBundle(const ConfigBundle &bundle, MergeStrategy st
         }
         break;
     }
-    case MergeStrategy::LocalWins: {
+    case MergeStrategy::LocalWins:
+    {
         const QJsonArray local = readServersJson();
         const QSet<QString> localIds = idSetOfArray(local);
         finalServers = local;
@@ -664,8 +606,7 @@ bool WebdavSyncService::applyBundle(const ConfigBundle &bundle, MergeStrategy st
         localKeysCache = store->allKeys();
     }
 
-    for (auto it = bundle.configEntries.constBegin();
-         it != bundle.configEntries.constEnd(); ++it)
+    for (auto it = bundle.configEntries.constBegin(); it != bundle.configEntries.constEnd(); ++it)
     {
         const QString &key = it.key();
         if (ConfigBundle::shouldExcludeKey(key))


### PR DESCRIPTION
## 变更内容
- 将项目版本更新为 0.0.6
- 提交 qEmby 应用与核心服务源码更新
- 增加应用更新、单实例管理、播放恢复与 danmu_api 支持

## 影响
包含 0.0.6 Windows 发布所使用的 CMake 配置及 src 源码；libs/qwindowkit 的本地自定义修改未纳入父仓库提交。

## 验证
- 已成功使用发布产物生成 qEmby-0.0.6-Win-x64-Setup.exe
- `cmake --build build --config Release --parallel` 未执行成功：现有 build 缓存使用 Visual Studio 17 2022，但目录中缺少 ALL_BUILD.vcxproj